### PR TITLE
Read host and port from environment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,5 +13,5 @@ REDMINE_PASSWORD=your_password
 # REDMINE_API_KEY=your_api_key
 
 # Server configuration
-SERVER_HOST=0.0.0.0
-SERVER_PORT=8000
+SERVER_HOST=0.0.0.0  # Default host
+SERVER_PORT=8000     # Default port

--- a/README.md
+++ b/README.md
@@ -91,8 +91,8 @@ redmine-mcp-server/
    # REDMINE_API_KEY=your_api_key
    
    # Server configuration
-   SERVER_HOST=0.0.0.0
-   SERVER_PORT=8000
+   SERVER_HOST=0.0.0.0  # Listening host (default: 0.0.0.0)
+   SERVER_PORT=8000     # Listening port (default: 8000)
    ```
 
 ## Usage
@@ -109,7 +109,7 @@ uv run fastapi dev src/redmine_mcp_server/main.py
 uv run python src/redmine_mcp_server/main.py
 ```
 
-The server will start on `http://localhost:8000` with the MCP endpoint available at `/sse`.
+The server will start on `http://<SERVER_HOST>:<SERVER_PORT>` (defaults to `0.0.0.0:8000`) with the MCP endpoint available at `/sse`.
 
 ### Testing Connection
 

--- a/src/redmine_mcp_server/main.py
+++ b/src/redmine_mcp_server/main.py
@@ -19,6 +19,7 @@ Modules:
 from fastapi import FastAPI, Request
 from mcp.server.sse import SseServerTransport
 from starlette.routing import Mount
+import os
 import uvicorn
 from .redmine_handler import mcp
 
@@ -43,4 +44,6 @@ async def handle_sse(request: Request):
         )
 
 if __name__ == "__main__":
-    uvicorn.run(app, host="0.0.0.0", port=8000)
+    host = os.getenv("SERVER_HOST", "0.0.0.0")
+    port = int(os.getenv("SERVER_PORT", "8000"))
+    uvicorn.run(app, host=host, port=port)


### PR DESCRIPTION
## Summary
- allow configuring server host and port with `SERVER_HOST` and `SERVER_PORT`
- document the default host and port in README and `.env.example`

## Testing
- `uv pip install -e .`
- `uv pip install '.[dev]'`
- `pytest -q` *(fails: ModuleNotFoundError for redminelib, httpx, python-dotenv)*

------
https://chatgpt.com/codex/tasks/task_e_684c21b1c3e0832bb04f093a705f2bfc