### PR TITLE
Fix deployment test path

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -101,15 +101,15 @@ test_deployment() {
     echo "🧪 Testing deployment..."
     sleep 5  # Wait for container to start
     
-    if curl -s -f http://localhost:8000/health > /dev/null 2>&1; then
-        echo "✅ Health check passed"
+    if curl -s -f http://localhost:8000/messages/ > /dev/null 2>&1; then
+        echo "✅ Messages endpoint check passed"
     else
-        echo "⚠️  Health check failed - checking if server is starting..."
+        echo "⚠️  Messages endpoint check failed - checking if server is starting..."
         sleep 10
-        if curl -s -f http://localhost:8000/health > /dev/null 2>&1; then
-            echo "✅ Health check passed (after delay)"
+        if curl -s -f http://localhost:8000/messages/ > /dev/null 2>&1; then
+            echo "✅ Messages endpoint check passed (after delay)"
         else
-            echo "❌ Health check failed"
+            echo "❌ Messages endpoint check failed"
             echo "🔍 Container logs:"
             docker logs --tail 10 $CONTAINER_NAME
         fi


### PR DESCRIPTION
## Summary
- adjust deployment smoke test path

## Testing
- `pytest -q` *(fails: ProxyError while trying to connect to your-redmine-server.com)*

------
https://chatgpt.com/codex/tasks/task_e_684c25a7f324832bb68ab0ec8a5fa9b1