### PR TITLE
Release v0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,15 +2,21 @@
 
 All notable changes to this project will be documented in this file.
 
+
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [0.1.2] - 2025-05-26
 
+### Changed
+- Roadmap moved to its own document with updated plans
+- Improved README badges and links
+
 ### Added
 - New MCP tools `create_redmine_issue` and `update_redmine_issue` for managing issues
 - Documentation updates describing the new tools
 - Integration tests for issue creation and update
+- Integration test for Redmine issue management
 
 ## [0.1.1] - 2025-05-25
 

--- a/README.md
+++ b/README.md
@@ -10,13 +10,20 @@ A Model Context Protocol (MCP) server that integrates with Redmine project manag
 
 ## Features
 
-- **Project Management**: List all accessible Redmine projects
-- **Issue Tracking**: Retrieve detailed information about specific Redmine issues
-- **Issue Management**: Create and update issues directly from Redmine
-- **Multiple Authentication**: Support for both username/password and API key authentication
-- **FastAPI Integration**: RESTful API with Server-Sent Events (SSE) for real-time communication
-- **MCP Compatibility**: Full compatibility with Model Context Protocol standards
-- **Docker Support**: Ready for containerized deployment
+### Redmine Tools
+- List your accessible projects
+- View full issue details
+- Create or update issues
+
+### API and Protocol
+- FastAPI server with Server-Sent Events
+- Compliant with the Model Context Protocol
+
+### Authentication
+- Use a username/password or API key
+
+### Deployment
+- Docker image for quick setup
 
 ## Quick Start
 


### PR DESCRIPTION
## Summary
- bump version to 0.1.2
- consolidate changelog entries for the release
- simplify README feature section

## Testing
- `python tests/run_tests.py --all`


------
https://chatgpt.com/codex/tasks/task_e_684e4201f138832bb22d77726224b58e