### PR TITLE
Fix roadmap reference in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -419,4 +419,4 @@ See the [CHANGELOG](CHANGELOG.md) for a detailed version history.
 
 ## Roadmap
 
-See [roadmap.md](./ROADMAP.md) for the latest roadmap.
+See [roadmap.md](./roadmap.md) for the latest roadmap.


### PR DESCRIPTION
## Summary
- fix the broken link to the roadmap file

## Testing
- `python tests/run_tests.py --all`

------
https://chatgpt.com/codex/tasks/task_e_684e87b86544832bac7b6f8903c8c2cf