### PR TITLE
Add search_redmine_issues tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ htmlcov/
 .venv
 .env
 .env.docker
+CLAUDE.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.6] - 2025-06-19
+### Added
+- New MCP tool `search_redmine_issues` for querying issues by text.
+
 ## [0.1.5] - 2025-06-18
 ### Added
 - `get_redmine_issue` can now return attachment metadata via a new

--- a/README.md
+++ b/README.md
@@ -126,6 +126,9 @@ Lists all accessible projects in the Redmine instance.
 ### `list_my_redmine_issues(**filters)`
 Lists issues assigned to the authenticated user. Uses the Redmine filter `assigned_to_id="me"`. Additional query parameters can be supplied as keyword arguments.
 
+### `search_redmine_issues(query: str, **options)`
+Searches issues for text contained in the ``query`` string. Extra options are forwarded directly to ``python-redmine``'s search API.
+
 ### `create_redmine_issue(project_id: int, subject: str, description: str = "", **fields)`
 Creates a new issue in the specified project. Additional Redmine fields such as `priority_id` can be passed as keyword arguments.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcp-redmine"
-version = "0.1.5"
+version = "0.1.6"
 description = "A Model Context Protocol (MCP) server for Redmine integration"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/redmine_mcp_server/redmine_handler.py
+++ b/src/redmine_mcp_server/redmine_handler.py
@@ -248,6 +248,33 @@ async def list_my_redmine_issues(**filters: Any) -> List[Dict[str, Any]]:
 
 
 @mcp.tool()
+async def search_redmine_issues(query: str, **options: Any) -> List[Dict[str, Any]]:
+    """Search Redmine issues matching a query string.
+
+    Args:
+        query: Text to search for in issues.
+        **options: Additional search options passed directly to the
+            underlying python-redmine ``search`` API.
+
+    Returns:
+        A list of issue dictionaries. If no issues are found an empty list
+        is returned. On error a list containing a single dictionary with an
+        ``"error"`` key is returned.
+    """
+    if not redmine:
+        return [{"error": "Redmine client not initialized."}]
+
+    try:
+        results = redmine.issue.search(query, **options)
+        if results is None:
+            return []
+        return [_issue_to_dict(issue) for issue in results]
+    except Exception as e:
+        print(f"Error searching Redmine issues: {e}")
+        return [{"error": "An error occurred while searching issues."}]
+
+
+@mcp.tool()
 async def create_redmine_issue(
     project_id: int,
     subject: str,

--- a/uv.lock
+++ b/uv.lock
@@ -331,7 +331,7 @@ cli = [
 
 [[package]]
 name = "mcp-redmine"
-version = "0.1.5"
+version = "0.1.6"
 source = { virtual = "." }
 dependencies = [
     { name = "fastapi", extra = ["standard"] },


### PR DESCRIPTION
## Summary
- add `search_redmine_issues` tool to query issues by string
- document the search tool in README
- update changelog and bump version to 0.1.6

## Testing
- `python tests/run_tests.py --all`

------
https://chatgpt.com/codex/tasks/task_e_6853f3e76ca4832bb5c4311970b17d48