### PR TITLE
feat: strengthen Redmine custom-field support with discovery and safer updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Dependency Updates**
   - `black` upgraded from 25.12.0 to 26.1.0
 - Improved issue update validation for named custom fields with clear errors when values are not allowed for the target custom field.
+- `create_redmine_issue` now accepts `extra_fields` as an explicit object/string payload and no longer forwards a literal `extra_fields` attribute to Redmine.
 
 ### Improved
 - **Test Coverage** - 44 new unit tests for custom field helper functions (`redmine_handler.py` lines 474-640)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **New MCP Tool: `list_project_issue_custom_fields`** - Discover issue custom fields for a Redmine project
+  - Lists custom field metadata (`id`, `name`, `field_format`, `is_required`, `multiple`, `default_value`)
+  - Includes allowed values (`possible_values`) and tracker bindings (`trackers`)
+  - Optional `tracker_id` filter to show only fields applicable to a specific tracker
+  - 7 unit tests covering serialization, filtering, validation, and error handling
 - **New MCP Tool: `list_redmine_versions`** - List versions/milestones for a Redmine project
   - Filter by `project_id` (numeric or string identifier)
   - Optional `status_filter` parameter (open, locked, closed)
@@ -41,7 +46,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `redmine_handler.py` coverage improved from 94% to 97% (with integration tests)
   - Overall coverage improved from 95% to 98%
 - **Documentation** - Updated README and tool-reference.md
-  - Tool count updated from 15 to 16
+  - Tool count updated from 15 to 17
+  - Added `list_project_issue_custom_fields` to Project Management category in README
+  - Added full `list_project_issue_custom_fields` documentation to tool-reference.md
   - Added `list_redmine_versions` to Project Management category in README
   - Added full tool documentation to tool-reference.md with parameters, examples, and usage guidance
   - Documented `fixed_version_id` parameter for `list_redmine_issues`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - 6 integration tests for project ID, string identifier, structure, filtering, and error handling
 - **`fixed_version_id` filter** documented for `list_redmine_issues` tool
 - **Claude Desktop MCP client configuration** added to README with stdio transport via FastMCP proxy
