### PR TITLE
Add status_name mapping for issue updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,10 @@ Creates a new issue in the specified project. Additional Redmine fields such as 
 ### `update_redmine_issue(issue_id: int, fields: Dict[str, Any])`
 Updates an existing issue with the provided fields.
 
+You may supply either ``status_id`` or ``status_name`` to change the issue
+status. When ``status_name`` is given the tool resolves the corresponding
+identifier automatically.
+
 
 ## Docker Deployment
 

--- a/src/redmine_mcp_server/redmine_handler.py
+++ b/src/redmine_mcp_server/redmine_handler.py
@@ -230,7 +230,9 @@ async def update_redmine_issue(issue_id: int, fields: Dict[str, Any]) -> Dict[st
     if "status_name" in fields and "status_id" not in fields:
         name = str(fields.pop("status_name")).lower()
         try:
-            statuses = redmine.issue_status.all()
+            statuses = list(redmine.issue_status.filter(name=name))
+            if not statuses:
+                statuses = redmine.issue_status.all()
             for status in statuses:
                 if getattr(status, "name", "").lower() == name:
                     fields["status_id"] = status.id

--- a/tests/test_redmine_handler.py
+++ b/tests/test_redmine_handler.py
@@ -346,7 +346,7 @@ class TestRedmineHandler:
         status = Mock()
         status.id = 5
         status.name = "Closed"
-        mock_redmine.issue_status.all.return_value = [status]
+        mock_redmine.issue_status.filter.return_value = [status]
 
         from redmine_mcp_server.redmine_handler import update_redmine_issue
 

--- a/tests/test_redmine_handler.py
+++ b/tests/test_redmine_handler.py
@@ -338,6 +338,25 @@ class TestRedmineHandler:
 
     @pytest.mark.asyncio
     @patch('redmine_mcp_server.redmine_handler.redmine')
+    async def test_update_redmine_issue_status_name(self, mock_redmine, mock_redmine_issue):
+        """Update issue using a status name instead of an ID."""
+        mock_redmine.issue.update.return_value = True
+        mock_redmine.issue.get.return_value = mock_redmine_issue
+
+        status = Mock()
+        status.id = 5
+        status.name = "Closed"
+        mock_redmine.issue_status.all.return_value = [status]
+
+        from redmine_mcp_server.redmine_handler import update_redmine_issue
+
+        result = await update_redmine_issue(123, {"status_name": "Closed"})
+
+        assert result["id"] == 123
+        mock_redmine.issue.update.assert_called_once_with(123, status_id=5)
+
+    @pytest.mark.asyncio
+    @patch('redmine_mcp_server.redmine_handler.redmine')
     async def test_update_redmine_issue_not_found(self, mock_redmine):
         """Test update when issue not found."""
         from redminelib.exceptions import ResourceNotFoundError


### PR DESCRIPTION
## Summary
- map a `status_name` field to the proper ID when updating issues
- document the behavior in the README
- test using status names in update_redmine_issue

## Testing
- `python tests/run_tests.py --all`

------
https://chatgpt.com/codex/tasks/task_e_68522f1be0b0832ba8220c89cc7daa59