### PR TITLE
Fix server host and port env variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,9 @@ uv run fastapi dev src/redmine_mcp_server/main.py
 uv run python src/redmine_mcp_server/main.py
 ```
 
-The server will start on `http://localhost:8000` with the MCP endpoint available at `/sse`.
+By default the server runs on `http://0.0.0.0:8000`. You can override the host or
+port using the `SERVER_HOST` and `SERVER_PORT` environment variables. The MCP
+endpoint is available at `/sse`.
 
 ### Testing Connection
 

--- a/src/redmine_mcp_server/main.py
+++ b/src/redmine_mcp_server/main.py
@@ -20,6 +20,8 @@ from fastapi import FastAPI, Request
 from mcp.server.sse import SseServerTransport
 from starlette.routing import Mount
 import uvicorn
+import os
+from dotenv import load_dotenv
 from .redmine_handler import mcp
 
 
@@ -43,4 +45,7 @@ async def handle_sse(request: Request):
         )
 
 if __name__ == "__main__":
-    uvicorn.run(app, host="0.0.0.0", port=8000)
+    load_dotenv(os.path.join(os.path.dirname(__file__), "..", "..", ".env"))
+    host = os.getenv("SERVER_HOST", "0.0.0.0")
+    port = int(os.getenv("SERVER_PORT", "8000"))
+    uvicorn.run(app, host=host, port=port)


### PR DESCRIPTION
## Summary
- load SERVER_HOST and SERVER_PORT variables in `main.py`
- document configurable host and port in README

## Testing
- `python tests/run_tests.py`

------
https://chatgpt.com/codex/tasks/task_e_684c239ba228832bb4818c34d3cf088a