+- `get_redmine_issue` now supports `include_custom_fields` (default: `true`) and can return serialized issue `custom_fields`.
+- `update_redmine_issue` now supports updating custom fields by name (for example `{"size": "S"}`) by resolving project custom-field metadata.
 
 ### Fixed
 - **Required custom field handling** for `create_redmine_issue` and `update_redmine_issue` ([#65](https://github.com/jztan/redmine-mcp-server/issues/65))
@@ -30,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - **Dependency Updates**
   - `black` upgraded from 25.12.0 to 26.1.0
+- Improved issue update validation for named custom fields with clear errors when values are not allowed for the target custom field.
 
 ### Improved
 - **Test Coverage** - 44 new unit tests for custom field helper functions (`redmine_handler.py` lines 474-640)
@@ -709,4 +712,3 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [0.1.2]: https://github.com/jztan/redmine-mcp-server/releases/tag/v0.1.2
 [0.1.1]: https://github.com/jztan/redmine-mcp-server/releases/tag/v0.1.1
 [0.1.0]: https://github.com/jztan/redmine-mcp-server/releases/tag/v0.1.0
-

--- a/README.md
+++ b/README.md
@@ -374,10 +374,11 @@ curl http://localhost:8000/health
 
 ## Available Tools
 
-This MCP server provides 16 tools for interacting with Redmine. For detailed documentation, see [Tool Reference](./docs/tool-reference.md).
+This MCP server provides 17 tools for interacting with Redmine. For detailed documentation, see [Tool Reference](./docs/tool-reference.md).
 
-- **Project Management** (3 tools)
+- **Project Management** (4 tools)
   - [`list_redmine_projects`](docs/tool-reference.md#list_redmine_projects) - List all accessible projects
+  - [`list_project_issue_custom_fields`](docs/tool-reference.md#list_project_issue_custom_fields) - List issue custom fields configured for a project
   - [`list_redmine_versions`](docs/tool-reference.md#list_redmine_versions) - List versions/milestones for a project
   - [`summarize_project_status`](docs/tool-reference.md#summarize_project_status) - Get comprehensive project status summary
 

--- a/README.md
+++ b/README.md
@@ -388,6 +388,7 @@ This MCP server provides 16 tools for interacting with Redmine. For detailed doc
   - [`search_redmine_issues`](docs/tool-reference.md#search_redmine_issues) - Search issues by text query
   - [`create_redmine_issue`](docs/tool-reference.md#create_redmine_issue) - Create new issues
   - [`update_redmine_issue`](docs/tool-reference.md#update_redmine_issue) - Update existing issues
+  - Note: `get_redmine_issue` can include `custom_fields` and `update_redmine_issue` can update custom fields by name (for example `{"size": "S"}`).
 
 - **Search & Wiki** (5 tools)
   - [`search_entire_redmine`](docs/tool-reference.md#search_entire_redmine) - Global search across issues and wiki pages (Redmine 3.3.0+)

--- a/docs/tool-reference.md
+++ b/docs/tool-reference.md
@@ -177,6 +177,39 @@ Lists all accessible projects in the Redmine instance.
 
 ---
 
+### `list_project_issue_custom_fields`
+
+List issue custom fields configured for a project, including allowed values and tracker bindings.
+
+**Parameters:**
+- `project_id` (integer or string, required): Project ID (numeric) or identifier (string)
+- `tracker_id` (integer, optional): Restrict output to fields applicable to the given tracker ID
+
+**Returns:** List of custom field metadata dictionaries
+
+**Example:**
+```json
+[
+  {
+    "id": 6,
+    "name": "Size",
+    "field_format": "list",
+    "is_required": false,
+    "multiple": false,
+    "default_value": "M",
+    "possible_values": ["S", "M", "L"],
+    "trackers": [{"id": 5, "name": "Bug"}]
+  }
+]
+```
+
+**Example with tracker filter:**
+```python
+list_project_issue_custom_fields(project_id="pipeline", tracker_id=5)
+```
+
+---
+
 ### `summarize_project_status`
 
 Provide a comprehensive summary of project status based on issue activity over a specified time period.

--- a/docs/tool-reference.md
+++ b/docs/tool-reference.md
@@ -485,7 +485,9 @@ Creates a new issue in the specified project.
 - `fields` (object|string, optional): Additional Redmine fields as:
   - an object (`{"priority_id": 3, "tracker_id": 1}`), or
   - a serialized JSON object string (for MCP clients that pass string payloads)
-- `**extra_fields` (optional): Additional Redmine fields passed directly as keyword arguments (e.g., `priority_id`, `assigned_to_id`, `tracker_id`, `status_id`)
+- `extra_fields` (object|string, optional): Additional Redmine fields as:
+  - an object (`{"priority_id": 3, "tracker_id": 1}`), or
+  - a serialized JSON object string
 
 **Returns:** Created issue dictionary
 
@@ -498,8 +500,7 @@ create_redmine_issue(
     project_id=1,
     subject="Login button not working",
     description="The login button does not respond to clicks",
-    priority_id=3,  # High priority
-    tracker_id=1    # Bug tracker
+    fields={"priority_id": 3, "tracker_id": 1}
 )
 ```
 

--- a/docs/tool-reference.md
+++ b/docs/tool-reference.md
@@ -259,6 +259,7 @@ Retrieve detailed information about a specific Redmine issue.
 - `issue_id` (integer, required): The ID of the issue to retrieve
 - `include_journals` (boolean, optional): Include journals (comments) in result. Default: `true`
 - `include_attachments` (boolean, optional): Include attachments metadata. Default: `true`
+- `include_custom_fields` (boolean, optional): Include custom fields in result. Default: `true`
 
 **Returns:** Issue dictionary with details, journals, and attachments
 
@@ -270,6 +271,7 @@ Retrieve detailed information about a specific Redmine issue.
   "description": "Users cannot login...",
   "status": {"id": 1, "name": "New"},
   "priority": {"id": 2, "name": "Normal"},
+  "custom_fields": [{"id": 6, "name": "Size", "value": "S"}],
   "journals": [...],
   "attachments": [...]
 }
@@ -514,6 +516,7 @@ Updates an existing issue with the provided fields.
 **Returns:** Updated issue dictionary
 
 **Note:** You can use either `status_id` or `status_name` in fields. When `status_name` is provided, the tool automatically resolves the corresponding status ID.
+You can also update custom fields by name (for example `{"size": "S"}`) and the tool will resolve them to Redmine `custom_fields` entries using project custom-field metadata. You can still pass explicit `custom_fields` with field IDs.
 
 **Example:**
 ```python
@@ -532,6 +535,14 @@ update_redmine_issue(
     fields={
         "status_id": 3,
         "assigned_to_id": 5
+    }
+)
+
+# Update Agile/custom field by name
+update_redmine_issue(
+    issue_id=123,
+    fields={
+        "size": "S"
     }
 )
 ```

--- a/src/redmine_mcp_server/redmine_handler.py
+++ b/src/redmine_mcp_server/redmine_handler.py
@@ -935,7 +935,10 @@ def _map_named_custom_fields_for_update(
         return update_fields
 
     # Keep caller-provided custom_fields and merge name-based mappings into it.
-    merged_custom_fields = _coerce_update_custom_fields(update_fields.pop("custom_fields", None))
+    custom_fields_provided = "custom_fields" in update_fields
+    merged_custom_fields = _coerce_update_custom_fields(
+        update_fields.pop("custom_fields", None)
+    )
 
     named_candidates = [
         field_name
@@ -943,7 +946,7 @@ def _map_named_custom_fields_for_update(
         if not _is_standard_issue_update_key(field_name)
     ]
     if not named_candidates:
-        if merged_custom_fields:
+        if custom_fields_provided:
             update_fields["custom_fields"] = merged_custom_fields
         return update_fields
 
@@ -993,7 +996,7 @@ def _map_named_custom_fields_for_update(
             )
         _upsert_custom_field_entry(merged_custom_fields, match["id"], value)
 
-    if merged_custom_fields:
+    if merged_custom_fields or custom_fields_provided:
         update_fields["custom_fields"] = merged_custom_fields
 
     return update_fields

--- a/src/redmine_mcp_server/redmine_handler.py
+++ b/src/redmine_mcp_server/redmine_handler.py
@@ -994,10 +994,9 @@ def _map_named_custom_fields_for_update(
 
         value = update_fields.pop(candidate)
         possible_values = match["possible_values"]
-        if (
-            not _is_missing_custom_field_value(value)
-            and not _is_allowed_custom_field_value(value, possible_values)
-        ):
+        if not _is_missing_custom_field_value(
+            value
+        ) and not _is_allowed_custom_field_value(value, possible_values):
             raise ValueError(
                 f"Invalid value '{value}' for custom field '{match['name']}'. "
                 f"Allowed values: {possible_values}."

--- a/src/redmine_mcp_server/redmine_handler.py
+++ b/src/redmine_mcp_server/redmine_handler.py
@@ -564,7 +564,8 @@ def _parse_optional_object_payload(
             parsed = json.loads(raw)
         except Exception as e:
             raise ValueError(
-                f"Invalid {payload_name} payload. Expected a dict or JSON object string."
+                f"Invalid {payload_name} payload. Expected a dict or "
+                "JSON object string."
             ) from e
     else:
         raise ValueError(

--- a/tests/test_list_project_issue_custom_fields.py
+++ b/tests/test_list_project_issue_custom_fields.py
@@ -1,0 +1,178 @@
+"""
+Test cases for list_project_issue_custom_fields tool.
+"""
+
+import os
+import sys
+from unittest.mock import Mock, patch
+
+import pytest
+
+# Add the src directory to the path
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from redmine_mcp_server.redmine_handler import (  # noqa: E402
+    _custom_field_to_dict,
+    list_project_issue_custom_fields,
+)
+
+
+def create_mock_custom_field(
+    field_id=6,
+    name="Size",
+    field_format="list",
+    is_required=False,
+    multiple=False,
+    default_value="M",
+    possible_values=None,
+    trackers=None,
+):
+    """Create a mock Redmine custom field with sensible defaults."""
+    custom_field = Mock()
+    custom_field.id = field_id
+    custom_field.name = name
+    custom_field.field_format = field_format
+    custom_field.is_required = is_required
+    custom_field.multiple = multiple
+    custom_field.default_value = default_value
+    custom_field.possible_values = (
+        possible_values
+        if possible_values is not None
+        else [{"value": "S"}, {"value": "M"}]
+    )
+    custom_field.trackers = trackers if trackers is not None else []
+    return custom_field
+
+
+class TestCustomFieldToDict:
+    """Unit tests for _custom_field_to_dict helper."""
+
+    def test_serializes_expected_fields(self):
+        """Helper should serialize metadata, values, and tracker bindings."""
+        bug_tracker = Mock()
+        bug_tracker.id = 5
+        bug_tracker.name = "Bug"
+
+        custom_field = create_mock_custom_field(trackers=[bug_tracker])
+        result = _custom_field_to_dict(custom_field)
+
+        assert result["id"] == 6
+        assert result["name"] == "Size"
+        assert result["field_format"] == "list"
+        assert result["is_required"] is False
+        assert result["multiple"] is False
+        assert result["default_value"] == "M"
+        assert result["possible_values"] == ["S", "M"]
+        assert result["trackers"] == [{"id": 5, "name": "Bug"}]
+
+
+class TestListProjectIssueCustomFields:
+    """Unit tests for list_project_issue_custom_fields tool."""
+
+    @pytest.fixture
+    def mock_redmine(self):
+        """Create a mock Redmine client."""
+        with patch("redmine_mcp_server.redmine_handler.redmine") as mock:
+            yield mock
+
+    @pytest.mark.asyncio
+    async def test_list_project_issue_custom_fields_success(self, mock_redmine):
+        """Returns project custom fields with metadata."""
+        custom_field = create_mock_custom_field()
+        project = Mock()
+        project.issue_custom_fields = [custom_field]
+        mock_redmine.project.get.return_value = project
+
+        result = await list_project_issue_custom_fields(project_id=41)
+
+        assert isinstance(result, list)
+        assert len(result) == 1
+        assert result[0]["id"] == 6
+        assert result[0]["name"] == "Size"
+        assert result[0]["possible_values"] == ["S", "M"]
+        mock_redmine.project.get.assert_called_once_with(
+            41, include="issue_custom_fields"
+        )
+
+    @pytest.mark.asyncio
+    async def test_list_project_issue_custom_fields_filters_by_tracker(
+        self, mock_redmine
+    ):
+        """Tracker filtering keeps matching and global (unrestricted) custom fields."""
+        tracker_bug = Mock()
+        tracker_bug.id = 5
+        tracker_bug.name = "Bug"
+
+        tracker_feature = Mock()
+        tracker_feature.id = 7
+        tracker_feature.name = "Feature"
+
+        for_bug = create_mock_custom_field(
+            field_id=10, name="Bug-only", trackers=[tracker_bug]
+        )
+        for_feature = create_mock_custom_field(
+            field_id=11, name="Feature-only", trackers=[tracker_feature]
+        )
+        global_field = create_mock_custom_field(field_id=12, name="Global", trackers=[])
+
+        project = Mock()
+        project.issue_custom_fields = [for_bug, for_feature, global_field]
+        mock_redmine.project.get.return_value = project
+
+        result = await list_project_issue_custom_fields(project_id=41, tracker_id=5)
+
+        assert len(result) == 2
+        assert {field["id"] for field in result} == {10, 12}
+
+    @pytest.mark.asyncio
+    async def test_list_project_issue_custom_fields_accepts_string_tracker_id(
+        self, mock_redmine
+    ):
+        """String tracker IDs are accepted when parseable as integers."""
+        tracker_bug = Mock()
+        tracker_bug.id = 5
+        tracker_bug.name = "Bug"
+
+        field = create_mock_custom_field(field_id=10, trackers=[tracker_bug])
+        project = Mock()
+        project.issue_custom_fields = [field]
+        mock_redmine.project.get.return_value = project
+
+        result = await list_project_issue_custom_fields(
+            project_id="pipeline", tracker_id="5"
+        )
+
+        assert len(result) == 1
+        assert result[0]["id"] == 10
+        mock_redmine.project.get.assert_called_once_with(
+            "pipeline", include="issue_custom_fields"
+        )
+
+    @pytest.mark.asyncio
+    async def test_list_project_issue_custom_fields_invalid_tracker_id(
+        self, mock_redmine
+    ):
+        """Invalid tracker IDs should return a clear validation error."""
+        result = await list_project_issue_custom_fields(project_id=41, tracker_id="abc")
+
+        assert len(result) == 1
+        assert "error" in result[0]
+        assert "Invalid tracker_id" in result[0]["error"]
+        mock_redmine.project.get.assert_not_called()
+
+    @pytest.mark.asyncio
+    @patch("redmine_mcp_server.redmine_handler.redmine", None)
+    async def test_list_project_issue_custom_fields_no_client(self):
+        """Returns initialization error when Redmine client is unavailable."""
+        result = await list_project_issue_custom_fields(project_id=41)
+        assert result == [{"error": "Redmine client not initialized."}]
+
+    @pytest.mark.asyncio
+    async def test_list_project_issue_custom_fields_error(self, mock_redmine):
+        """API errors are returned in standard error format."""
+        mock_redmine.project.get.side_effect = Exception("Boom")
+
+        result = await list_project_issue_custom_fields(project_id=41)
+
+        assert len(result) == 1
+        assert "error" in result[0]

--- a/tests/test_redmine_handler.py
+++ b/tests/test_redmine_handler.py
@@ -932,6 +932,20 @@ class TestRedmineHandler:
 
     @pytest.mark.asyncio
     @patch("redmine_mcp_server.redmine_handler.redmine")
+    async def test_update_redmine_issue_preserves_empty_custom_fields_payload(
+        self, mock_redmine, mock_redmine_issue
+    ):
+        """Explicit empty custom_fields should be forwarded to clear values."""
+        from redmine_mcp_server.redmine_handler import update_redmine_issue
+
+        await update_redmine_issue(123, {"subject": "New", "custom_fields": []})
+
+        update_kwargs = mock_redmine.issue.update.call_args.kwargs
+        assert "custom_fields" in update_kwargs
+        assert update_kwargs["custom_fields"] == []
+
+    @pytest.mark.asyncio
+    @patch("redmine_mcp_server.redmine_handler.redmine")
     async def test_update_redmine_issue_invalid_named_custom_field_value(
         self, mock_redmine
     ):


### PR DESCRIPTION
## Elevator Pitch
This PR turns custom fields from a trial-and-error workflow into a discoverable, validated, automation-safe API surface for Redmine MCP clients.


### Why this matters
Clients could update issue custom fields, but they had no first-class way to discover what fields exist, which values are allowed, or which trackers a field applies to. That led to avoidable validation failures and brittle automation.

### What is included
- Added a new MCP tool: `list_project_issue_custom_fields(project_id, tracker_id=None)`
- Returns actionable metadata per field: `id`, `name`, `field_format`, `is_required`, `multiple`, `default_value`, `possible_values`, `trackers`
- Added optional `tracker_id` filtering to return only fields applicable to a specific tracker
- Strengthened custom-field handling across issue operations:
  - safer `create_redmine_issue` payload handling
  - improved `update_redmine_issue` custom-field behavior and validation
  - preserves intended null/empty semantics for `custom_fields` updates
  - supports named custom field updates and custom field visibility in issue retrieval
- Updated README + tool reference + changelog for the full custom-field workflow
- Added/updated focused unit tests for helper behavior and tool-level paths

### Expected impact
- Fewer failed update/create calls caused by unknown or invalid custom-field values
- Better MCP agent reliability via explicit preflight discovery
- Faster client integration due to reduced Redmine-specific guesswork

### Risk and mitigation
Risk is low-to-moderate and concentrated in issue custom-field pathways. The change is covered by targeted tests, preserves existing APIs, and adds additive discovery capabilities.

### Validation
Executed:
- `uv run pytest -q tests/test_list_project_issue_custom_fields.py tests/test_redmine_handler.py`
