### PR TITLE
Remove comments tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.4] - 2025-05-28
+
+### Removed
+- Deprecated `get_redmine_issue_comments` tool. Use `get_redmine_issue` with
+  `include_journals=True` to retrieve comments.
+
+### Changed
+- `get_redmine_issue` now includes issue journals by default. A new
+  `include_journals` parameter allows opting out of comment retrieval.
+
 ## [0.1.3] - 2025-05-27
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -112,8 +112,11 @@ python tests/run_tests.py --all
 
 ## Available MCP Tools
 
-### `get_redmine_issue(issue_id: int)`
-Retrieves detailed information about a specific Redmine issue.
+### `get_redmine_issue(issue_id: int, include_journals: bool = True)`
+Retrieves detailed information about a specific Redmine issue. When
+`include_journals` is `True` (default) the returned dictionary also contains a
+`"journals"` key with the issue's comments. Set `include_journals=False` to skip
+fetching comments for a lighter request.
 
 ### `list_redmine_projects()`
 Lists all accessible projects in the Redmine instance.
@@ -127,8 +130,6 @@ Creates a new issue in the specified project. Additional Redmine fields such as 
 ### `update_redmine_issue(issue_id: int, fields: Dict[str, Any])`
 Updates an existing issue with the provided fields.
 
-### `get_redmine_issue_comments(issue_id: int)`
-Retrieves comments (journals) for the specified issue.
 
 ## Docker Deployment
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcp-redmine"
-version = "0.1.3"
+version = "0.1.4"
 description = "A Model Context Protocol (MCP) server for Redmine integration"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/redmine_mcp_server/redmine_handler.py
+++ b/src/redmine_mcp_server/redmine_handler.py
@@ -87,11 +87,16 @@ def _issue_to_dict(issue: Any) -> Dict[str, Any]:
 def _journals_to_list(issue: Any) -> List[Dict[str, Any]]:
     """Convert journals on an issue object to a list of dicts."""
     raw_journals = getattr(issue, "journals", None)
-    if not isinstance(raw_journals, list):
+    if raw_journals is None:
         return []
 
     journals: List[Dict[str, Any]] = []
-    for journal in raw_journals:
+    try:
+        iterator = iter(raw_journals)
+    except TypeError:
+        return []
+
+    for journal in iterator:
         notes = getattr(journal, "notes", "")
         if not notes:
             continue

--- a/tests/test_redmine_handler.py
+++ b/tests/test_redmine_handler.py
@@ -84,14 +84,14 @@ class TestRedmineHandler:
 
     @pytest.mark.asyncio
     @patch('redmine_mcp_server.redmine_handler.redmine')
-    async def test_get_redmine_issue_success(self, mock_redmine, mock_redmine_issue):
-        """Test successful issue retrieval."""
+    async def test_get_redmine_issue_success(self, mock_redmine, mock_issue_with_comments):
+        """Test successful issue retrieval including journals by default."""
         # Setup
-        mock_redmine.issue.get.return_value = mock_redmine_issue
-        
+        mock_redmine.issue.get.return_value = mock_issue_with_comments
+
         # Execute
         result = await get_redmine_issue(123)
-        
+
         # Verify
         assert result is not None
         assert result["id"] == 123
@@ -109,9 +109,11 @@ class TestRedmineHandler:
         assert result["assigned_to"]["name"] == "Test Assignee"
         assert result["created_on"] == "2025-01-01T10:00:00"
         assert result["updated_on"] == "2025-01-02T15:30:00"
-        
+        assert isinstance(result.get("journals"), list)
+        assert result["journals"][0]["notes"] == "First comment"
+
         # Verify the mock was called correctly
-        mock_redmine.issue.get.assert_called_once_with(123)
+        mock_redmine.issue.get.assert_called_once_with(123, include="journals")
 
     @pytest.mark.asyncio
     @patch('redmine_mcp_server.redmine_handler.redmine')
@@ -164,13 +166,24 @@ class TestRedmineHandler:
         # Setup - remove assigned_to attribute
         delattr(mock_redmine_issue, 'assigned_to')
         mock_redmine.issue.get.return_value = mock_redmine_issue
-        
+
         # Execute
         result = await get_redmine_issue(123)
-        
+
         # Verify
         assert result is not None
         assert result["assigned_to"] is None
+
+    @pytest.mark.asyncio
+    @patch('redmine_mcp_server.redmine_handler.redmine')
+    async def test_get_redmine_issue_without_journals(self, mock_redmine, mock_redmine_issue):
+        """Test opting out of journal retrieval."""
+        mock_redmine.issue.get.return_value = mock_redmine_issue
+
+        result = await get_redmine_issue(123, include_journals=False)
+
+        assert "journals" not in result
+        mock_redmine.issue.get.assert_called_once_with(123)
 
     @pytest.mark.asyncio
     @patch('redmine_mcp_server.redmine_handler.redmine')
@@ -414,75 +427,3 @@ class TestRedmineHandler:
         mock_redmine_issue.journals = [journal]
         return mock_redmine_issue
 
