### PR TITLE
Improve README for open-source style

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,16 @@ A Model Context Protocol (MCP) server that integrates with Redmine project manag
 - **MCP Compatibility**: Full compatibility with Model Context Protocol standards
 - **Docker Support**: Ready for containerized deployment
 
+## Quick Start
+
+```bash
+uv venv
+source .venv/bin/activate
+uv pip install -e .
+uv run fastapi dev src/redmine_mcp_server/main.py
+```
+
+
 ## Architecture
 
 The server is built using:
@@ -362,7 +372,8 @@ Enable debug logging by modifying the FastAPI app initialization in `main.py`.
 
 ## Contributing
 
-This project is planned to be open-sourced. Contributions will be welcome once the repository is public.
+Contributions are welcome! Please open an issue or submit a pull request.
+Before sending a PR, run `python tests/run_tests.py --all` to ensure all tests pass.
 
 ## License
 


### PR DESCRIPTION
## Summary
- add a **Quick Start** section with minimal commands
- clarify contributing instructions

## Testing
- `uv pip install pytest pytest-asyncio pytest-cov pytest-mock`
- `python tests/run_tests.py --all` *(fails: `REDMINE_URL not set`)*

------
https://chatgpt.com/codex/tasks/task_e_684cf2fdb4e0832bab7b83f04f2266b3