### PR TITLE
feat: add project members and time tracking tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **New MCP Tool: `list_project_members`** - List members and groups of a Redmine project
+  - Returns user/group info along with assigned roles
+  - Supports both numeric project IDs and string identifiers
+  - Includes comprehensive unit tests
+- **New MCP Tools: Time Tracking** - Full time entry management
+  - `list_time_entries` - List time entries with filtering by project, issue, user, and date range
+  - `create_time_entry` - Log time against projects or issues with activity and date support
+  - `update_time_entry` - Modify existing time entries (hours, comments, activity, date)
+  - All tools include pagination support and comprehensive unit tests
+- **Documentation** - Updated tool-reference.md with new tools and Time Tracking section
+
 ## [0.12.1] - 2026-03-05
 
 ### Fixed

--- a/docs/tool-reference.md
+++ b/docs/tool-reference.md
@@ -282,6 +282,49 @@ issues = list_redmine_issues(fixed_version_id=versions[0]["id"])
 
 ---
 
+### `list_project_members`
+
+List all members (users and groups) of a Redmine project along with their assigned roles.
+
+**Parameters:**
+- `project_id` (integer or string, required): Project ID (numeric) or identifier (string)
+
+**Returns:** List of membership dictionaries containing user/group info and roles
+
+**Example:**
+```json
+[
+  {
+    "id": 1,
+    "user": {"id": 5, "name": "John Doe"},
+    "group": null,
+    "project": {"id": 10, "name": "My Project"},
+    "roles": [{"id": 3, "name": "Developer"}]
+  },
+  {
+    "id": 2,
+    "user": null,
+    "group": {"id": 15, "name": "Dev Team"},
+    "project": {"id": 10, "name": "My Project"},
+    "roles": [{"id": 4, "name": "Manager"}]
+  }
+]
+```
+
+**Usage:**
+```python
+# List members by project ID
+members = list_project_members(project_id=10)
+
+# List members by project identifier
+members = list_project_members(project_id="my-project")
+
+# Get all developers in a project
+devs = [m for m in members if any(r["name"] == "Developer" for r in m["roles"])]
+```
+
+---
+
 ## Issue Operations
 
 ### `get_redmine_issue`