-    @pytest.mark.asyncio
-    @patch('redmine_mcp_server.redmine_handler.redmine')
-    async def test_get_redmine_issue_comments_success(self, mock_redmine, mock_issue_with_comments):
-        """Test retrieving comments for an issue."""
-        mock_redmine.issue.get.return_value = mock_issue_with_comments
-
-        from redmine_mcp_server.redmine_handler import get_redmine_issue_comments
-
-        result = await get_redmine_issue_comments(123)
-
-        assert isinstance(result, list)
-        assert len(result) == 1
-        comment = result[0]
-        assert comment["id"] == 1
-        assert comment["notes"] == "First comment"
-        assert comment["user"]["id"] == 3
-        assert comment["user"]["name"] == "Commenter"
-        assert comment["created_on"] == "2025-01-03T12:00:00"
-        mock_redmine.issue.get.assert_called_once_with(123, include="journals")
-
-    @pytest.mark.asyncio
-    @patch('redmine_mcp_server.redmine_handler.redmine')
-    async def test_get_redmine_issue_comments_empty(self, mock_redmine, mock_redmine_issue):
-        """Test retrieving comments when none exist."""
-        mock_redmine_issue.journals = []
-        mock_redmine.issue.get.return_value = mock_redmine_issue
-
-        from redmine_mcp_server.redmine_handler import get_redmine_issue_comments
-
-        result = await get_redmine_issue_comments(123)
-
-        assert isinstance(result, list)
-        assert result == []
-
-    @pytest.mark.asyncio
-    @patch('redmine_mcp_server.redmine_handler.redmine')
-    async def test_get_redmine_issue_comments_not_found(self, mock_redmine):
-        """Test comments retrieval when issue is missing."""
-        from redminelib.exceptions import ResourceNotFoundError
-
-        mock_redmine.issue.get.side_effect = ResourceNotFoundError()
-
-        from redmine_mcp_server.redmine_handler import get_redmine_issue_comments
-
-        result = await get_redmine_issue_comments(999)
-
-        assert isinstance(result, list)
-        assert result[0]["error"] == "Issue 999 not found."
-
-    @pytest.mark.asyncio
-    @patch('redmine_mcp_server.redmine_handler.redmine')
-    async def test_get_redmine_issue_comments_error(self, mock_redmine):
-        """Test general error when retrieving comments."""
-        mock_redmine.issue.get.side_effect = Exception("Boom")
-
-        from redmine_mcp_server.redmine_handler import get_redmine_issue_comments
-
-        result = await get_redmine_issue_comments(123)
-
-        assert isinstance(result, list)
-        assert "error" in result[0]
-
-    @pytest.mark.asyncio
-    @patch('redmine_mcp_server.redmine_handler.redmine', None)
-    async def test_get_redmine_issue_comments_no_client(self):
-        """Test retrieving comments when client is not initialized."""
-        from redmine_mcp_server.redmine_handler import get_redmine_issue_comments
-
-        result = await get_redmine_issue_comments(123)
-
-        assert isinstance(result, list)
-        assert result[0]["error"] == "Redmine client not initialized."


### PR DESCRIPTION
This pull request refactors the handling of Redmine issue comments by deprecating the `get_redmine_issue_comments` tool and integrating its functionality into the `get_redmine_issue` tool. It also updates the documentation and tests to reflect these changes. The most important changes are grouped below by theme.

### Feature Changes
* [`src/redmine_mcp_server/redmine_handler.py`](diffhunk://#diff-6f71ca6e577c97803b6a8ca195486747315f6feb3abb29e9fcced62dbecbe875R87-R141): Refactored `get_redmine_issue` to include an optional `include_journals` parameter (defaulting to `True`) for retrieving issue comments. Added a helper function `_journals_to_list` to process journal entries into a structured format. [[1]](diffhunk://#diff-6f71ca6e577c97803b6a8ca195486747315f6feb3abb29e9fcced62dbecbe875R87-R141) [[2]](diffhunk://#diff-6f71ca6e577c97803b6a8ca195486747315f6feb3abb29e9fcced62dbecbe875L203-L243)

### Deprecation and Cleanup
* [`src/redmine_mcp_server/redmine_handler.py`](diffhunk://#diff-6f71ca6e577c97803b6a8ca195486747315f6feb3abb29e9fcced62dbecbe875L203-L243): Removed the deprecated `get_redmine_issue_comments` tool, as its functionality is now integrated into `get_redmine_issue`.

### Documentation Updates
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L115-R119): Updated the `get_redmine_issue` documentation to include details about the new `include_journals` parameter. Removed the section for the deprecated `get_redmine_issue_comments` tool. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L115-R119) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L130-L131)

### Versioning
* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L3-R3): Incremented the project version from `0.1.3` to `0.1.4` to reflect the changes.
* [`CHANGELOG.md`](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR9-R18): Added an entry for version `0.1.4` documenting the removal of `get_redmine_issue_comments` and the changes to `get_redmine_issue`.

### Test Updates
* [`tests/test_redmine_handler.py`](diffhunk://#diff-536e095d6d423fa9d47d291f48526195f534a92db6734bfe4f3ee0e2fafb34e8L87-R90): Updated tests for `get_redmine_issue` to verify the inclusion of journals by default and the ability to opt out. Removed all tests related to the deprecated `get_redmine_issue_comments` tool. [[1]](diffhunk://#diff-536e095d6d423fa9d47d291f48526195f534a92db6734bfe4f3ee0e2fafb34e8L87-R90) [[2]](diffhunk://#diff-536e095d6d423fa9d47d291f48526195f534a92db6734bfe4f3ee0e2fafb34e8R112-R116) [[3]](diffhunk://#diff-536e095d6d423fa9d47d291f48526195f534a92db6734bfe4f3ee0e2fafb34e8R177-R187) [[4]](diffhunk://#diff-536e095d6d423fa9d47d291f48526195f534a92db6734bfe4f3ee0e2fafb34e8L417-L488)