### PR TITLE
docs: update roadmap and README for test counts

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,11 +252,11 @@ Core dependencies are managed in `pyproject.toml`:
 
 ### Testing
 
-The project includes a comprehensive test suite with 22 tests covering unit tests, integration tests, and connection validation.
+The project includes a comprehensive test suite with 27 tests covering unit tests, integration tests, and connection validation.
 
 #### Test Structure
-- **Unit Tests** (10 tests): Test individual functions with mocked dependencies
-- **Integration Tests** (9 tests): Test end-to-end functionality with real Redmine connections
+- **Unit Tests** (16 tests): Test individual functions with mocked dependencies
+- **Integration Tests** (8 tests): Test end-to-end functionality with real Redmine connections
 - **Connection Tests** (3 tests): Validate infrastructure and connectivity
 
 #### Running Tests

--- a/roadmap.md
+++ b/roadmap.md
@@ -2,7 +2,7 @@
 
 ### Completed ✅
 - [x] Docker containerization with multi-stage builds
-- [x] Comprehensive unit and integration tests (22 tests)
+- [x] Comprehensive unit and integration tests (27 tests)
 - [x] Enhanced error handling and logging
 - [x] Documentation improvements
 - [x] Environment-based configuration


### PR DESCRIPTION
## Summary
- update roadmap to note 27 tests
- fix README test counts

## Testing
- `python tests/run_tests.py --all`
- `python -m pytest tests/ --tb=short -v`

------
https://chatgpt.com/codex/tasks/task_e_684e87b86544832bac7b6f8903c8c2cf