@@ -578,6 +621,147 @@ update_redmine_issue(
     fields={
         "size": "S"
     }
+)
+```
+
+---
+
+## Time Tracking
+
+### `list_time_entries`
+
+List time entries from Redmine with optional filtering and pagination.
+
+**Parameters:**
+- `project_id` (integer or string, optional): Filter by project (numeric ID or string identifier)
+- `issue_id` (integer, optional): Filter by issue ID
+- `user_id` (integer or string, optional): Filter by user ID. Use `"me"` for current user
+- `from_date` (string, optional): Start date filter (YYYY-MM-DD format)
+- `to_date` (string, optional): End date filter (YYYY-MM-DD format)
+- `limit` (integer, optional): Maximum entries to return. Default: `25`, Max: `100`
+- `offset` (integer, optional): Number of entries to skip for pagination. Default: `0`
+
+**Returns:** List of time entry dictionaries
+
+**Example:**
+```json
+[
+  {
+    "id": 1,
+    "hours": 2.5,
+    "comments": "Bug fix work",
+    "spent_on": "2024-03-15",
+    "user": {"id": 5, "name": "John Doe"},
+    "project": {"id": 10, "name": "My Project"},
+    "issue": {"id": 123},
+    "activity": {"id": 9, "name": "Development"},
+    "created_on": "2024-03-15T10:30:00",
+    "updated_on": "2024-03-15T10:30:00"
+  }
+]
+```
+
+**Usage:**
+```python
+# List all time entries for a project
+entries = list_time_entries(project_id="my-project")
+
+# Filter by issue and date range
+entries = list_time_entries(
+    issue_id=123,
+    from_date="2024-01-01",
+    to_date="2024-03-31"
+)
+
+# Get current user's time entries
+my_entries = list_time_entries(user_id="me")
+```
+
+---
+
+### `create_time_entry`
+
+Create a new time entry in Redmine. Log time against a project or issue.
+
+**Parameters:**
+- `hours` (float, required): Number of hours spent. Must be positive. Can be decimal (e.g., `1.5`)
+- `project_id` (integer or string, optional): Project to log time against. Required if `issue_id` is not provided
+- `issue_id` (integer, optional): Issue to log time against. If provided, `project_id` is optional
+- `activity_id` (integer, optional): Time entry activity ID (e.g., Development, Design). Uses default if not provided
+- `comments` (string, optional): Description of work performed
+- `spent_on` (string, optional): Date when time was spent (YYYY-MM-DD). Defaults to today
+
+**Returns:** Created time entry dictionary
+
+**Example:**
+```json
+{
+  "id": 1,
+  "hours": 2.5,
+  "comments": "Bug fix",
+  "spent_on": "2024-03-15",
+  "user": {"id": 5, "name": "John Doe"},
+  "project": {"id": 10, "name": "My Project"},
+  "issue": {"id": 123},
+  "activity": {"id": 9, "name": "Development"}
+}
+```
+
+**Usage:**
+```python
+# Log time against an issue
+create_time_entry(
+    hours=2.5,
+    issue_id=123,
+    comments="Fixed login bug"
+)
+
+# Log time against a project with specific date
+create_time_entry(
+    hours=1.0,
+    project_id="my-project",
+    activity_id=9,
+    comments="Code review",
+    spent_on="2024-03-15"
+)
+```
+
+---
+
+### `update_time_entry`
+
+Update an existing time entry in Redmine.
+
+**Parameters:**
+- `time_entry_id` (integer, required): ID of the time entry to update
+- `hours` (float, optional): New hours value. Must be positive if provided
+- `activity_id` (integer, optional): New activity ID
+- `comments` (string, optional): New comments/description
+- `spent_on` (string, optional): New date (YYYY-MM-DD format)
+
+**Returns:** Updated time entry dictionary
+
+**Example:**
+```json
+{
+  "id": 1,
+  "hours": 3.0,
+  "comments": "Extended work on bug fix",
+  "spent_on": "2024-03-15"
+}
+```
+
+**Usage:**
+```python
+# Update hours
+update_time_entry(time_entry_id=1, hours=3.0)
+
+# Update multiple fields
+update_time_entry(
+    time_entry_id=1,
+    hours=4.0,
+    comments="Extended debugging session",
+    spent_on="2024-03-16"
 )
 ```
 

--- a/src/redmine_mcp_server/redmine_handler.py
+++ b/src/redmine_mcp_server/redmine_handler.py
@@ -2491,6 +2491,104 @@ async def search_entire_redmine(
         return _handle_redmine_error(e, f"searching Redmine for '{query}'")
 
 
+def _membership_to_dict(membership: Any) -> Dict[str, Any]:
+    """Convert a project membership to a serializable dict."""
+    user = getattr(membership, "user", None)
+    group = getattr(membership, "group", None)
+    project = getattr(membership, "project", None)
+    roles = getattr(membership, "roles", None) or []
+
+    result: Dict[str, Any] = {
+        "id": getattr(membership, "id", None),
+    }
+
+    # User or group (memberships can be for either)
+    if user is not None:
+        result["user"] = {
+            "id": getattr(user, "id", None),
+            "name": getattr(user, "name", ""),
+        }
+        result["group"] = None
+    elif group is not None:
+        result["user"] = None
+        result["group"] = {
+            "id": getattr(group, "id", None),
+            "name": getattr(group, "name", ""),
+        }
+    else:
+        result["user"] = None
+        result["group"] = None
+
+    # Project info
+    if project is not None:
+        result["project"] = {
+            "id": getattr(project, "id", None),
+            "name": getattr(project, "name", ""),
+        }
+    else:
+        result["project"] = None
+
+    # Roles
+    result["roles"] = []
+    try:
+        for role in roles:
+            if isinstance(role, dict):
+                result["roles"].append(
+                    {
+                        "id": role.get("id"),
+                        "name": role.get("name", ""),
+                    }
+                )
+            else:
+                result["roles"].append(
+                    {
+                        "id": getattr(role, "id", None),
+                        "name": getattr(role, "name", ""),
+                    }
+                )
+    except TypeError:
+        pass  # roles not iterable
+
+    return result
+
+
+def _time_entry_to_dict(time_entry: Any) -> Dict[str, Any]:
+    """Convert a time entry to a serializable dict."""
+    user = getattr(time_entry, "user", None)
+    project = getattr(time_entry, "project", None)
+    issue = getattr(time_entry, "issue", None)
+    activity = getattr(time_entry, "activity", None)
+
+    return {
+        "id": getattr(time_entry, "id", None),
+        "hours": getattr(time_entry, "hours", 0),
+        "comments": getattr(time_entry, "comments", ""),
+        "spent_on": (
+            str(time_entry.spent_on)
+            if getattr(time_entry, "spent_on", None) is not None
+            else None
+        ),
+        "user": ({"id": user.id, "name": user.name} if user is not None else None),
+        "project": (
+            {"id": project.id, "name": project.name} if project is not None else None
+        ),
+        "issue": ({"id": issue.id} if issue is not None else None),
+        "activity": (
+            {"id": activity.id, "name": activity.name} if activity is not None else None
+        ),
+        "created_on": (
+            time_entry.created_on.isoformat()
+            if getattr(time_entry, "created_on", None) is not None
+            else None
+        ),
+        "updated_on": (
+            time_entry.updated_on.isoformat()
+            if getattr(time_entry, "updated_on", None) is not None
+            else None
+        ),
+    }
+
+
 def _wiki_page_to_dict(
     wiki_page: Any, include_attachments: bool = True
 ) -> Dict[str, Any]:
@@ -2729,6 +2827,274 @@ async def delete_redmine_wiki_page(
             e,
             f"deleting wiki page '{wiki_page_title}' in project {project_id}",
             {"resource_type": "wiki page", "resource_id": wiki_page_title},
+        )
+
+
+@mcp.tool()
+async def list_project_members(
+    project_id: Union[str, int],
+) -> List[Dict[str, Any]]:
+    """List members of a Redmine project.
+
+    Returns all users and groups that are members of the specified project,
+    along with their assigned roles.
+
+    Args:
+        project_id: Project identifier (ID number or string identifier)
+
+    Returns:
+        A list of membership dictionaries containing user/group info and roles.
+        On failure, a list containing a single dictionary with an "error" key.
+
+    Examples:
+        >>> await list_project_members("my-project")
+        [
+            {
+                "id": 1,
+                "user": {"id": 5, "name": "John Doe"},
+                "group": null,
+                "project": {"id": 1, "name": "My Project"},
+                "roles": [{"id": 3, "name": "Developer"}]
+            },
+            ...
+        ]
+    """
+    if not redmine:
+        return [{"error": "Redmine client not initialized."}]
+
+    await _ensure_cleanup_started()
+
+    try:
+        memberships = redmine.project_membership.filter(project_id=project_id)
+        return [_membership_to_dict(m) for m in memberships]
+    except Exception as e:
+        return [
+            _handle_redmine_error(
+                e,
+                f"listing members for project {project_id}",
+                {"resource_type": "project", "resource_id": project_id},
+            )
+        ]
+
+
+@mcp.tool()
+async def list_time_entries(
+    project_id: Optional[Union[str, int]] = None,
+    issue_id: Optional[int] = None,
+    user_id: Optional[Union[str, int]] = None,
+    from_date: Optional[str] = None,
+    to_date: Optional[str] = None,
+    limit: int = 25,
+    offset: int = 0,
+) -> Union[List[Dict[str, Any]], Dict[str, Any]]:
+    """List time entries from Redmine with filtering and pagination.
+
+    Retrieve time entries with optional filtering by project, issue, user,
+    and date range. Supports pagination for handling large result sets.
+
+    Args:
+        project_id: Filter by project (ID number or string identifier).
+        issue_id: Filter by issue ID.
+        user_id: Filter by user ID. Use "me" for current user.
+        from_date: Start date filter (YYYY-MM-DD format).
+        to_date: End date filter (YYYY-MM-DD format).
+        limit: Maximum number of entries to return (default: 25, max: 100).
+        offset: Number of entries to skip for pagination (default: 0).
+
+    Returns:
+        A list of time entry dictionaries. On failure, a list containing
+        a single dictionary with an "error" key.
+
+    Examples:
+        >>> await list_time_entries(project_id="my-project")
+        [{"id": 1, "hours": 2.5, "comments": "Bug fix", ...}, ...]
+
+        >>> await list_time_entries(issue_id=123, from_date="2024-01-01")
+        [{"id": 2, "hours": 1.0, "issue": {"id": 123}, ...}, ...]
+
+        >>> await list_time_entries(user_id="me", limit=10)
+        [{"id": 3, "hours": 4.0, "user": {"id": 5, "name": "Current User"}, ...}]
+    """
+    if not redmine:
+        return [{"error": "Redmine client not initialized."}]
+
+    await _ensure_cleanup_started()
+
+    try:
+        # Build filter parameters
+        filters: Dict[str, Any] = {
+            "limit": min(limit, 100),
+            "offset": offset,
+        }
+
+        if project_id is not None:
+            filters["project_id"] = project_id
+        if issue_id is not None:
+            filters["issue_id"] = issue_id
+        if user_id is not None:
+            filters["user_id"] = user_id
+        if from_date is not None:
+            filters["from_date"] = from_date
+        if to_date is not None:
+            filters["to_date"] = to_date
+
+        time_entries = redmine.time_entry.filter(**filters)
+        return [_time_entry_to_dict(te) for te in time_entries]
+
+    except Exception as e:
+        return [_handle_redmine_error(e, "listing time entries")]
+
+
+@mcp.tool()
+async def create_time_entry(
+    hours: float,
+    project_id: Optional[Union[str, int]] = None,
+    issue_id: Optional[int] = None,
+    activity_id: Optional[int] = None,
+    comments: str = "",
+    spent_on: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Create a new time entry in Redmine.
+
+    Log time against a project or issue. Either project_id or issue_id
+    must be provided. If issue_id is provided, the time entry will be
+    associated with that issue's project.
+
+    Args:
+        hours: Number of hours spent (required). Can be decimal (e.g., 1.5).
+        project_id: Project to log time against (ID or identifier).
+            Required if issue_id is not provided.
+        issue_id: Issue to log time against. If provided, project_id is optional.
+        activity_id: Time entry activity ID (e.g., Development, Design).
+            If not provided, Redmine uses the default activity.
+        comments: Description of work performed.
+        spent_on: Date when time was spent (YYYY-MM-DD). Defaults to today.
+
+    Returns:
+        Dictionary containing the created time entry, or error dict on failure.
+
+    Examples:
+        >>> await create_time_entry(hours=2.5, issue_id=123, comments="Bug fix")
+        {"id": 1, "hours": 2.5, "issue": {"id": 123}, ...}
+
+        >>> await create_time_entry(
+        ...     hours=1.0,
+        ...     project_id="my-project",
+        ...     activity_id=9,
+        ...     comments="Code review",
+        ...     spent_on="2024-03-15"
+        ... )
+        {"id": 2, "hours": 1.0, "project": {"id": 1, "name": "My Project"}, ...}
+    """
+    if not redmine:
+        return {"error": "Redmine client not initialized."}
+
+    if project_id is None and issue_id is None:
+        return {"error": "Either project_id or issue_id must be provided."}
+
+    if hours <= 0:
+        return {"error": "Hours must be a positive number."}
+
+    await _ensure_cleanup_started()
+
+    try:
+        # Build create parameters
+        params: Dict[str, Any] = {
+            "hours": hours,
+        }
+
+        if project_id is not None:
+            params["project_id"] = project_id
+        if issue_id is not None:
+            params["issue_id"] = issue_id
+        if activity_id is not None:
+            params["activity_id"] = activity_id
+        if comments:
+            params["comments"] = comments
+        if spent_on is not None:
+            params["spent_on"] = spent_on
+
+        time_entry = redmine.time_entry.create(**params)
+        return _time_entry_to_dict(time_entry)
+
+    except Exception as e:
+        context = {}
+        if issue_id:
+            context = {"resource_type": "issue", "resource_id": issue_id}
+        elif project_id:
+            context = {"resource_type": "project", "resource_id": project_id}
+        return _handle_redmine_error(e, "creating time entry", context)
+
+
+@mcp.tool()
+async def update_time_entry(
+    time_entry_id: int,
+    hours: Optional[float] = None,
+    activity_id: Optional[int] = None,
+    comments: Optional[str] = None,
+    spent_on: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Update an existing time entry in Redmine.
+
+    Modify hours, activity, comments, or date of an existing time entry.
+    Only provided fields will be updated.
+
+    Args:
+        time_entry_id: ID of the time entry to update (required).
+        hours: New hours value. Must be positive if provided.
+        activity_id: New activity ID.
+        comments: New comments/description.
+        spent_on: New date (YYYY-MM-DD format).
+
+    Returns:
+        Dictionary containing the updated time entry, or error dict on failure.
+
+    Examples:
+        >>> await update_time_entry(time_entry_id=1, hours=3.0)
+        {"id": 1, "hours": 3.0, ...}
+
+        >>> await update_time_entry(
+        ...     time_entry_id=1,
+        ...     comments="Updated description",
+        ...     spent_on="2024-03-16"
+        ... )
+        {"id": 1, "comments": "Updated description", ...}
+    """
+    if not redmine:
+        return {"error": "Redmine client not initialized."}
+
+    if hours is not None and hours <= 0:
+        return {"error": "Hours must be a positive number."}
+
+    await _ensure_cleanup_started()
+
+    try:
+        # Build update parameters
+        params: Dict[str, Any] = {}
+
+        if hours is not None:
+            params["hours"] = hours
+        if activity_id is not None:
+            params["activity_id"] = activity_id
+        if comments is not None:
+            params["comments"] = comments
+        if spent_on is not None:
+            params["spent_on"] = spent_on
+
+        if not params:
+            return {"error": "No fields provided for update."}
+
+        redmine.time_entry.update(time_entry_id, **params)
+
+        # Fetch and return updated entry
+        updated_entry = redmine.time_entry.get(time_entry_id)
+        return _time_entry_to_dict(updated_entry)
+
+    except Exception as e:
+        return _handle_redmine_error(
+            e,
+            f"updating time entry {time_entry_id}",
+            {"resource_type": "time entry", "resource_id": time_entry_id},
         )
 
 

--- a/tests/test_project_members.py
+++ b/tests/test_project_members.py
@@ -1,0 +1,278 @@
+"""
+Test cases for list_project_members tool.
+
+Tests for listing project memberships including users, groups, and roles.
+"""
+
+import pytest
+from unittest.mock import Mock, patch
+import os
+import sys
+
+# Add the src directory to the path
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from redmine_mcp_server.redmine_handler import (  # noqa: E402
+    list_project_members,
+    _membership_to_dict,
+)
+
+
+def make_mock_with_name(id_val, name_val):
+    """Helper to create a Mock with a name attribute (not Mock's internal name)."""
+    m = Mock()
+    m.id = id_val
+    m.name = name_val
+    return m
+
+
+class TestMembershipToDict:
+    """Test cases for _membership_to_dict helper function."""
+
+    def test_user_membership(self):
+        """Test converting a user membership to dict."""
+        mock_membership = Mock()
+        mock_membership.id = 1
+        mock_membership.user = make_mock_with_name(5, "John Doe")
+        mock_membership.group = None
+        mock_membership.project = make_mock_with_name(10, "Test Project")
+        mock_membership.roles = [make_mock_with_name(3, "Developer")]
+
+        result = _membership_to_dict(mock_membership)
+
+        assert result["id"] == 1
+        assert result["user"] == {"id": 5, "name": "John Doe"}
+        assert result["group"] is None
+        assert result["project"] == {"id": 10, "name": "Test Project"}
+        assert len(result["roles"]) == 1
+        assert result["roles"][0] == {"id": 3, "name": "Developer"}
+
+    def test_group_membership(self):
+        """Test converting a group membership to dict."""
+        mock_membership = Mock()
+        mock_membership.id = 2
+        mock_membership.user = None
+        mock_membership.group = make_mock_with_name(15, "Dev Team")
+        mock_membership.project = make_mock_with_name(10, "Test Project")
+        mock_membership.roles = [make_mock_with_name(4, "Manager")]
+
+        result = _membership_to_dict(mock_membership)
+
+        assert result["id"] == 2
+        assert result["user"] is None
+        assert result["group"] == {"id": 15, "name": "Dev Team"}
+        assert result["project"] == {"id": 10, "name": "Test Project"}
+        assert len(result["roles"]) == 1
+        assert result["roles"][0] == {"id": 4, "name": "Manager"}
+
+    def test_multiple_roles(self):
+        """Test membership with multiple roles."""
+        mock_membership = Mock()
+        mock_membership.id = 3
+        mock_membership.user = make_mock_with_name(5, "John Doe")
+        mock_membership.group = None
+        mock_membership.project = make_mock_with_name(10, "Test Project")
+        mock_membership.roles = [
+            make_mock_with_name(3, "Developer"),
+            make_mock_with_name(4, "Reporter"),
+        ]
+
+        result = _membership_to_dict(mock_membership)
+
+        assert len(result["roles"]) == 2
+        assert result["roles"][0] == {"id": 3, "name": "Developer"}
+        assert result["roles"][1] == {"id": 4, "name": "Reporter"}
+
+    def test_no_roles(self):
+        """Test membership with no roles."""
+        mock_membership = Mock()
+        mock_membership.id = 4
+        mock_membership.user = make_mock_with_name(5, "John Doe")
+        mock_membership.group = None
+        mock_membership.project = make_mock_with_name(10, "Test Project")
+        mock_membership.roles = []
+
+        result = _membership_to_dict(mock_membership)
+
+        assert result["roles"] == []
+
+    def test_dict_format_roles(self):
+        """Test roles in dict format (some Redmine versions)."""
+        mock_membership = Mock()
+        mock_membership.id = 5
+        mock_membership.user = make_mock_with_name(5, "John Doe")
+        mock_membership.group = None
+        mock_membership.project = make_mock_with_name(10, "Test Project")
+        mock_membership.roles = [{"id": 3, "name": "Developer"}]
+
+        result = _membership_to_dict(mock_membership)
+
+        assert len(result["roles"]) == 1
+        assert result["roles"][0] == {"id": 3, "name": "Developer"}
+
+    def test_missing_attributes(self):
+        """Test handling of missing attributes."""
+        mock_membership = Mock(spec=[])  # Empty spec, no attributes
+        mock_membership.id = None
+        mock_membership.user = None
+        mock_membership.group = None
+        mock_membership.project = None
+        mock_membership.roles = None
+
+        result = _membership_to_dict(mock_membership)
+
+        assert result["id"] is None
+        assert result["user"] is None
+        assert result["group"] is None
+        assert result["project"] is None
+        assert result["roles"] == []
+
+
+class TestListProjectMembers:
+    """Test cases for list_project_members tool."""
+
+    @pytest.fixture
+    def mock_redmine(self):
+        """Create a mock Redmine client."""
+        with patch("redmine_mcp_server.redmine_handler.redmine") as mock:
+            yield mock
+
+    def create_mock_membership(
+        self, membership_id=1, user_id=5, user_name="John Doe", is_group=False
+    ):
+        """Create a single mock membership."""
+        mock_membership = Mock()
+        mock_membership.id = membership_id
+
+        if is_group:
+            mock_membership.user = None
+            mock_membership.group = make_mock_with_name(user_id, user_name)
+        else:
+            mock_membership.user = make_mock_with_name(user_id, user_name)
+            mock_membership.group = None
+
+        mock_membership.project = make_mock_with_name(10, "Test Project")
+        mock_membership.roles = [make_mock_with_name(3, "Developer")]
+
+        return mock_membership
+
+    @pytest.mark.asyncio
+    async def test_list_members_by_project_id(self, mock_redmine):
+        """Test listing project members by numeric project ID."""
+        mock_memberships = [
+            self.create_mock_membership(1, 5, "John Doe"),
+            self.create_mock_membership(2, 6, "Jane Smith"),
+        ]
+        mock_redmine.project_membership.filter.return_value = mock_memberships
+
+        result = await list_project_members(project_id=10)
+
+        assert isinstance(result, list)
+        assert len(result) == 2
+        assert result[0]["user"]["name"] == "John Doe"
+        assert result[1]["user"]["name"] == "Jane Smith"
+        mock_redmine.project_membership.filter.assert_called_once_with(project_id=10)
+
+    @pytest.mark.asyncio
+    async def test_list_members_by_project_identifier(self, mock_redmine):
+        """Test listing project members by string project identifier."""
+        mock_memberships = [self.create_mock_membership(1, 5, "John Doe")]
+        mock_redmine.project_membership.filter.return_value = mock_memberships
+
+        result = await list_project_members(project_id="my-project")
+
+        assert isinstance(result, list)
+        assert len(result) == 1
+        mock_redmine.project_membership.filter.assert_called_once_with(
+            project_id="my-project"
+        )
+
+    @pytest.mark.asyncio
+    async def test_list_members_includes_groups(self, mock_redmine):
+        """Test that group memberships are included."""
+        mock_memberships = [
+            self.create_mock_membership(1, 5, "John Doe", is_group=False),
+            self.create_mock_membership(2, 15, "Dev Team", is_group=True),
+        ]
+        mock_redmine.project_membership.filter.return_value = mock_memberships
+
+        result = await list_project_members(project_id=10)
+
+        assert len(result) == 2
+        # First is a user
+        assert result[0]["user"] is not None
+        assert result[0]["group"] is None
+        # Second is a group
+        assert result[1]["user"] is None
+        assert result[1]["group"] is not None
+        assert result[1]["group"]["name"] == "Dev Team"
+
+    @pytest.mark.asyncio
+    async def test_list_members_empty_project(self, mock_redmine):
+        """Test listing members of a project with no members."""
+        mock_redmine.project_membership.filter.return_value = []
+
+        result = await list_project_members(project_id=10)
+
+        assert isinstance(result, list)
+        assert len(result) == 0
+
+    @pytest.mark.asyncio
+    async def test_list_members_redmine_not_initialized(self, mock_redmine):
+        """Test error when Redmine client is not initialized."""
+        with patch("redmine_mcp_server.redmine_handler.redmine", None):
+            result = await list_project_members(project_id=10)
+
+        assert isinstance(result, list)
+        assert len(result) == 1
+        assert "error" in result[0]
+        assert "not initialized" in result[0]["error"]
+
+    @pytest.mark.asyncio
+    async def test_list_members_project_not_found(self, mock_redmine):
+        """Test error when project is not found."""
+        from redminelib.exceptions import ResourceNotFoundError
+
+        mock_redmine.project_membership.filter.side_effect = ResourceNotFoundError()
+
+        result = await list_project_members(project_id=999)
+
+        assert isinstance(result, list)
+        assert len(result) == 1
+        assert "error" in result[0]
+
+    @pytest.mark.asyncio
+    async def test_list_members_forbidden(self, mock_redmine):
+        """Test error when user lacks permission."""
+        from redminelib.exceptions import ForbiddenError
+
+        mock_redmine.project_membership.filter.side_effect = ForbiddenError()
+
+        result = await list_project_members(project_id=10)
+
+        assert isinstance(result, list)
+        assert len(result) == 1
+        assert "error" in result[0]
+        assert "Access denied" in result[0]["error"]
+
+    @pytest.mark.asyncio
+    async def test_list_members_includes_roles(self, mock_redmine):
+        """Test that roles are included in membership data."""
+        mock_membership = Mock()
+        mock_membership.id = 1
+        mock_membership.user = make_mock_with_name(5, "John Doe")
+        mock_membership.group = None
+        mock_membership.project = make_mock_with_name(10, "Test Project")
+        mock_membership.roles = [
+            make_mock_with_name(3, "Developer"),
+            make_mock_with_name(4, "Reporter"),
+        ]
+        mock_redmine.project_membership.filter.return_value = [mock_membership]
+
+        result = await list_project_members(project_id=10)
+
+        assert len(result) == 1
+        assert len(result[0]["roles"]) == 2
+        role_names = [r["name"] for r in result[0]["roles"]]
+        assert "Developer" in role_names
+        assert "Reporter" in role_names

--- a/tests/test_time_entries.py
+++ b/tests/test_time_entries.py
@@ -1,0 +1,550 @@
+"""
+Test cases for time entry tools.
+
+Tests for list_time_entries, create_time_entry, and update_time_entry tools.
+"""
+
+import pytest
+from unittest.mock import Mock, patch
+from datetime import datetime
+import os
+import sys
+
+# Add the src directory to the path
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from redmine_mcp_server.redmine_handler import (  # noqa: E402
+    list_time_entries,
+    create_time_entry,
+    update_time_entry,
+    _time_entry_to_dict,
+)
+
+
+def make_mock_with_name(id_val, name_val):
+    """Helper to create a Mock with a name attribute (not Mock's internal name)."""
+    m = Mock()
+    m.id = id_val
+    m.name = name_val
+    return m
+
+
+class TestTimeEntryToDict:
+    """Test cases for _time_entry_to_dict helper function."""
+
+    def test_complete_time_entry(self):
+        """Test converting a complete time entry to dict."""
+        mock_entry = Mock()
+        mock_entry.id = 1
+        mock_entry.hours = 2.5
+        mock_entry.comments = "Bug fix work"
+        mock_entry.spent_on = "2024-03-15"
+        mock_entry.user = make_mock_with_name(5, "John Doe")
+        mock_entry.project = make_mock_with_name(10, "Test Project")
+        mock_entry.issue = Mock(id=123)
+        mock_entry.activity = make_mock_with_name(9, "Development")
+        mock_entry.created_on = datetime(2024, 3, 15, 10, 30, 0)
+        mock_entry.updated_on = datetime(2024, 3, 15, 14, 0, 0)
+
+        result = _time_entry_to_dict(mock_entry)
+
+        assert result["id"] == 1
+        assert result["hours"] == 2.5
+        assert result["comments"] == "Bug fix work"
+        assert result["spent_on"] == "2024-03-15"
+        assert result["user"] == {"id": 5, "name": "John Doe"}
+        assert result["project"] == {"id": 10, "name": "Test Project"}
+        assert result["issue"] == {"id": 123}
+        assert result["activity"] == {"id": 9, "name": "Development"}
+        assert result["created_on"] is not None
+        assert result["updated_on"] is not None
+
+    def test_time_entry_without_issue(self):
+        """Test time entry logged against project without issue."""
+        mock_entry = Mock()
+        mock_entry.id = 2
+        mock_entry.hours = 1.0
+        mock_entry.comments = "Project meeting"
+        mock_entry.spent_on = "2024-03-15"
+        mock_entry.user = make_mock_with_name(5, "John Doe")
+        mock_entry.project = make_mock_with_name(10, "Test Project")
+        mock_entry.issue = None
+        mock_entry.activity = make_mock_with_name(10, "Meeting")
+        mock_entry.created_on = None
+        mock_entry.updated_on = None
+
+        result = _time_entry_to_dict(mock_entry)
+
+        assert result["id"] == 2
+        assert result["issue"] is None
+        assert result["project"] == {"id": 10, "name": "Test Project"}
+
+    def test_time_entry_minimal(self):
+        """Test time entry with minimal data."""
+        mock_entry = Mock()
+        mock_entry.id = 3
+        mock_entry.hours = 0.5
+        mock_entry.comments = ""
+        mock_entry.spent_on = None
+        mock_entry.user = None
+        mock_entry.project = None
+        mock_entry.issue = None
+        mock_entry.activity = None
+        mock_entry.created_on = None
+        mock_entry.updated_on = None
+
+        result = _time_entry_to_dict(mock_entry)
+
+        assert result["id"] == 3
+        assert result["hours"] == 0.5
+        assert result["comments"] == ""
+        assert result["spent_on"] is None
+        assert result["user"] is None
+        assert result["project"] is None
+        assert result["issue"] is None
+        assert result["activity"] is None
+
+
+class TestListTimeEntries:
+    """Test cases for list_time_entries tool."""
+
+    @pytest.fixture
+    def mock_redmine(self):
+        """Create a mock Redmine client."""
+        with patch("redmine_mcp_server.redmine_handler.redmine") as mock:
+            yield mock
+
+    def create_mock_time_entry(
+        self, entry_id=1, hours=2.0, project_id=10, issue_id=None
+    ):
+        """Create a single mock time entry."""
+        mock_entry = Mock()
+        mock_entry.id = entry_id
+        mock_entry.hours = hours
+        mock_entry.comments = f"Work on entry {entry_id}"
+        mock_entry.spent_on = "2024-03-15"
+        mock_entry.user = make_mock_with_name(5, "John Doe")
+        mock_entry.project = make_mock_with_name(project_id, "Test Project")
+        mock_entry.issue = Mock(id=issue_id) if issue_id else None
+        mock_entry.activity = make_mock_with_name(9, "Development")
+        mock_entry.created_on = datetime(2024, 3, 15, 10, 0, 0)
+        mock_entry.updated_on = datetime(2024, 3, 15, 10, 0, 0)
+        return mock_entry
+
+    @pytest.mark.asyncio
+    async def test_list_all_time_entries(self, mock_redmine):
+        """Test listing time entries without filters."""
+        mock_entries = [
+            self.create_mock_time_entry(1, 2.0),
+            self.create_mock_time_entry(2, 1.5),
+        ]
+        mock_redmine.time_entry.filter.return_value = mock_entries
+
+        result = await list_time_entries()
+
+        assert isinstance(result, list)
+        assert len(result) == 2
+        assert result[0]["hours"] == 2.0
+        assert result[1]["hours"] == 1.5
+
+    @pytest.mark.asyncio
+    async def test_list_time_entries_by_project(self, mock_redmine):
+        """Test filtering time entries by project."""
+        mock_entries = [self.create_mock_time_entry(1, 2.0, project_id=10)]
+        mock_redmine.time_entry.filter.return_value = mock_entries
+
+        result = await list_time_entries(project_id=10)
+
+        assert len(result) == 1
+        call_kwargs = mock_redmine.time_entry.filter.call_args[1]
+        assert call_kwargs["project_id"] == 10
+
+    @pytest.mark.asyncio
+    async def test_list_time_entries_by_project_identifier(self, mock_redmine):
+        """Test filtering by string project identifier."""
+        mock_entries = [self.create_mock_time_entry(1, 2.0)]
+        mock_redmine.time_entry.filter.return_value = mock_entries
+
+        await list_time_entries(project_id="my-project")
+
+        call_kwargs = mock_redmine.time_entry.filter.call_args[1]
+        assert call_kwargs["project_id"] == "my-project"
+
+    @pytest.mark.asyncio
+    async def test_list_time_entries_by_issue(self, mock_redmine):
+        """Test filtering time entries by issue."""
+        mock_entries = [self.create_mock_time_entry(1, 2.0, issue_id=123)]
+        mock_redmine.time_entry.filter.return_value = mock_entries
+
+        result = await list_time_entries(issue_id=123)
+
+        assert len(result) == 1
+        call_kwargs = mock_redmine.time_entry.filter.call_args[1]
+        assert call_kwargs["issue_id"] == 123
+
+    @pytest.mark.asyncio
+    async def test_list_time_entries_by_user(self, mock_redmine):
+        """Test filtering time entries by user."""
+        mock_entries = [self.create_mock_time_entry(1, 2.0)]
+        mock_redmine.time_entry.filter.return_value = mock_entries
+
+        await list_time_entries(user_id=5)
+
+        call_kwargs = mock_redmine.time_entry.filter.call_args[1]
+        assert call_kwargs["user_id"] == 5
+
+    @pytest.mark.asyncio
+    async def test_list_time_entries_by_current_user(self, mock_redmine):
+        """Test filtering time entries by 'me' for current user."""
+        mock_entries = [self.create_mock_time_entry(1, 2.0)]
+        mock_redmine.time_entry.filter.return_value = mock_entries
+
+        await list_time_entries(user_id="me")
+
+        call_kwargs = mock_redmine.time_entry.filter.call_args[1]
+        assert call_kwargs["user_id"] == "me"
+
+    @pytest.mark.asyncio
+    async def test_list_time_entries_date_range(self, mock_redmine):
+        """Test filtering time entries by date range."""
+        mock_entries = [self.create_mock_time_entry(1, 2.0)]
+        mock_redmine.time_entry.filter.return_value = mock_entries
+
+        await list_time_entries(from_date="2024-01-01", to_date="2024-03-31")
+
+        call_kwargs = mock_redmine.time_entry.filter.call_args[1]
+        assert call_kwargs["from_date"] == "2024-01-01"
+        assert call_kwargs["to_date"] == "2024-03-31"
+
+    @pytest.mark.asyncio
+    async def test_list_time_entries_pagination(self, mock_redmine):
+        """Test pagination with limit and offset."""
+        mock_entries = [self.create_mock_time_entry(1, 2.0)]
+        mock_redmine.time_entry.filter.return_value = mock_entries
+
+        await list_time_entries(limit=10, offset=20)
+
+        call_kwargs = mock_redmine.time_entry.filter.call_args[1]
+        assert call_kwargs["limit"] == 10
+        assert call_kwargs["offset"] == 20
+
+    @pytest.mark.asyncio
+    async def test_list_time_entries_limit_cap(self, mock_redmine):
+        """Test that limit is capped at 100."""
+        mock_entries = []
+        mock_redmine.time_entry.filter.return_value = mock_entries
+
+        await list_time_entries(limit=500)
+
+        call_kwargs = mock_redmine.time_entry.filter.call_args[1]
+        assert call_kwargs["limit"] == 100
+
+    @pytest.mark.asyncio
+    async def test_list_time_entries_redmine_not_initialized(self, mock_redmine):
+        """Test error when Redmine client is not initialized."""
+        with patch("redmine_mcp_server.redmine_handler.redmine", None):
+            result = await list_time_entries()
+
+        assert isinstance(result, list)
+        assert len(result) == 1
+        assert "error" in result[0]
+        assert "not initialized" in result[0]["error"]
+
+    @pytest.mark.asyncio
+    async def test_list_time_entries_empty_result(self, mock_redmine):
+        """Test listing when no time entries exist."""
+        mock_redmine.time_entry.filter.return_value = []
+
+        result = await list_time_entries(project_id=10)
+
+        assert isinstance(result, list)
+        assert len(result) == 0
+
+
+class TestCreateTimeEntry:
+    """Test cases for create_time_entry tool."""
+
+    @pytest.fixture
+    def mock_redmine(self):
+        """Create a mock Redmine client."""
+        with patch("redmine_mcp_server.redmine_handler.redmine") as mock:
+            yield mock
+
+    def create_mock_time_entry(self, entry_id=1, hours=2.0, issue_id=None):
+        """Create a mock time entry for create response."""
+        mock_entry = Mock()
+        mock_entry.id = entry_id
+        mock_entry.hours = hours
+        mock_entry.comments = "Test work"
+        mock_entry.spent_on = "2024-03-15"
+        mock_entry.user = make_mock_with_name(5, "John Doe")
+        mock_entry.project = make_mock_with_name(10, "Test Project")
+        mock_entry.issue = Mock(id=issue_id) if issue_id else None
+        mock_entry.activity = make_mock_with_name(9, "Development")
+        mock_entry.created_on = datetime(2024, 3, 15, 10, 0, 0)
+        mock_entry.updated_on = datetime(2024, 3, 15, 10, 0, 0)
+        return mock_entry
+
+    @pytest.mark.asyncio
+    async def test_create_time_entry_with_issue(self, mock_redmine):
+        """Test creating a time entry against an issue."""
+        mock_entry = self.create_mock_time_entry(1, 2.5, issue_id=123)
+        mock_redmine.time_entry.create.return_value = mock_entry
+
+        result = await create_time_entry(hours=2.5, issue_id=123, comments="Bug fix")
+
+        assert result["id"] == 1
+        assert result["hours"] == 2.5
+        call_kwargs = mock_redmine.time_entry.create.call_args[1]
+        assert call_kwargs["hours"] == 2.5
+        assert call_kwargs["issue_id"] == 123
+        assert call_kwargs["comments"] == "Bug fix"
+
+    @pytest.mark.asyncio
+    async def test_create_time_entry_with_project(self, mock_redmine):
+        """Test creating a time entry against a project."""
+        mock_entry = self.create_mock_time_entry(1, 1.0)
+        mock_redmine.time_entry.create.return_value = mock_entry
+
+        result = await create_time_entry(
+            hours=1.0, project_id=10, comments="Project meeting"
+        )
+
+        assert result["id"] == 1
+        call_kwargs = mock_redmine.time_entry.create.call_args[1]
+        assert call_kwargs["project_id"] == 10
+
+    @pytest.mark.asyncio
+    async def test_create_time_entry_with_project_identifier(self, mock_redmine):
+        """Test creating time entry using string project identifier."""
+        mock_entry = self.create_mock_time_entry(1, 1.0)
+        mock_redmine.time_entry.create.return_value = mock_entry
+
+        await create_time_entry(hours=1.0, project_id="my-project", comments="Work")
+
+        call_kwargs = mock_redmine.time_entry.create.call_args[1]
+        assert call_kwargs["project_id"] == "my-project"
+
+    @pytest.mark.asyncio
+    async def test_create_time_entry_with_activity(self, mock_redmine):
+        """Test creating time entry with specific activity."""
+        mock_entry = self.create_mock_time_entry(1, 2.0)
+        mock_redmine.time_entry.create.return_value = mock_entry
+
+        await create_time_entry(hours=2.0, issue_id=123, activity_id=9)
+
+        call_kwargs = mock_redmine.time_entry.create.call_args[1]
+        assert call_kwargs["activity_id"] == 9
+
+    @pytest.mark.asyncio
+    async def test_create_time_entry_with_spent_on(self, mock_redmine):
+        """Test creating time entry with specific date."""
+        mock_entry = self.create_mock_time_entry(1, 2.0)
+        mock_redmine.time_entry.create.return_value = mock_entry
+
+        await create_time_entry(hours=2.0, issue_id=123, spent_on="2024-03-15")
+
+        call_kwargs = mock_redmine.time_entry.create.call_args[1]
+        assert call_kwargs["spent_on"] == "2024-03-15"
+
+    @pytest.mark.asyncio
+    async def test_create_time_entry_missing_project_and_issue(self, mock_redmine):
+        """Test error when neither project_id nor issue_id provided."""
+        result = await create_time_entry(hours=2.0)
+
+        assert "error" in result
+        assert "project_id or issue_id" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_create_time_entry_zero_hours(self, mock_redmine):
+        """Test error when hours is zero."""
+        result = await create_time_entry(hours=0, issue_id=123)
+
+        assert "error" in result
+        assert "positive" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_create_time_entry_negative_hours(self, mock_redmine):
+        """Test error when hours is negative."""
+        result = await create_time_entry(hours=-1.0, issue_id=123)
+
+        assert "error" in result
+        assert "positive" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_create_time_entry_redmine_not_initialized(self, mock_redmine):
+        """Test error when Redmine client is not initialized."""
+        with patch("redmine_mcp_server.redmine_handler.redmine", None):
+            result = await create_time_entry(hours=2.0, issue_id=123)
+
+        assert "error" in result
+        assert "not initialized" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_create_time_entry_issue_not_found(self, mock_redmine):
+        """Test error when issue is not found."""
+        from redminelib.exceptions import ResourceNotFoundError
+
+        mock_redmine.time_entry.create.side_effect = ResourceNotFoundError()
+
+        result = await create_time_entry(hours=2.0, issue_id=9999)
+
+        assert "error" in result
+
+    @pytest.mark.asyncio
+    async def test_create_time_entry_decimal_hours(self, mock_redmine):
+        """Test creating time entry with decimal hours."""
+        mock_entry = self.create_mock_time_entry(1, 0.25)
+        mock_redmine.time_entry.create.return_value = mock_entry
+
+        result = await create_time_entry(hours=0.25, issue_id=123)
+
+        assert result["id"] == 1
+        call_kwargs = mock_redmine.time_entry.create.call_args[1]
+        assert call_kwargs["hours"] == 0.25
+
+
+class TestUpdateTimeEntry:
+    """Test cases for update_time_entry tool."""
+
+    @pytest.fixture
+    def mock_redmine(self):
+        """Create a mock Redmine client."""
+        with patch("redmine_mcp_server.redmine_handler.redmine") as mock:
+            yield mock
+
+    def create_mock_time_entry(self, entry_id=1, hours=2.0):
+        """Create a mock time entry for update response."""
+        mock_entry = Mock()
+        mock_entry.id = entry_id
+        mock_entry.hours = hours
+        mock_entry.comments = "Updated work"
+        mock_entry.spent_on = "2024-03-15"
+        mock_entry.user = make_mock_with_name(5, "John Doe")
+        mock_entry.project = make_mock_with_name(10, "Test Project")
+        mock_entry.issue = Mock(id=123)
+        mock_entry.activity = make_mock_with_name(9, "Development")
+        mock_entry.created_on = datetime(2024, 3, 15, 10, 0, 0)
+        mock_entry.updated_on = datetime(2024, 3, 15, 14, 0, 0)
+        return mock_entry
+
+    @pytest.mark.asyncio
+    async def test_update_time_entry_hours(self, mock_redmine):
+        """Test updating time entry hours."""
+        mock_entry = self.create_mock_time_entry(1, 3.0)
+        mock_redmine.time_entry.get.return_value = mock_entry
+
+        result = await update_time_entry(time_entry_id=1, hours=3.0)
+
+        assert result["id"] == 1
+        assert result["hours"] == 3.0
+        mock_redmine.time_entry.update.assert_called_once()
+        call_kwargs = mock_redmine.time_entry.update.call_args[1]
+        assert call_kwargs["hours"] == 3.0
+
+    @pytest.mark.asyncio
+    async def test_update_time_entry_comments(self, mock_redmine):
+        """Test updating time entry comments."""
+        mock_entry = self.create_mock_time_entry(1, 2.0)
+        mock_redmine.time_entry.get.return_value = mock_entry
+
+        await update_time_entry(time_entry_id=1, comments="New description")
+
+        call_kwargs = mock_redmine.time_entry.update.call_args[1]
+        assert call_kwargs["comments"] == "New description"
+
+    @pytest.mark.asyncio
+    async def test_update_time_entry_activity(self, mock_redmine):
+        """Test updating time entry activity."""
+        mock_entry = self.create_mock_time_entry(1, 2.0)
+        mock_redmine.time_entry.get.return_value = mock_entry
+
+        await update_time_entry(time_entry_id=1, activity_id=10)
+
+        call_kwargs = mock_redmine.time_entry.update.call_args[1]
+        assert call_kwargs["activity_id"] == 10
+
+    @pytest.mark.asyncio
+    async def test_update_time_entry_spent_on(self, mock_redmine):
+        """Test updating time entry date."""
+        mock_entry = self.create_mock_time_entry(1, 2.0)
+        mock_redmine.time_entry.get.return_value = mock_entry
+
+        await update_time_entry(time_entry_id=1, spent_on="2024-03-20")
+
+        call_kwargs = mock_redmine.time_entry.update.call_args[1]
+        assert call_kwargs["spent_on"] == "2024-03-20"
+
+    @pytest.mark.asyncio
+    async def test_update_time_entry_multiple_fields(self, mock_redmine):
+        """Test updating multiple fields at once."""
+        mock_entry = self.create_mock_time_entry(1, 4.0)
+        mock_redmine.time_entry.get.return_value = mock_entry
+
+        await update_time_entry(
+            time_entry_id=1,
+            hours=4.0,
+            comments="Extended work",
+            spent_on="2024-03-20",
+        )
+
+        call_kwargs = mock_redmine.time_entry.update.call_args[1]
+        assert call_kwargs["hours"] == 4.0
+        assert call_kwargs["comments"] == "Extended work"
+        assert call_kwargs["spent_on"] == "2024-03-20"
+
+    @pytest.mark.asyncio
+    async def test_update_time_entry_no_fields(self, mock_redmine):
+        """Test error when no fields provided for update."""
+        result = await update_time_entry(time_entry_id=1)
+
+        assert "error" in result
+        assert "No fields" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_update_time_entry_zero_hours(self, mock_redmine):
+        """Test error when hours set to zero."""
+        result = await update_time_entry(time_entry_id=1, hours=0)
+
+        assert "error" in result
+        assert "positive" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_update_time_entry_negative_hours(self, mock_redmine):
+        """Test error when hours set to negative."""
+        result = await update_time_entry(time_entry_id=1, hours=-1.0)
+
+        assert "error" in result
+        assert "positive" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_update_time_entry_not_found(self, mock_redmine):
+        """Test error when time entry not found."""
+        from redminelib.exceptions import ResourceNotFoundError
+
+        mock_redmine.time_entry.update.side_effect = ResourceNotFoundError()
+
+        result = await update_time_entry(time_entry_id=9999, hours=2.0)
+
+        assert "error" in result
+
+    @pytest.mark.asyncio
+    async def test_update_time_entry_redmine_not_initialized(self, mock_redmine):
+        """Test error when Redmine client is not initialized."""
+        with patch("redmine_mcp_server.redmine_handler.redmine", None):
+            result = await update_time_entry(time_entry_id=1, hours=2.0)
+
+        assert "error" in result
+        assert "not initialized" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_update_time_entry_forbidden(self, mock_redmine):
+        """Test error when user lacks permission to update."""
+        from redminelib.exceptions import ForbiddenError
+
+        mock_redmine.time_entry.update.side_effect = ForbiddenError()
+
+        result = await update_time_entry(time_entry_id=1, hours=2.0)
+
+        assert "error" in result
+        assert "Access denied" in result["error"]


### PR DESCRIPTION
## Description
Add support for project members and time tracking functionality to the Redmine MCP Server, implementing 4 new MCP tools to expand API coverage.

## Related Issue
Implements missing endpoints from requirements: Project Members and Time Tracking

## Changes Made
- Added `list_project_members` tool to retrieve project membership information including user details and roles
- Added `list_time_entries` tool with filtering by project, issue, user, and date range
- Added `create_time_entry` tool to log time against issues or projects
- Added `update_time_entry` tool to modify existing time entries
- Implemented helper functions `_membership_to_dict()` and `_time_entry_to_dict()` for consistent response formatting
- Updated tool-reference.md with comprehensive documentation for all new tools
- Updated CHANGELOG.md with new feature descriptions

## Testing
- [x] Unit tests added/updated (50 new tests across 2 test files)
- [x] Integration tests pass (552 tests passed)
- [x] Manual testing completed

## Checklist
- [x] Code follows style guidelines (Black formatted, Flake8 passed)
- [x] Documentation updated (tool-reference.md)
- [x] Tests added/updated (test_project_members.py, test_time_entries.py)
- [x] CHANGELOG updated