### PR TITLE
Bugfix/update issue status by name

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ The tool will automatically be available through the MCP interface.
 
 ### Testing
 
-The project includes 36 tests covering unit tests, integration tests, and connection validation.
+The project includes unit tests, integration tests, and connection validation.
 
 **Run tests:**
 ```bash

--- a/README.md
+++ b/README.md
@@ -130,6 +130,10 @@ Creates a new issue in the specified project. Additional Redmine fields such as 
 ### `update_redmine_issue(issue_id: int, fields: Dict[str, Any])`
 Updates an existing issue with the provided fields.
 
+You may supply either ``status_id`` or ``status_name`` to change the issue
+status. When ``status_name`` is given the tool resolves the corresponding
+identifier automatically.
+
 
 ## Docker Deployment
 

--- a/roadmap.md
+++ b/roadmap.md
@@ -13,9 +13,8 @@
 - [x] Additional Redmine tools (list my issues)
 - [x] Additional Redmine tools (get comments by issue)
 
-### In Progress 🚧
-
 ### Planned 📋
+- [ ] Update Redmine tools (get attachments by issue)
 - [ ] Advanced search and filtering
 - [ ] Performance optimizations and caching
 - [ ] Custom field support

--- a/tests/test_redmine_handler.py
+++ b/tests/test_redmine_handler.py
@@ -338,6 +338,25 @@ class TestRedmineHandler:
 
     @pytest.mark.asyncio
     @patch('redmine_mcp_server.redmine_handler.redmine')
+    async def test_update_redmine_issue_status_name(self, mock_redmine, mock_redmine_issue):
+        """Update issue using a status name instead of an ID."""
+        mock_redmine.issue.update.return_value = True
+        mock_redmine.issue.get.return_value = mock_redmine_issue
+
+        status = Mock()
+        status.id = 5
+        status.name = "Closed"
+        mock_redmine.issue_status.all.return_value = [status]
+
+        from redmine_mcp_server.redmine_handler import update_redmine_issue
+
+        result = await update_redmine_issue(123, {"status_name": "Closed"})
+
+        assert result["id"] == 123
+        mock_redmine.issue.update.assert_called_once_with(123, status_id=5)
+
+    @pytest.mark.asyncio
+    @patch('redmine_mcp_server.redmine_handler.redmine')
     async def test_update_redmine_issue_not_found(self, mock_redmine):
         """Test update when issue not found."""
         from redminelib.exceptions import ResourceNotFoundError


### PR DESCRIPTION
This pull request introduces enhancements to the Redmine issue update functionality, updates documentation, and adjusts the project roadmap. The most notable changes include adding support for resolving issue statuses by name, improving test coverage for this feature, and refining the project's documentation for clarity and consistency.

### Enhancements to Redmine issue updates:
* [`src/redmine_mcp_server/redmine_handler.py`](diffhunk://#diff-6f71ca6e577c97803b6a8ca195486747315f6feb3abb29e9fcced62dbecbe875L220-R240): Added support for resolving `status_name` to `status_id` when updating Redmine issues. If `status_name` is provided but `status_id` is not, the function automatically resolves the corresponding ID.

### Improved test coverage:
* [`tests/test_redmine_handler.py`](diffhunk://#diff-536e095d6d423fa9d47d291f48526195f534a92db6734bfe4f3ee0e2fafb34e8R339-R357): Added a new test to verify the behavior of updating a Redmine issue using a `status_name` instead of a `status_id`. This ensures the new functionality works as intended.

### Documentation updates:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R133-R136): Clarified that either `status_id` or `status_name` can be used to update issue statuses. Also streamlined the description of the project's test suite. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R133-R136) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L201-R205)

### Roadmap adjustments:
* [`roadmap.md`](diffhunk://#diff-51abe96bc493857fdfba599c6b70e3a6c09200cf29e130d15b599fef538e32dfL16-R17): Updated the roadmap to remove completed items and add a new planned feature for retrieving attachments by issue.