### PR TITLE
Add tool for fetching issue comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - New MCP tool `list_my_redmine_issues` for retrieving issues assigned to the current user
+- New MCP tool `get_redmine_issue_comments` for retrieving issue comments
 ## [0.1.2] - 2025-05-26
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -126,6 +126,9 @@ Creates a new issue in the specified project. Additional Redmine fields such as 
 ### `update_redmine_issue(issue_id: int, fields: Dict[str, Any])`
 Updates an existing issue with the provided fields.
 
+### `get_redmine_issue_comments(issue_id: int)`
+Retrieves comments (journals) for the specified issue.
+
 ## Docker Deployment
 
 ### Quick Start with Docker
@@ -193,7 +196,7 @@ The tool will automatically be available through the MCP interface.
 
 ### Testing
 
-The project includes 27 tests covering unit tests, integration tests, and connection validation.
+The project includes 32 tests covering unit tests, integration tests, and connection validation.
 
 **Run tests:**
 ```bash

--- a/roadmap.md
+++ b/roadmap.md
@@ -2,7 +2,7 @@
 
 ### Completed ✅
 - [x] Docker containerization with multi-stage builds
-- [x] Comprehensive unit and integration tests (27 tests)
+- [x] Comprehensive unit and integration tests (32 tests)
 - [x] Enhanced error handling and logging
 - [x] Documentation improvements
 - [x] Environment-based configuration
@@ -15,7 +15,7 @@
 ### In Progress 🚧
 
 ### Planned 📋
-- [ ] Additional Redmine tools (get comments by issue)
+- [x] Additional Redmine tools (get comments by issue)
 - [ ] Advanced search and filtering
 - [ ] Performance optimizations and caching
 - [ ] Custom field support

--- a/src/redmine_mcp_server/redmine_handler.py
+++ b/src/redmine_mcp_server/redmine_handler.py
@@ -201,6 +201,46 @@ async def update_redmine_issue(issue_id: int, fields: Dict[str, Any]) -> Dict[st
         return {"error": f"An error occurred while updating issue {issue_id}."}
 
 
+@mcp.tool()
+async def get_redmine_issue_comments(issue_id: int) -> List[Dict[str, Any]]:
+    """Retrieve comments (journals) for a specific Redmine issue."""
+
+    if not redmine:
+        return [{"error": "Redmine client not initialized."}]
+    try:
+        issue = redmine.issue.get(issue_id, include="journals")
+        comments: List[Dict[str, Any]] = []
+        for journal in getattr(issue, "journals", []):
+            notes = getattr(journal, "notes", "")
+            if not notes:
+                continue
+            comments.append(
+                {
+                    "id": journal.id,
+                    "user": {
+                        "id": journal.user.id,
+                        "name": journal.user.name,
+                    }
+                    if hasattr(journal, "user")
+                    else None,
+                    "notes": notes,
+                    "created_on": journal.created_on.isoformat()
+                    if hasattr(journal, "created_on")
+                    else None,
+                }
+            )
+        return comments
+    except ResourceNotFoundError:
+        return [{"error": f"Issue {issue_id} not found."}]
+    except Exception as e:
+        print(f"Error fetching comments for Redmine issue {issue_id}: {e}")
+        return [
+            {
+                "error": f"An error occurred while fetching comments for issue {issue_id}."
+            }
+        ]
+
+
 if __name__ == "__main__":
     if not redmine:
         print("Redmine client could not be initialized. Some tools may not work.")

--- a/tests/test_redmine_handler.py
+++ b/tests/test_redmine_handler.py
@@ -396,3 +396,93 @@ class TestRedmineHandler:
 
         assert isinstance(result, list)
         assert result[0]["error"] == "Redmine client not initialized."
+
+    @pytest.fixture
+    def mock_issue_with_comments(self, mock_redmine_issue):
+        """Add journals with comments to the mock issue."""
+        from datetime import datetime
+
+        journal = Mock()
+        journal.id = 1
+        journal.notes = "First comment"
+        journal.created_on = datetime(2025, 1, 3, 12, 0, 0)
+        user = Mock()
+        user.id = 3
+        user.name = "Commenter"
+        journal.user = user
+
+        mock_redmine_issue.journals = [journal]
+        return mock_redmine_issue
+
+    @pytest.mark.asyncio
+    @patch('redmine_mcp_server.redmine_handler.redmine')
+    async def test_get_redmine_issue_comments_success(self, mock_redmine, mock_issue_with_comments):
+        """Test retrieving comments for an issue."""
+        mock_redmine.issue.get.return_value = mock_issue_with_comments
+
+        from redmine_mcp_server.redmine_handler import get_redmine_issue_comments
+
+        result = await get_redmine_issue_comments(123)
+
+        assert isinstance(result, list)
+        assert len(result) == 1
+        comment = result[0]
+        assert comment["id"] == 1
+        assert comment["notes"] == "First comment"
+        assert comment["user"]["id"] == 3
+        assert comment["user"]["name"] == "Commenter"
+        assert comment["created_on"] == "2025-01-03T12:00:00"
+        mock_redmine.issue.get.assert_called_once_with(123, include="journals")
+
+    @pytest.mark.asyncio
+    @patch('redmine_mcp_server.redmine_handler.redmine')
+    async def test_get_redmine_issue_comments_empty(self, mock_redmine, mock_redmine_issue):
+        """Test retrieving comments when none exist."""
+        mock_redmine_issue.journals = []
+        mock_redmine.issue.get.return_value = mock_redmine_issue
+
+        from redmine_mcp_server.redmine_handler import get_redmine_issue_comments
+
+        result = await get_redmine_issue_comments(123)
+
+        assert isinstance(result, list)
+        assert result == []
+
+    @pytest.mark.asyncio
+    @patch('redmine_mcp_server.redmine_handler.redmine')
+    async def test_get_redmine_issue_comments_not_found(self, mock_redmine):
+        """Test comments retrieval when issue is missing."""
+        from redminelib.exceptions import ResourceNotFoundError
+
+        mock_redmine.issue.get.side_effect = ResourceNotFoundError()
+
+        from redmine_mcp_server.redmine_handler import get_redmine_issue_comments
+
+        result = await get_redmine_issue_comments(999)
+
+        assert isinstance(result, list)
+        assert result[0]["error"] == "Issue 999 not found."
+
+    @pytest.mark.asyncio
+    @patch('redmine_mcp_server.redmine_handler.redmine')
+    async def test_get_redmine_issue_comments_error(self, mock_redmine):
+        """Test general error when retrieving comments."""
+        mock_redmine.issue.get.side_effect = Exception("Boom")
+
+        from redmine_mcp_server.redmine_handler import get_redmine_issue_comments
+
+        result = await get_redmine_issue_comments(123)
+
+        assert isinstance(result, list)
+        assert "error" in result[0]
+
+    @pytest.mark.asyncio
+    @patch('redmine_mcp_server.redmine_handler.redmine', None)
+    async def test_get_redmine_issue_comments_no_client(self):
+        """Test retrieving comments when client is not initialized."""
+        from redmine_mcp_server.redmine_handler import get_redmine_issue_comments
+
+        result = await get_redmine_issue_comments(123)
+
+        assert isinstance(result, list)
+        assert result[0]["error"] == "Redmine client not initialized."


### PR DESCRIPTION
## Summary
- support retrieving comments for a Redmine issue
- test the new tool extensively
- document new tool and update test counts
- mark roadmap entry complete
- keep 0.1.3 changelog entry with new tool

## Testing
- `python tests/run_tests.py --all`


------
https://chatgpt.com/codex/tasks/task_e_684f45889fbc832b98eb9288ac8d0bf2