### PR TITLE
Add health check endpoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,7 +59,7 @@ USER appuser
 
 # Health check
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
-    CMD curl -f http://localhost:8000/messages/ || exit 1
+    CMD curl -f http://localhost:8000/health || exit 1
 
 # Expose port
 EXPOSE 8000

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ uv run fastapi dev src/redmine_mcp_server/main.py
 ```
 
 The server runs on `http://localhost:8000` with the MCP endpoint at `/sse`.
+For container orchestration, a lightweight health check is available at `/health`.
 
 ## Installation
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,7 @@ services:
     networks:
       - redmine-mcp-network
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8000/messages/"]
+      test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/src/redmine_mcp_server/main.py
+++ b/src/redmine_mcp_server/main.py
@@ -30,6 +30,11 @@ app = FastAPI(docs_url=None, redoc_url=None,)
 sse = SseServerTransport("/messages/")
 app.router.routes.append(Mount("/messages", app=sse.handle_post_message))
 
+@app.get("/health", tags=["Health"])
+async def health() -> dict:
+    """Simple health check endpoint."""
+    return {"status": "ok"}
+
 @app.get("/sse", tags=["MCP"])
 async def handle_sse(request: Request):
     async with sse.connect_sse(request.scope, request.receive, request._send) as (

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -176,6 +176,15 @@ class TestFastAPIIntegration:
         # Should have the SSE endpoint
         assert any('/sse' in path or path == '/sse' for path in route_paths), f"SSE endpoint not found. Available routes: {route_paths}"
 
+    @pytest.mark.integration
+    def test_health_endpoint_exists(self):
+        """Test that the health check endpoint is configured."""
+        from redmine_mcp_server.main import app
+
+        route_paths = [route.path for route in app.router.routes if hasattr(route, 'path')]
+
+        assert '/health' in route_paths, f"Health endpoint not found. Available routes: {route_paths}"
+
 
 @pytest.mark.integration
 class TestEnvironmentConfiguration:


### PR DESCRIPTION
## Summary
- add `/health` endpoint
- direct Docker health checks at `/health`
- confirm new `/health` route in integration tests
- document `/health` endpoint in README

## Testing
- `python tests/run_tests.py --all`

------
https://chatgpt.com/codex/tasks/task_e_68508af2b860832bb12ce7867e5bfc8f