### PR TITLE
feat: add project members, time tracking, and enumeration tools

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -8,9 +8,6 @@ on:
   push:
     branches:
       - develop
-      - feature/*
-      - release/*
-      - hotfix/*
 
   workflow_dispatch:  # 👈 allows manual run from GitHub UI
 

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ plans
 .mcpregistry_github_token
 .mcpregistry_registry_token
 coverage.xml
+docs_internal/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,13 +12,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **New MCP Tool: `list_project_members`** - List members and groups of a Redmine project
   - Returns user/group info along with assigned roles
   - Supports both numeric project IDs and string identifiers
-  - Includes comprehensive unit tests
 - **New MCP Tools: Time Tracking** - Full time entry management
   - `list_time_entries` - List time entries with filtering by project, issue, user, and date range
   - `create_time_entry` - Log time against projects or issues with activity and date support
   - `update_time_entry` - Modify existing time entries (hours, comments, activity, date)
-  - All tools include pagination support and comprehensive unit tests
-- **Documentation** - Updated tool-reference.md with new tools and Time Tracking section
+  - All tools support pagination and use `_get_redmine_client()` for OAuth compatibility
+- **50 new unit tests** for project members and time tracking tools (`test_project_members.py`, `test_time_entries.py`)
 - **OAuth2 per-user authentication mode** (`REDMINE_AUTH_MODE=oauth`)
   - New `oauth_middleware.py`: Starlette middleware that validates `Authorization: Bearer <token>` headers against Redmine's `/users/current.json` before forwarding MCP requests
   - Per-request token isolation via `contextvars.ContextVar` — safe under async concurrent load
@@ -43,6 +42,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Contributors
 - @mihajlovicjj — OAuth2 per-user authentication, `/revoke` endpoint, discovery endpoints, and 33 new tests ([#71](https://github.com/jztan/redmine-mcp-server/pull/71))
+- @mihajlovicjj — Project members and time tracking tools with 50 new tests ([#72](https://github.com/jztan/redmine-mcp-server/pull/72))
 
 ## [0.12.1] - 2026-03-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `update_time_entry` - Modify existing time entries (hours, comments, activity, date)
   - All tools support pagination and use `_get_redmine_client()` for OAuth compatibility
 - **50 new unit tests** for project members and time tracking tools (`test_project_members.py`, `test_time_entries.py`)
+- **26 new integration tests** covering all 21 MCP tools with zero skips — includes project members (4), time entries (7), custom fields (3), search issues (3), summarize project (3), global search (4), and cleanup (2)
 - **OAuth2 per-user authentication mode** (`REDMINE_AUTH_MODE=oauth`)
   - New `oauth_middleware.py`: Starlette middleware that validates `Authorization: Bearer <token>` headers against Redmine's `/users/current.json` before forwarding MCP requests
   - Per-request token isolation via `contextvars.ContextVar` — safe under async concurrent load

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **New MCP Tool: `list_project_members`** - List members and groups of a Redmine project
+  - Returns user/group info along with assigned roles
+  - Supports both numeric project IDs and string identifiers
+  - Includes comprehensive unit tests
+- **New MCP Tools: Time Tracking** - Full time entry management
+  - `list_time_entries` - List time entries with filtering by project, issue, user, and date range
+  - `create_time_entry` - Log time against projects or issues with activity and date support
+  - `update_time_entry` - Modify existing time entries (hours, comments, activity, date)
+  - All tools include pagination support and comprehensive unit tests
+- **Documentation** - Updated tool-reference.md with new tools and Time Tracking section
 - **OAuth2 per-user authentication mode** (`REDMINE_AUTH_MODE=oauth`)
   - New `oauth_middleware.py`: Starlette middleware that validates `Authorization: Bearer <token>` headers against Redmine's `/users/current.json` before forwarding MCP requests
   - Per-request token isolation via `contextvars.ContextVar` — safe under async concurrent load

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `list_time_entries` - List time entries with filtering by project, issue, user, and date range
   - `create_time_entry` - Log time against projects or issues with activity and date support
   - `update_time_entry` - Modify existing time entries (hours, comments, activity, date)
+  - `list_time_entry_activities` - Discover available activity types (Development, Design, etc.) for time entry creation
   - All tools support pagination and use `_get_redmine_client()` for OAuth compatibility
 - **50 new unit tests** for project members and time tracking tools (`test_project_members.py`, `test_time_entries.py`)
 - **26 new integration tests** covering all 21 MCP tools with zero skips — includes project members (4), time entries (7), custom fields (3), search issues (3), summarize project (3), global search (4), and cleanup (2)

--- a/README.md
+++ b/README.md
@@ -430,12 +430,13 @@ curl http://localhost:8000/health
 
 ## Available Tools
 
-This MCP server provides 17 tools for interacting with Redmine. For detailed documentation, see [Tool Reference](./docs/tool-reference.md).
+This MCP server provides 22 tools for interacting with Redmine. For detailed documentation, see [Tool Reference](./docs/tool-reference.md).
 
-- **Project Management** (4 tools)
+- **Project Management** (5 tools)
   - [`list_redmine_projects`](docs/tool-reference.md#list_redmine_projects) - List all accessible projects
   - [`list_project_issue_custom_fields`](docs/tool-reference.md#list_project_issue_custom_fields) - List issue custom fields configured for a project
   - [`list_redmine_versions`](docs/tool-reference.md#list_redmine_versions) - List versions/milestones for a project
+  - [`list_project_members`](docs/tool-reference.md#list_project_members) - List members and roles of a project
   - [`summarize_project_status`](docs/tool-reference.md#summarize_project_status) - Get comprehensive project status summary
 
 - **Issue Operations** (6 tools)
@@ -446,6 +447,12 @@ This MCP server provides 17 tools for interacting with Redmine. For detailed doc
   - [`create_redmine_issue`](docs/tool-reference.md#create_redmine_issue) - Create new issues
   - [`update_redmine_issue`](docs/tool-reference.md#update_redmine_issue) - Update existing issues
   - Note: `get_redmine_issue` can include `custom_fields` and `update_redmine_issue` can update custom fields by name (for example `{"size": "S"}`).
+
+- **Time Tracking** (4 tools)
+  - [`list_time_entries`](docs/tool-reference.md#list_time_entries) - List time entries with filtering by project, issue, user, and date range
+  - [`create_time_entry`](docs/tool-reference.md#create_time_entry) - Log time against projects or issues
+  - [`update_time_entry`](docs/tool-reference.md#update_time_entry) - Modify existing time entries
+  - [`list_time_entry_activities`](docs/tool-reference.md#list_time_entry_activities) - Discover available activity types for time entries
 
 - **Search & Wiki** (5 tools)
   - [`search_entire_redmine`](docs/tool-reference.md#search_entire_redmine) - Global search across issues and wiki pages (Redmine 3.3.0+)

--- a/docs/tool-reference.md
+++ b/docs/tool-reference.md
@@ -767,6 +767,27 @@ update_time_entry(
 
 ---
 
+### `list_time_entry_activities`
+
+List all available time entry activity types from Redmine.
+
+Use this tool to discover valid `activity_id` values before calling `create_time_entry` or `update_time_entry`.
+
+**Parameters:** None
+
+**Returns:** List of activity dictionaries
+
+**Example:**
+```json
+[
+  {"id": 4, "name": "Development", "active": true, "is_default": false},
+  {"id": 5, "name": "Design", "active": true, "is_default": false},
+  {"id": 6, "name": "Testing", "active": true, "is_default": false}
+]
+```
+
+---
+
 ## Search & Wiki
 
 ### `search_entire_redmine`

--- a/docs/tool-reference.md
+++ b/docs/tool-reference.md
@@ -282,6 +282,49 @@ issues = list_redmine_issues(fixed_version_id=versions[0]["id"])
 
 ---
 
+### `list_project_members`
+
+List all members (users and groups) of a Redmine project along with their assigned roles.
+
+**Parameters:**
+- `project_id` (integer or string, required): Project ID (numeric) or identifier (string)
+
+**Returns:** List of membership dictionaries containing user/group info and roles
+
+**Example:**
+```json
+[
+  {
+    "id": 1,
+    "user": {"id": 5, "name": "John Doe"},
+    "group": null,
+    "project": {"id": 10, "name": "My Project"},
+    "roles": [{"id": 3, "name": "Developer"}]
+  },
+  {
+    "id": 2,
+    "user": null,
+    "group": {"id": 15, "name": "Dev Team"},
+    "project": {"id": 10, "name": "My Project"},
+    "roles": [{"id": 4, "name": "Manager"}]
+  }
+]
+```
+
+**Usage:**
+```python
+# List members by project ID
+members = list_project_members(project_id=10)
+
+# List members by project identifier
+members = list_project_members(project_id="my-project")
+
+# Get all developers in a project
+devs = [m for m in members if any(r["name"] == "Developer" for r in m["roles"])]
+```
+
+---
+
 ## Issue Operations
 
 ### `get_redmine_issue`
@@ -578,6 +621,147 @@ update_redmine_issue(
     fields={
         "size": "S"
     }
+)
+```
+
+---
+
+## Time Tracking
+
+### `list_time_entries`
+
+List time entries from Redmine with optional filtering and pagination.
+
+**Parameters:**
+- `project_id` (integer or string, optional): Filter by project (numeric ID or string identifier)
+- `issue_id` (integer, optional): Filter by issue ID
+- `user_id` (integer or string, optional): Filter by user ID. Use `"me"` for current user
+- `from_date` (string, optional): Start date filter (YYYY-MM-DD format)
+- `to_date` (string, optional): End date filter (YYYY-MM-DD format)
+- `limit` (integer, optional): Maximum entries to return. Default: `25`, Max: `100`
+- `offset` (integer, optional): Number of entries to skip for pagination. Default: `0`
+
+**Returns:** List of time entry dictionaries
+
+**Example:**
+```json
+[
+  {
+    "id": 1,
+    "hours": 2.5,
+    "comments": "Bug fix work",
+    "spent_on": "2024-03-15",
+    "user": {"id": 5, "name": "John Doe"},
+    "project": {"id": 10, "name": "My Project"},
+    "issue": {"id": 123},
+    "activity": {"id": 9, "name": "Development"},
+    "created_on": "2024-03-15T10:30:00",
+    "updated_on": "2024-03-15T10:30:00"
+  }
+]
+```
+
+**Usage:**
+```python
+# List all time entries for a project
+entries = list_time_entries(project_id="my-project")
+
+# Filter by issue and date range
+entries = list_time_entries(
+    issue_id=123,
+    from_date="2024-01-01",
+    to_date="2024-03-31"
+)
+
+# Get current user's time entries
+my_entries = list_time_entries(user_id="me")
+```
+
+---
+
+### `create_time_entry`
+
+Create a new time entry in Redmine. Log time against a project or issue.
+
+**Parameters:**
+- `hours` (float, required): Number of hours spent. Must be positive. Can be decimal (e.g., `1.5`)
+- `project_id` (integer or string, optional): Project to log time against. Required if `issue_id` is not provided
+- `issue_id` (integer, optional): Issue to log time against. If provided, `project_id` is optional
+- `activity_id` (integer, optional): Time entry activity ID (e.g., Development, Design). Uses default if not provided
+- `comments` (string, optional): Description of work performed
+- `spent_on` (string, optional): Date when time was spent (YYYY-MM-DD). Defaults to today
+
+**Returns:** Created time entry dictionary
+
+**Example:**
+```json
+{
+  "id": 1,
+  "hours": 2.5,
+  "comments": "Bug fix",
+  "spent_on": "2024-03-15",
+  "user": {"id": 5, "name": "John Doe"},
+  "project": {"id": 10, "name": "My Project"},
+  "issue": {"id": 123},
+  "activity": {"id": 9, "name": "Development"}
+}
+```
+
+**Usage:**
+```python
+# Log time against an issue
+create_time_entry(
+    hours=2.5,
+    issue_id=123,
+    comments="Fixed login bug"
+)
+
+# Log time against a project with specific date
+create_time_entry(
+    hours=1.0,
+    project_id="my-project",
+    activity_id=9,
+    comments="Code review",
+    spent_on="2024-03-15"
+)
+```
+
+---
+
+### `update_time_entry`
+
+Update an existing time entry in Redmine.
+
+**Parameters:**
+- `time_entry_id` (integer, required): ID of the time entry to update
+- `hours` (float, optional): New hours value. Must be positive if provided
+- `activity_id` (integer, optional): New activity ID
+- `comments` (string, optional): New comments/description
+- `spent_on` (string, optional): New date (YYYY-MM-DD format)
+
+**Returns:** Updated time entry dictionary
+
+**Example:**
+```json
+{
+  "id": 1,
+  "hours": 3.0,
+  "comments": "Extended work on bug fix",
+  "spent_on": "2024-03-15"
+}
+```
+
+**Usage:**
+```python
+# Update hours
+update_time_entry(time_entry_id=1, hours=3.0)
+
+# Update multiple fields
+update_time_entry(
+    time_entry_id=1,
+    hours=4.0,
+    comments="Extended debugging session",
+    spent_on="2024-03-16"
 )
 ```
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -202,6 +202,58 @@ This guide covers common issues and solutions for the Redmine MCP Server.
 
 ## Authentication Issues
 
+### Server Unexpectedly Requires OAuth / "unauthorized" Error
+
+**Symptoms:**
+- MCP client fails to connect with `{"error":"unauthorized"}`
+- Server returns `401 Unauthorized` with a `WWW-Authenticate: Bearer` header
+- Health endpoint shows `"auth_mode":"oauth"` when you expected legacy mode
+
+**Cause:** The server is running in OAuth mode (`REDMINE_AUTH_MODE=oauth`) instead of legacy mode. This can happen if:
+- `REDMINE_AUTH_MODE=oauth` is set in your shell environment (e.g., via `export`), which takes precedence over `.env`
+- The `.env` file doesn't explicitly set `REDMINE_AUTH_MODE=legacy`, and a shell variable overrides the default
+- The server was started with a previous configuration and hasn't been restarted after changes
+
+**Solutions:**
+
+1. **Check current auth mode**
+   ```bash
+   # Query the health endpoint
+   curl http://localhost:8000/health
+   # Look for "auth_mode" in the response
+   ```
+
+2. **Check for shell environment overrides**
+   ```bash
+   # Shell env vars take precedence over .env file
+   echo $REDMINE_AUTH_MODE
+
+   # If set, unset it
+   unset REDMINE_AUTH_MODE
+   ```
+
+3. **Explicitly set auth mode in `.env`**
+   ```bash
+   # Add to your .env file
+   REDMINE_AUTH_MODE=legacy
+   ```
+
+4. **Restart the server**
+   - Configuration changes require a server restart
+   - The auth mode is determined at startup and cannot change at runtime
+   ```bash
+   # Find and stop the running server
+   lsof -i :8000
+   kill <PID>
+
+   # Restart
+   redmine-mcp-server
+   ```
+
+5. **Verify after restart**
+   - Check server startup logs for: `Auth mode: legacy`
+   - Query health endpoint to confirm: `curl http://localhost:8000/health`
+
 ### API Key Not Working
 
 **Symptoms:**

--- a/src/redmine_mcp_server/main.py
+++ b/src/redmine_mcp_server/main.py
@@ -190,9 +190,10 @@ def main():
     """Main entry point for the console script."""
     # Note: .env is already loaded during redmine_handler import
 
-    # Log version at startup
+    # Log version and auth mode at startup
     server_version = get_version()
     logger.info(f"Redmine MCP Server v{server_version}")
+    logger.info(f"Auth mode: {REDMINE_AUTH_MODE}")
 
     # Enable stateless HTTP mode (checked at request time by FastMCP)
     mcp.settings.stateless_http = True

--- a/src/redmine_mcp_server/oauth_middleware.py
+++ b/src/redmine_mcp_server/oauth_middleware.py
@@ -40,7 +40,14 @@ class RedmineOAuthMiddleware(BaseHTTPMiddleware):
         if not auth_header.startswith("Bearer "):
             return JSONResponse(
                 status_code=401,
-                content={"error": "unauthorized"},
+                content={
+                    "error": "unauthorized",
+                    "error_description": (
+                        "Bearer token required. Server is running in OAuth mode "
+                        "(REDMINE_AUTH_MODE=oauth). If you intended legacy mode, "
+                        "set REDMINE_AUTH_MODE=legacy and restart the server."
+                    ),
+                },
                 headers={
                     "WWW-Authenticate": _www_authenticate_header(include_error=False)
                 },

--- a/src/redmine_mcp_server/redmine_handler.py
+++ b/src/redmine_mcp_server/redmine_handler.py
@@ -2511,6 +2511,104 @@ async def search_entire_redmine(
         return _handle_redmine_error(e, f"searching Redmine for '{query}'")
 
 
+def _membership_to_dict(membership: Any) -> Dict[str, Any]:
+    """Convert a project membership to a serializable dict."""
+    user = getattr(membership, "user", None)
+    group = getattr(membership, "group", None)
+    project = getattr(membership, "project", None)
+    roles = getattr(membership, "roles", None) or []
+
+    result: Dict[str, Any] = {
+        "id": getattr(membership, "id", None),
+    }
+
+    # User or group (memberships can be for either)
+    if user is not None:
+        result["user"] = {
+            "id": getattr(user, "id", None),
+            "name": getattr(user, "name", ""),
+        }
+        result["group"] = None
+    elif group is not None:
+        result["user"] = None
+        result["group"] = {
+            "id": getattr(group, "id", None),
+            "name": getattr(group, "name", ""),
+        }
+    else:
+        result["user"] = None
+        result["group"] = None
+
+    # Project info
+    if project is not None:
+        result["project"] = {
+            "id": getattr(project, "id", None),
+            "name": getattr(project, "name", ""),
+        }
+    else:
+        result["project"] = None
+
+    # Roles
+    result["roles"] = []
+    try:
+        for role in roles:
+            if isinstance(role, dict):
+                result["roles"].append(
+                    {
+                        "id": role.get("id"),
+                        "name": role.get("name", ""),
+                    }
+                )
+            else:
+                result["roles"].append(
+                    {
+                        "id": getattr(role, "id", None),
+                        "name": getattr(role, "name", ""),
+                    }
+                )
+    except TypeError:
+        pass  # roles not iterable
+
+    return result
+
+
+def _time_entry_to_dict(time_entry: Any) -> Dict[str, Any]:
+    """Convert a time entry to a serializable dict."""
+    user = getattr(time_entry, "user", None)
+    project = getattr(time_entry, "project", None)
+    issue = getattr(time_entry, "issue", None)
+    activity = getattr(time_entry, "activity", None)
+
+    return {
+        "id": getattr(time_entry, "id", None),
+        "hours": getattr(time_entry, "hours", 0),
+        "comments": getattr(time_entry, "comments", ""),
+        "spent_on": (
+            str(time_entry.spent_on)
+            if getattr(time_entry, "spent_on", None) is not None
+            else None
+        ),
+        "user": ({"id": user.id, "name": user.name} if user is not None else None),
+        "project": (
+            {"id": project.id, "name": project.name} if project is not None else None
+        ),
+        "issue": ({"id": issue.id} if issue is not None else None),
+        "activity": (
+            {"id": activity.id, "name": activity.name} if activity is not None else None
+        ),
+        "created_on": (
+            time_entry.created_on.isoformat()
+            if getattr(time_entry, "created_on", None) is not None
+            else None
+        ),
+        "updated_on": (
+            time_entry.updated_on.isoformat()
+            if getattr(time_entry, "updated_on", None) is not None
+            else None
+        ),
+    }
+
+
 def _wiki_page_to_dict(
     wiki_page: Any, include_attachments: bool = True
 ) -> Dict[str, Any]:
@@ -2745,6 +2843,274 @@ async def delete_redmine_wiki_page(
             e,
             f"deleting wiki page '{wiki_page_title}' in project {project_id}",
             {"resource_type": "wiki page", "resource_id": wiki_page_title},
+        )
+
+
+@mcp.tool()
+async def list_project_members(
+    project_id: Union[str, int],
+) -> List[Dict[str, Any]]:
+    """List members of a Redmine project.
+
+    Returns all users and groups that are members of the specified project,
+    along with their assigned roles.
+
+    Args:
+        project_id: Project identifier (ID number or string identifier)
+
+    Returns:
+        A list of membership dictionaries containing user/group info and roles.
+        On failure, a list containing a single dictionary with an "error" key.
+
+    Examples:
+        >>> await list_project_members("my-project")
+        [
+            {
+                "id": 1,
+                "user": {"id": 5, "name": "John Doe"},
+                "group": null,
+                "project": {"id": 1, "name": "My Project"},
+                "roles": [{"id": 3, "name": "Developer"}]
+            },
+            ...
+        ]
+    """
+    if not redmine:
+        return [{"error": "Redmine client not initialized."}]
+
+    await _ensure_cleanup_started()
+
+    try:
+        memberships = redmine.project_membership.filter(project_id=project_id)
+        return [_membership_to_dict(m) for m in memberships]
+    except Exception as e:
+        return [
+            _handle_redmine_error(
+                e,
+                f"listing members for project {project_id}",
+                {"resource_type": "project", "resource_id": project_id},
+            )
+        ]
+
+
+@mcp.tool()
+async def list_time_entries(
+    project_id: Optional[Union[str, int]] = None,
+    issue_id: Optional[int] = None,
+    user_id: Optional[Union[str, int]] = None,
+    from_date: Optional[str] = None,
+    to_date: Optional[str] = None,
+    limit: int = 25,
+    offset: int = 0,
+) -> Union[List[Dict[str, Any]], Dict[str, Any]]:
+    """List time entries from Redmine with filtering and pagination.
+
+    Retrieve time entries with optional filtering by project, issue, user,
+    and date range. Supports pagination for handling large result sets.
+
+    Args:
+        project_id: Filter by project (ID number or string identifier).
+        issue_id: Filter by issue ID.
+        user_id: Filter by user ID. Use "me" for current user.
+        from_date: Start date filter (YYYY-MM-DD format).
+        to_date: End date filter (YYYY-MM-DD format).
+        limit: Maximum number of entries to return (default: 25, max: 100).
+        offset: Number of entries to skip for pagination (default: 0).
+
+    Returns:
+        A list of time entry dictionaries. On failure, a list containing
+        a single dictionary with an "error" key.
+
+    Examples:
+        >>> await list_time_entries(project_id="my-project")
+        [{"id": 1, "hours": 2.5, "comments": "Bug fix", ...}, ...]
+
+        >>> await list_time_entries(issue_id=123, from_date="2024-01-01")
+        [{"id": 2, "hours": 1.0, "issue": {"id": 123}, ...}, ...]
+
+        >>> await list_time_entries(user_id="me", limit=10)
+        [{"id": 3, "hours": 4.0, "user": {"id": 5, "name": "Current User"}, ...}]
+    """
+    if not redmine:
+        return [{"error": "Redmine client not initialized."}]
+
+    await _ensure_cleanup_started()
+
+    try:
+        # Build filter parameters
+        filters: Dict[str, Any] = {
+            "limit": min(limit, 100),
+            "offset": offset,
+        }
+
+        if project_id is not None:
+            filters["project_id"] = project_id
+        if issue_id is not None:
+            filters["issue_id"] = issue_id
+        if user_id is not None:
+            filters["user_id"] = user_id
+        if from_date is not None:
+            filters["from_date"] = from_date
+        if to_date is not None:
+            filters["to_date"] = to_date
+
+        time_entries = redmine.time_entry.filter(**filters)
+        return [_time_entry_to_dict(te) for te in time_entries]
+
+    except Exception as e:
+        return [_handle_redmine_error(e, "listing time entries")]
+
+
+@mcp.tool()
+async def create_time_entry(
+    hours: float,
+    project_id: Optional[Union[str, int]] = None,
+    issue_id: Optional[int] = None,
+    activity_id: Optional[int] = None,
+    comments: str = "",
+    spent_on: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Create a new time entry in Redmine.
+
+    Log time against a project or issue. Either project_id or issue_id
+    must be provided. If issue_id is provided, the time entry will be
+    associated with that issue's project.
+
+    Args:
+        hours: Number of hours spent (required). Can be decimal (e.g., 1.5).
+        project_id: Project to log time against (ID or identifier).
+            Required if issue_id is not provided.
+        issue_id: Issue to log time against. If provided, project_id is optional.
+        activity_id: Time entry activity ID (e.g., Development, Design).
+            If not provided, Redmine uses the default activity.
+        comments: Description of work performed.
+        spent_on: Date when time was spent (YYYY-MM-DD). Defaults to today.
+
+    Returns:
+        Dictionary containing the created time entry, or error dict on failure.
+
+    Examples:
+        >>> await create_time_entry(hours=2.5, issue_id=123, comments="Bug fix")
+        {"id": 1, "hours": 2.5, "issue": {"id": 123}, ...}
+
+        >>> await create_time_entry(
+        ...     hours=1.0,
+        ...     project_id="my-project",
+        ...     activity_id=9,
+        ...     comments="Code review",
+        ...     spent_on="2024-03-15"
+        ... )
+        {"id": 2, "hours": 1.0, "project": {"id": 1, "name": "My Project"}, ...}
+    """
+    if not redmine:
+        return {"error": "Redmine client not initialized."}
+
+    if project_id is None and issue_id is None:
+        return {"error": "Either project_id or issue_id must be provided."}
+
+    if hours <= 0:
+        return {"error": "Hours must be a positive number."}
+
+    await _ensure_cleanup_started()
+
+    try:
+        # Build create parameters
+        params: Dict[str, Any] = {
+            "hours": hours,
+        }
+
+        if project_id is not None:
+            params["project_id"] = project_id
+        if issue_id is not None:
+            params["issue_id"] = issue_id
+        if activity_id is not None:
+            params["activity_id"] = activity_id
+        if comments:
+            params["comments"] = comments
+        if spent_on is not None:
+            params["spent_on"] = spent_on
+
+        time_entry = redmine.time_entry.create(**params)
+        return _time_entry_to_dict(time_entry)
+
+    except Exception as e:
+        context = {}
+        if issue_id:
+            context = {"resource_type": "issue", "resource_id": issue_id}
+        elif project_id:
+            context = {"resource_type": "project", "resource_id": project_id}
+        return _handle_redmine_error(e, "creating time entry", context)
+
+
+@mcp.tool()
+async def update_time_entry(
+    time_entry_id: int,
+    hours: Optional[float] = None,
+    activity_id: Optional[int] = None,
+    comments: Optional[str] = None,
+    spent_on: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Update an existing time entry in Redmine.
+
+    Modify hours, activity, comments, or date of an existing time entry.
+    Only provided fields will be updated.
+
+    Args:
+        time_entry_id: ID of the time entry to update (required).
+        hours: New hours value. Must be positive if provided.
+        activity_id: New activity ID.
+        comments: New comments/description.
+        spent_on: New date (YYYY-MM-DD format).
+
+    Returns:
+        Dictionary containing the updated time entry, or error dict on failure.
+
+    Examples:
+        >>> await update_time_entry(time_entry_id=1, hours=3.0)
+        {"id": 1, "hours": 3.0, ...}
+
+        >>> await update_time_entry(
+        ...     time_entry_id=1,
+        ...     comments="Updated description",
+        ...     spent_on="2024-03-16"
+        ... )
+        {"id": 1, "comments": "Updated description", ...}
+    """
+    if not redmine:
+        return {"error": "Redmine client not initialized."}
+
+    if hours is not None and hours <= 0:
+        return {"error": "Hours must be a positive number."}
+
+    await _ensure_cleanup_started()
+
+    try:
+        # Build update parameters
+        params: Dict[str, Any] = {}
+
+        if hours is not None:
+            params["hours"] = hours
+        if activity_id is not None:
+            params["activity_id"] = activity_id
+        if comments is not None:
+            params["comments"] = comments
+        if spent_on is not None:
+            params["spent_on"] = spent_on
+
+        if not params:
+            return {"error": "No fields provided for update."}
+
+        redmine.time_entry.update(time_entry_id, **params)
+
+        # Fetch and return updated entry
+        updated_entry = redmine.time_entry.get(time_entry_id)
+        return _time_entry_to_dict(updated_entry)
+
+    except Exception as e:
+        return _handle_redmine_error(
+            e,
+            f"updating time entry {time_entry_id}",
+            {"resource_type": "time entry", "resource_id": time_entry_id},
         )
 
 

--- a/src/redmine_mcp_server/redmine_handler.py
+++ b/src/redmine_mcp_server/redmine_handler.py
@@ -319,7 +319,13 @@ async def health_check(request):
     # Initialize cleanup task on first health check (lazy initialization)
     await _ensure_cleanup_started()
 
-    return JSONResponse({"status": "ok", "service": "redmine_mcp_tools"})
+    return JSONResponse(
+        {
+            "status": "ok",
+            "service": "redmine_mcp_tools",
+            "auth_mode": REDMINE_AUTH_MODE,
+        }
+    )
 
 
 @mcp.custom_route("/files/{file_id}", methods=["GET"])

--- a/src/redmine_mcp_server/redmine_handler.py
+++ b/src/redmine_mcp_server/redmine_handler.py
@@ -3118,6 +3118,39 @@ async def update_time_entry(
 
 
 @mcp.tool()
+async def list_time_entry_activities() -> List[Dict[str, Any]]:
+    """List available time entry activities from Redmine.
+
+    Returns all activity types that can be used when creating or updating
+    time entries (e.g., Development, Design, Testing).
+
+    Returns:
+        A list of activity dictionaries. On failure, a list containing
+        a single dictionary with an "error" key.
+
+    Examples:
+        >>> await list_time_entry_activities()
+        [{"id": 4, "name": "Development", "active": True, "is_default": False}, ...]
+    """
+    try:
+        activities = _get_redmine_client().enumeration.filter(
+            resource="time_entry_activities"
+        )
+        return [
+            {
+                "id": getattr(a, "id", None),
+                "name": getattr(a, "name", None),
+                "active": getattr(a, "active", None),
+                "is_default": getattr(a, "is_default", None),
+            }
+            for a in activities
+        ]
+
+    except Exception as e:
+        return [_handle_redmine_error(e, "listing time entry activities")]
+
+
+@mcp.tool()
 async def cleanup_attachment_files() -> Dict[str, Any]:
     """Clean up expired attachment files and return storage statistics.
 

--- a/src/redmine_mcp_server/redmine_handler.py
+++ b/src/redmine_mcp_server/redmine_handler.py
@@ -2588,13 +2588,29 @@ def _time_entry_to_dict(time_entry: Any) -> Dict[str, Any]:
             if getattr(time_entry, "spent_on", None) is not None
             else None
         ),
-        "user": ({"id": user.id, "name": user.name} if user is not None else None),
-        "project": (
-            {"id": project.id, "name": project.name} if project is not None else None
+        "user": (
+            {"id": getattr(user, "id", None), "name": getattr(user, "name", "")}
+            if user is not None
+            else None
         ),
-        "issue": ({"id": issue.id} if issue is not None else None),
+        "project": (
+            {
+                "id": getattr(project, "id", None),
+                "name": getattr(project, "name", ""),
+            }
+            if project is not None
+            else None
+        ),
+        "issue": (
+            {"id": getattr(issue, "id", None)} if issue is not None else None
+        ),
         "activity": (
-            {"id": activity.id, "name": activity.name} if activity is not None else None
+            {
+                "id": getattr(activity, "id", None),
+                "name": getattr(activity, "name", ""),
+            }
+            if activity is not None
+            else None
         ),
         "created_on": (
             time_entry.created_on.isoformat()
@@ -2875,13 +2891,10 @@ async def list_project_members(
             ...
         ]
     """
-    if not redmine:
-        return [{"error": "Redmine client not initialized."}]
-
-    await _ensure_cleanup_started()
-
     try:
-        memberships = redmine.project_membership.filter(project_id=project_id)
+        memberships = _get_redmine_client().project_membership.filter(
+            project_id=project_id
+        )
         return [_membership_to_dict(m) for m in memberships]
     except Exception as e:
         return [
@@ -2931,11 +2944,6 @@ async def list_time_entries(
         >>> await list_time_entries(user_id="me", limit=10)
         [{"id": 3, "hours": 4.0, "user": {"id": 5, "name": "Current User"}, ...}]
     """
-    if not redmine:
-        return [{"error": "Redmine client not initialized."}]
-
-    await _ensure_cleanup_started()
-
     try:
         # Build filter parameters
         filters: Dict[str, Any] = {
@@ -2954,7 +2962,7 @@ async def list_time_entries(
         if to_date is not None:
             filters["to_date"] = to_date
 
-        time_entries = redmine.time_entry.filter(**filters)
+        time_entries = _get_redmine_client().time_entry.filter(**filters)
         return [_time_entry_to_dict(te) for te in time_entries]
 
     except Exception as e:
@@ -3002,16 +3010,11 @@ async def create_time_entry(
         ... )
         {"id": 2, "hours": 1.0, "project": {"id": 1, "name": "My Project"}, ...}
     """
-    if not redmine:
-        return {"error": "Redmine client not initialized."}
-
     if project_id is None and issue_id is None:
         return {"error": "Either project_id or issue_id must be provided."}
 
     if hours <= 0:
         return {"error": "Hours must be a positive number."}
-
-    await _ensure_cleanup_started()
 
     try:
         # Build create parameters
@@ -3030,7 +3033,7 @@ async def create_time_entry(
         if spent_on is not None:
             params["spent_on"] = spent_on
 
-        time_entry = redmine.time_entry.create(**params)
+        time_entry = _get_redmine_client().time_entry.create(**params)
         return _time_entry_to_dict(time_entry)
 
     except Exception as e:
@@ -3076,13 +3079,8 @@ async def update_time_entry(
         ... )
         {"id": 1, "comments": "Updated description", ...}
     """
-    if not redmine:
-        return {"error": "Redmine client not initialized."}
-
     if hours is not None and hours <= 0:
         return {"error": "Hours must be a positive number."}
-
-    await _ensure_cleanup_started()
 
     try:
         # Build update parameters
@@ -3100,10 +3098,11 @@ async def update_time_entry(
         if not params:
             return {"error": "No fields provided for update."}
 
-        redmine.time_entry.update(time_entry_id, **params)
+        client = _get_redmine_client()
+        client.time_entry.update(time_entry_id, **params)
 
         # Fetch and return updated entry
-        updated_entry = redmine.time_entry.get(time_entry_id)
+        updated_entry = client.time_entry.get(time_entry_id)
         return _time_entry_to_dict(updated_entry)
 
     except Exception as e:

--- a/src/redmine_mcp_server/redmine_handler.py
+++ b/src/redmine_mcp_server/redmine_handler.py
@@ -2601,9 +2601,7 @@ def _time_entry_to_dict(time_entry: Any) -> Dict[str, Any]:
             if project is not None
             else None
         ),
-        "issue": (
-            {"id": getattr(issue, "id", None)} if issue is not None else None
-        ),
+        "issue": ({"id": getattr(issue, "id", None)} if issue is not None else None),
         "activity": (
             {
                 "id": getattr(activity, "id", None),

--- a/tests/test_enumerations.py
+++ b/tests/test_enumerations.py
@@ -1,0 +1,73 @@
+"""Test cases for enumeration/lookup tools."""
+
+import pytest
+from unittest.mock import Mock, patch
+
+from redmine_mcp_server.redmine_handler import list_time_entry_activities
+
+
+class TestListTimeEntryActivities:
+    """Test cases for list_time_entry_activities tool."""
+
+    @pytest.fixture
+    def mock_redmine(self):
+        with patch("redmine_mcp_server.redmine_handler.redmine") as mock:
+            yield mock
+
+    def _make_activity(self, id, name, active=True, is_default=False):
+        m = Mock()
+        m.id = id
+        m.name = name
+        m.active = active
+        m.is_default = is_default
+        return m
+
+    @pytest.mark.asyncio
+    async def test_list_activities_success(self, mock_redmine):
+        mock_redmine.enumeration.filter.return_value = [
+            self._make_activity(4, "Development"),
+            self._make_activity(5, "Design"),
+            self._make_activity(6, "Testing"),
+        ]
+        result = await list_time_entry_activities()
+        assert len(result) == 3
+        assert result[0]["id"] == 4
+        assert result[0]["name"] == "Development"
+        mock_redmine.enumeration.filter.assert_called_once_with(
+            resource="time_entry_activities"
+        )
+
+    @pytest.mark.asyncio
+    async def test_list_activities_empty(self, mock_redmine):
+        mock_redmine.enumeration.filter.return_value = []
+        result = await list_time_entry_activities()
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_list_activities_field_structure(self, mock_redmine):
+        mock_redmine.enumeration.filter.return_value = [
+            self._make_activity(4, "Development", active=True, is_default=True),
+        ]
+        result = await list_time_entry_activities()
+        activity = result[0]
+        assert set(activity.keys()) == {"id", "name", "active", "is_default"}
+        assert activity["active"] is True
+        assert activity["is_default"] is True
+
+    @pytest.mark.asyncio
+    async def test_list_activities_client_not_initialized(self, mock_redmine):
+        mock_redmine.enumeration.filter.side_effect = RuntimeError(
+            "No Redmine authentication available."
+        )
+        result = await list_time_entry_activities()
+        assert len(result) == 1
+        assert "error" in result[0]
+
+    @pytest.mark.asyncio
+    async def test_list_activities_forbidden(self, mock_redmine):
+        from redminelib.exceptions import ForbiddenError
+
+        mock_redmine.enumeration.filter.side_effect = ForbiddenError()
+        result = await list_time_entry_activities()
+        assert len(result) == 1
+        assert "error" in result[0]

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -42,6 +42,15 @@ def _integration_test_custom_fields():
     return {"custom_fields": [{"id": 2, "value": "Engineering"}]}
 
 
+def _get_activity_id(redmine):
+    """Return the first available time entry activity ID, or None."""
+    try:
+        activities = list(redmine.enumeration.filter(resource="time_entry_activities"))
+        return activities[0].id if activities else None
+    except Exception:
+        return None
+
+
 class TestRedmineIntegration:
     """Integration tests for Redmine connectivity."""
 
@@ -1332,28 +1341,48 @@ class TestTimeEntriesIntegration:
         if redmine is None:
             pytest.skip("Redmine client not initialized")
 
-        from redmine_mcp_server.redmine_handler import list_time_entries
+        from redmine_mcp_server.redmine_handler import (
+            create_time_entry,
+            list_time_entries,
+        )
 
-        result = await list_time_entries(limit=1)
+        # Ensure at least one time entry exists
+        projects = list(redmine.project.all())
+        assert projects, "No projects available"
+        activity_id = _get_activity_id(redmine)
+        assert activity_id is not None, "No time entry activities configured"
 
-        assert isinstance(result, list)
-        if not result:
-            pytest.skip("No time entries found for testing")
+        created = await create_time_entry(
+            hours=0.1,
+            project_id=projects[0].id,
+            activity_id=activity_id,
+            comments="Structure test entry",
+        )
+        assert "error" not in created, f"Failed to create: {created.get('error')}"
 
-        entry = result[0]
-        if "error" in entry:
-            if "denied" in entry["error"].lower():
-                pytest.skip(f"Time tracking not permitted: {entry['error']}")
-            pytest.fail(f"API error: {entry['error']}")
-        assert "id" in entry
-        assert "hours" in entry
-        assert "comments" in entry
-        assert "spent_on" in entry
-        assert "user" in entry
-        assert "project" in entry
-        assert "activity" in entry
-        assert isinstance(entry["id"], int)
-        assert isinstance(entry["hours"], (int, float))
+        try:
+            result = await list_time_entries(limit=1)
+
+            assert isinstance(result, list)
+            assert len(result) > 0, "Expected at least one time entry"
+
+            entry = result[0]
+            if "error" in entry:
+                pytest.fail(f"API error: {entry['error']}")
+            assert "id" in entry
+            assert "hours" in entry
+            assert "comments" in entry
+            assert "spent_on" in entry
+            assert "user" in entry
+            assert "project" in entry
+            assert "activity" in entry
+            assert isinstance(entry["id"], int)
+            assert isinstance(entry["hours"], (int, float))
+        finally:
+            try:
+                redmine.time_entry.delete(created["id"])
+            except Exception:
+                pass
 
     @pytest.mark.skipif(not REDMINE_URL, reason="REDMINE_URL not configured")
     @pytest.mark.integration
@@ -1397,29 +1426,14 @@ class TestTimeEntriesIntegration:
             update_time_entry,
         )
 
-        import requests as req
-        from redmine_mcp_server.redmine_handler import REDMINE_URL
-
         # Pick the first available project
         projects = list(redmine.project.all())
-        if not projects:
-            pytest.skip("No projects available for testing")
+        assert projects, "No projects available for testing"
         project_id = projects[0].id
 
         # Find an activity_id (required by some Redmine configs)
-        api_key = os.getenv("REDMINE_API_KEY", "")
-        act_resp = req.get(
-            f"{REDMINE_URL}/enumerations/time_entry_activities.json",
-            headers={"X-Redmine-API-Key": api_key},
-        )
-        activities = (
-            act_resp.json().get("time_entry_activities", [])
-            if act_resp.status_code == 200
-            else []
-        )
-        if not activities:
-            pytest.skip("No time entry activities configured in Redmine")
-        activity_id = activities[0]["id"]
+        activity_id = _get_activity_id(redmine)
+        assert activity_id is not None, "No time entry activities configured"
 
         time_entry_id = None
         try:
@@ -1488,6 +1502,360 @@ class TestTimeEntriesIntegration:
         result = await create_time_entry(hours=-1.0, project_id=1)
         assert "error" in result
         assert "positive" in result["error"]
+
+
+class TestListProjectIssueCustomFieldsIntegration:
+    """Integration tests for list_project_issue_custom_fields tool."""
+
+    @pytest.mark.skipif(not REDMINE_URL, reason="REDMINE_URL not configured")
+    @pytest.mark.integration
+    @pytest.mark.asyncio
+    async def test_list_custom_fields_for_project(self):
+        """Test listing custom fields for an existing project."""
+        redmine = _get_redmine_or_none()
+        if redmine is None:
+            pytest.skip("Redmine client not initialized")
+
+        from redmine_mcp_server.redmine_handler import (
+            list_project_issue_custom_fields,
+        )
+
+        projects = list(redmine.project.all())
+        assert projects, "No projects available"
+
+        result = await list_project_issue_custom_fields(
+            project_id=projects[0].identifier
+        )
+
+        assert isinstance(result, list)
+        if result and "error" in result[0]:
+            pytest.fail(f"API error: {result[0]['error']}")
+
+    @pytest.mark.skipif(not REDMINE_URL, reason="REDMINE_URL not configured")
+    @pytest.mark.integration
+    @pytest.mark.asyncio
+    async def test_list_custom_fields_structure(self):
+        """Test that custom field dicts have expected keys."""
+        redmine = _get_redmine_or_none()
+        if redmine is None:
+            pytest.skip("Redmine client not initialized")
+
+        from redmine_mcp_server.redmine_handler import (
+            list_project_issue_custom_fields,
+        )
+
+        projects = list(redmine.project.all())
+        assert projects, "No projects available"
+
+        result = await list_project_issue_custom_fields(
+            project_id=projects[0].identifier
+        )
+
+        assert isinstance(result, list)
+        if not result:
+            # Project may have no custom fields; that's valid
+            return
+
+        if "error" in result[0]:
+            pytest.fail(f"API error: {result[0]['error']}")
+
+        field = result[0]
+        assert "id" in field
+        assert "name" in field
+
+    @pytest.mark.skipif(not REDMINE_URL, reason="REDMINE_URL not configured")
+    @pytest.mark.integration
+    @pytest.mark.asyncio
+    async def test_list_custom_fields_nonexistent_project(self):
+        """Test error handling for nonexistent project."""
+        redmine = _get_redmine_or_none()
+        if redmine is None:
+            pytest.skip("Redmine client not initialized")
+
+        from redmine_mcp_server.redmine_handler import (
+            list_project_issue_custom_fields,
+        )
+
+        result = await list_project_issue_custom_fields(
+            project_id="nonexistent-project-xyz-99999"
+        )
+
+        assert isinstance(result, list)
+        assert len(result) == 1
+        assert "error" in result[0]
+
+
+class TestSearchRedmineIssuesIntegration:
+    """Integration tests for search_redmine_issues tool."""
+
+    @pytest.mark.skipif(not REDMINE_URL, reason="REDMINE_URL not configured")
+    @pytest.mark.integration
+    @pytest.mark.asyncio
+    async def test_search_issues_basic(self):
+        """Test basic issue search."""
+        redmine = _get_redmine_or_none()
+        if redmine is None:
+            pytest.skip("Redmine client not initialized")
+
+        from redmine_mcp_server.redmine_handler import search_redmine_issues
+
+        result = await search_redmine_issues("test", limit=5)
+
+        assert isinstance(result, list)
+        for item in result:
+            if "error" in item:
+                pytest.fail(f"API error: {item['error']}")
+
+    @pytest.mark.skipif(not REDMINE_URL, reason="REDMINE_URL not configured")
+    @pytest.mark.integration
+    @pytest.mark.asyncio
+    async def test_search_issues_with_pagination(self):
+        """Test search with pagination info."""
+        redmine = _get_redmine_or_none()
+        if redmine is None:
+            pytest.skip("Redmine client not initialized")
+
+        from redmine_mcp_server.redmine_handler import search_redmine_issues
+
+        result = await search_redmine_issues(
+            "test", limit=2, include_pagination_info=True
+        )
+
+        assert isinstance(result, dict)
+        assert "issues" in result
+        assert "pagination" in result
+        assert isinstance(result["issues"], list)
+
+    @pytest.mark.skipif(not REDMINE_URL, reason="REDMINE_URL not configured")
+    @pytest.mark.integration
+    @pytest.mark.asyncio
+    async def test_search_issues_no_results(self):
+        """Test search with a query that returns no results."""
+        redmine = _get_redmine_or_none()
+        if redmine is None:
+            pytest.skip("Redmine client not initialized")
+
+        from redmine_mcp_server.redmine_handler import search_redmine_issues
+
+        result = await search_redmine_issues(
+            "zzz_nonexistent_xyzzy_999", limit=5
+        )
+
+        assert isinstance(result, list)
+        assert len(result) == 0
+
+
+class TestSummarizeProjectStatusIntegration:
+    """Integration tests for summarize_project_status tool."""
+
+    @pytest.mark.skipif(not REDMINE_URL, reason="REDMINE_URL not configured")
+    @pytest.mark.integration
+    @pytest.mark.asyncio
+    async def test_summarize_project_basic(self):
+        """Test basic project status summary."""
+        redmine = _get_redmine_or_none()
+        if redmine is None:
+            pytest.skip("Redmine client not initialized")
+
+        from redmine_mcp_server.redmine_handler import summarize_project_status
+
+        projects = list(redmine.project.all())
+        assert projects, "No projects available"
+
+        result = await summarize_project_status(
+            project_id=projects[0].id, days=30
+        )
+
+        assert isinstance(result, dict)
+        if "error" in result:
+            pytest.fail(f"API error: {result['error']}")
+
+        assert "project" in result
+        assert "analysis_period" in result
+
+    @pytest.mark.skipif(not REDMINE_URL, reason="REDMINE_URL not configured")
+    @pytest.mark.integration
+    @pytest.mark.asyncio
+    async def test_summarize_project_structure(self):
+        """Test that summary has expected structure."""
+        redmine = _get_redmine_or_none()
+        if redmine is None:
+            pytest.skip("Redmine client not initialized")
+
+        from redmine_mcp_server.redmine_handler import summarize_project_status
+
+        projects = list(redmine.project.all())
+        assert projects, "No projects available"
+
+        result = await summarize_project_status(
+            project_id=projects[0].id, days=7
+        )
+
+        assert isinstance(result, dict)
+        if "error" in result:
+            pytest.fail(f"API error: {result['error']}")
+
+        assert "project" in result
+        assert "analysis_period" in result
+        assert "project_totals" in result
+        assert "recent_activity" in result
+        assert "insights" in result
+        period = result["analysis_period"]
+        assert "days" in period
+        assert "start_date" in period
+        assert "end_date" in period
+        assert "total_issues" in result["project_totals"]
+
+    @pytest.mark.skipif(not REDMINE_URL, reason="REDMINE_URL not configured")
+    @pytest.mark.integration
+    @pytest.mark.asyncio
+    async def test_summarize_nonexistent_project(self):
+        """Test error handling for nonexistent project."""
+        redmine = _get_redmine_or_none()
+        if redmine is None:
+            pytest.skip("Redmine client not initialized")
+
+        from redmine_mcp_server.redmine_handler import summarize_project_status
+
+        result = await summarize_project_status(project_id=999999, days=30)
+
+        assert isinstance(result, dict)
+        assert "error" in result
+
+
+class TestSearchEntireRedmineIntegration:
+    """Integration tests for search_entire_redmine tool."""
+
+    @pytest.mark.skipif(not REDMINE_URL, reason="REDMINE_URL not configured")
+    @pytest.mark.integration
+    @pytest.mark.asyncio
+    async def test_search_entire_basic(self):
+        """Test basic cross-resource search."""
+        redmine = _get_redmine_or_none()
+        if redmine is None:
+            pytest.skip("Redmine client not initialized")
+
+        from redmine_mcp_server.redmine_handler import search_entire_redmine
+
+        result = await search_entire_redmine(query="test", limit=5)
+
+        assert isinstance(result, dict)
+        if "error" in result:
+            pytest.fail(f"API error: {result['error']}")
+
+        assert "results" in result
+        assert "total_count" in result
+
+    @pytest.mark.skipif(not REDMINE_URL, reason="REDMINE_URL not configured")
+    @pytest.mark.integration
+    @pytest.mark.asyncio
+    async def test_search_entire_filter_issues(self):
+        """Test searching only issues."""
+        redmine = _get_redmine_or_none()
+        if redmine is None:
+            pytest.skip("Redmine client not initialized")
+
+        from redmine_mcp_server.redmine_handler import search_entire_redmine
+
+        result = await search_entire_redmine(
+            query="test", resources=["issues"], limit=5
+        )
+
+        assert isinstance(result, dict)
+        if "error" in result:
+            pytest.fail(f"API error: {result['error']}")
+
+        assert "results" in result
+
+    @pytest.mark.skipif(not REDMINE_URL, reason="REDMINE_URL not configured")
+    @pytest.mark.integration
+    @pytest.mark.asyncio
+    async def test_search_entire_filter_wiki(self):
+        """Test searching only wiki pages."""
+        redmine = _get_redmine_or_none()
+        if redmine is None:
+            pytest.skip("Redmine client not initialized")
+
+        from redmine_mcp_server.redmine_handler import search_entire_redmine
+
+        result = await search_entire_redmine(
+            query="test", resources=["wiki_pages"], limit=5
+        )
+
+        assert isinstance(result, dict)
+        if "error" in result:
+            pytest.fail(f"API error: {result['error']}")
+
+        assert "results" in result
+
+    @pytest.mark.skipif(not REDMINE_URL, reason="REDMINE_URL not configured")
+    @pytest.mark.integration
+    @pytest.mark.asyncio
+    async def test_search_entire_no_results(self):
+        """Test search that returns no results."""
+        redmine = _get_redmine_or_none()
+        if redmine is None:
+            pytest.skip("Redmine client not initialized")
+
+        from redmine_mcp_server.redmine_handler import search_entire_redmine
+
+        result = await search_entire_redmine(
+            query="zzz_nonexistent_xyzzy_999", limit=5
+        )
+
+        assert isinstance(result, dict)
+        if "error" in result:
+            pytest.fail(f"API error: {result['error']}")
+
+        assert result["total_count"] == 0
+
+
+class TestCleanupAttachmentFilesIntegration:
+    """Integration tests for cleanup_attachment_files tool."""
+
+    @pytest.mark.skipif(not REDMINE_URL, reason="REDMINE_URL not configured")
+    @pytest.mark.integration
+    @pytest.mark.asyncio
+    async def test_cleanup_basic(self):
+        """Test cleanup returns expected structure."""
+        redmine = _get_redmine_or_none()
+        if redmine is None:
+            pytest.skip("Redmine client not initialized")
+
+        from redmine_mcp_server.redmine_handler import cleanup_attachment_files
+
+        result = await cleanup_attachment_files()
+
+        assert isinstance(result, dict)
+        if "error" in result:
+            pytest.fail(f"API error: {result['error']}")
+
+        assert "cleanup" in result
+        assert "current_storage" in result
+
+    @pytest.mark.skipif(not REDMINE_URL, reason="REDMINE_URL not configured")
+    @pytest.mark.integration
+    @pytest.mark.asyncio
+    async def test_cleanup_structure(self):
+        """Test cleanup stats have expected keys."""
+        redmine = _get_redmine_or_none()
+        if redmine is None:
+            pytest.skip("Redmine client not initialized")
+
+        from redmine_mcp_server.redmine_handler import cleanup_attachment_files
+
+        result = await cleanup_attachment_files()
+
+        assert isinstance(result, dict)
+        if "error" in result:
+            pytest.fail(f"API error: {result['error']}")
+
+        cleanup = result["cleanup"]
+        assert "cleaned_files" in cleanup
+        assert isinstance(cleanup["cleaned_files"], int)
+
+        storage = result["current_storage"]
+        assert "total_files" in storage or "file_count" in storage
 
 
 if __name__ == "__main__":

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -16,6 +16,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 from redmine_mcp_server.redmine_handler import (  # noqa: E402
     _get_redmine_client,
     REDMINE_URL,
+    list_time_entry_activities,
 )
 
 
@@ -1856,6 +1857,40 @@ class TestCleanupAttachmentFilesIntegration:
 
         storage = result["current_storage"]
         assert "total_files" in storage or "file_count" in storage
+
+
+class TestEnumerationsIntegration:
+    """Integration tests for enumeration/lookup tools."""
+
+    @pytest.mark.skipif(not REDMINE_URL, reason="REDMINE_URL not configured")
+    @pytest.mark.integration
+    @pytest.mark.asyncio
+    async def test_list_time_entry_activities(self):
+        redmine = _get_redmine_or_none()
+        if redmine is None:
+            pytest.skip("Redmine client not initialized")
+
+        result = await list_time_entry_activities()
+        assert isinstance(result, list)
+        assert len(result) > 0, "Should have at least one activity"
+
+    @pytest.mark.skipif(not REDMINE_URL, reason="REDMINE_URL not configured")
+    @pytest.mark.integration
+    @pytest.mark.asyncio
+    async def test_list_time_entry_activities_structure(self):
+        redmine = _get_redmine_or_none()
+        if redmine is None:
+            pytest.skip("Redmine client not initialized")
+
+        result = await list_time_entry_activities()
+        assert len(result) > 0
+        activity = result[0]
+        assert "id" in activity
+        assert "name" in activity
+        assert "active" in activity
+        assert "is_default" in activity
+        assert isinstance(activity["id"], int)
+        assert isinstance(activity["name"], str)
 
 
 if __name__ == "__main__":

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1273,6 +1273,8 @@ class TestTimeEntriesIntegration:
         assert isinstance(result, list)
         for entry in result:
             if "error" in entry:
+                if "denied" in entry["error"].lower():
+                    pytest.skip(f"Time tracking not permitted: {entry['error']}")
                 pytest.fail(f"API error: {entry['error']}")
 
     @pytest.mark.skipif(not REDMINE_URL, reason="REDMINE_URL not configured")
@@ -1296,7 +1298,10 @@ class TestTimeEntriesIntegration:
 
         assert isinstance(result, list)
         for entry in result:
-            assert "error" not in entry
+            if "error" in entry:
+                if "denied" in entry["error"].lower():
+                    pytest.skip(f"Time tracking not permitted: {entry['error']}")
+                pytest.fail(f"API error: {entry['error']}")
 
     @pytest.mark.skipif(not REDMINE_URL, reason="REDMINE_URL not configured")
     @pytest.mark.integration
@@ -1313,7 +1318,10 @@ class TestTimeEntriesIntegration:
 
         assert isinstance(result, list)
         for entry in result:
-            assert "error" not in entry
+            if "error" in entry:
+                if "denied" in entry["error"].lower():
+                    pytest.skip(f"Time tracking not permitted: {entry['error']}")
+                pytest.fail(f"API error: {entry['error']}")
 
     @pytest.mark.skipif(not REDMINE_URL, reason="REDMINE_URL not configured")
     @pytest.mark.integration
@@ -1333,6 +1341,10 @@ class TestTimeEntriesIntegration:
             pytest.skip("No time entries found for testing")
 
         entry = result[0]
+        if "error" in entry:
+            if "denied" in entry["error"].lower():
+                pytest.skip(f"Time tracking not permitted: {entry['error']}")
+            pytest.fail(f"API error: {entry['error']}")
         assert "id" in entry
         assert "hours" in entry
         assert "comments" in entry
@@ -1355,9 +1367,14 @@ class TestTimeEntriesIntegration:
         from redmine_mcp_server.redmine_handler import list_time_entries
 
         page1 = await list_time_entries(limit=3, offset=0)
-        page2 = await list_time_entries(limit=3, offset=3)
 
         assert isinstance(page1, list)
+        if page1 and "error" in page1[0]:
+            if "denied" in page1[0]["error"].lower():
+                pytest.skip(f"Time tracking not permitted: {page1[0]['error']}")
+
+        page2 = await list_time_entries(limit=3, offset=3)
+
         assert isinstance(page2, list)
         assert len(page1) <= 3
 
@@ -1380,11 +1397,29 @@ class TestTimeEntriesIntegration:
             update_time_entry,
         )
 
+        import requests as req
+        from redmine_mcp_server.redmine_handler import REDMINE_URL
+
         # Pick the first available project
         projects = list(redmine.project.all())
         if not projects:
             pytest.skip("No projects available for testing")
         project_id = projects[0].id
+
+        # Find an activity_id (required by some Redmine configs)
+        api_key = os.getenv("REDMINE_API_KEY", "")
+        act_resp = req.get(
+            f"{REDMINE_URL}/enumerations/time_entry_activities.json",
+            headers={"X-Redmine-API-Key": api_key},
+        )
+        activities = (
+            act_resp.json().get("time_entry_activities", [])
+            if act_resp.status_code == 200
+            else []
+        )
+        if not activities:
+            pytest.skip("No time entry activities configured in Redmine")
+        activity_id = activities[0]["id"]
 
         time_entry_id = None
         try:
@@ -1392,6 +1427,7 @@ class TestTimeEntriesIntegration:
             create_result = await create_time_entry(
                 hours=0.25,
                 project_id=project_id,
+                activity_id=activity_id,
                 comments="Integration test time entry",
             )
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1156,6 +1156,304 @@ class TestListRedmineVersionsIntegration:
         assert "error" in result[0]
 
 
+class TestListProjectMembersIntegration:
+    """Integration tests for list_project_members tool."""
+
+    @pytest.mark.skipif(not REDMINE_URL, reason="REDMINE_URL not configured")
+    @pytest.mark.integration
+    @pytest.mark.asyncio
+    async def test_list_members_by_project_id(self):
+        """Test listing members for a project by numeric ID."""
+        redmine = _get_redmine_or_none()
+        if redmine is None:
+            pytest.skip("Redmine client not initialized")
+
+        from redmine_mcp_server.redmine_handler import list_project_members
+
+        projects = list(redmine.project.all())
+        if not projects:
+            pytest.skip("No projects available for testing")
+
+        project_id = projects[0].id
+        result = await list_project_members(project_id=project_id)
+
+        assert isinstance(result, list)
+        for member in result:
+            if "error" in member:
+                pytest.fail(f"API error: {member['error']}")
+
+    @pytest.mark.skipif(not REDMINE_URL, reason="REDMINE_URL not configured")
+    @pytest.mark.integration
+    @pytest.mark.asyncio
+    async def test_list_members_by_string_identifier(self):
+        """Test listing members using a string project identifier."""
+        redmine = _get_redmine_or_none()
+        if redmine is None:
+            pytest.skip("Redmine client not initialized")
+
+        from redmine_mcp_server.redmine_handler import list_project_members
+
+        projects = list(redmine.project.all())
+        if not projects:
+            pytest.skip("No projects available for testing")
+
+        identifier = projects[0].identifier
+        result = await list_project_members(project_id=identifier)
+
+        assert isinstance(result, list)
+        for member in result:
+            assert "error" not in member
+
+    @pytest.mark.skipif(not REDMINE_URL, reason="REDMINE_URL not configured")
+    @pytest.mark.integration
+    @pytest.mark.asyncio
+    async def test_list_members_structure(self):
+        """Test that returned membership dicts have expected keys."""
+        redmine = _get_redmine_or_none()
+        if redmine is None:
+            pytest.skip("Redmine client not initialized")
+
+        from redmine_mcp_server.redmine_handler import list_project_members
+
+        projects = list(redmine.project.all())
+        if not projects:
+            pytest.skip("No projects available for testing")
+
+        result = await list_project_members(project_id=projects[0].id)
+
+        assert isinstance(result, list)
+        if not result:
+            pytest.skip("No members found in first project")
+
+        member = result[0]
+        assert "id" in member
+        assert "roles" in member
+        assert isinstance(member["roles"], list)
+        # Must have either user or group
+        assert member["user"] is not None or member["group"] is not None
+
+        if member["user"] is not None:
+            assert "id" in member["user"]
+            assert "name" in member["user"]
+
+    @pytest.mark.skipif(not REDMINE_URL, reason="REDMINE_URL not configured")
+    @pytest.mark.integration
+    @pytest.mark.asyncio
+    async def test_list_members_nonexistent_project(self):
+        """Test error handling for a project that doesn't exist."""
+        redmine = _get_redmine_or_none()
+        if redmine is None:
+            pytest.skip("Redmine client not initialized")
+
+        from redmine_mcp_server.redmine_handler import list_project_members
+
+        result = await list_project_members(project_id=999999)
+
+        assert isinstance(result, list)
+        assert len(result) == 1
+        assert "error" in result[0]
+
+
+class TestTimeEntriesIntegration:
+    """Integration tests for time entry tools."""
+
+    @pytest.mark.skipif(not REDMINE_URL, reason="REDMINE_URL not configured")
+    @pytest.mark.integration
+    @pytest.mark.asyncio
+    async def test_list_time_entries_no_filters(self):
+        """Test listing time entries without filters."""
+        redmine = _get_redmine_or_none()
+        if redmine is None:
+            pytest.skip("Redmine client not initialized")
+
+        from redmine_mcp_server.redmine_handler import list_time_entries
+
+        result = await list_time_entries(limit=5)
+
+        assert isinstance(result, list)
+        for entry in result:
+            if "error" in entry:
+                pytest.fail(f"API error: {entry['error']}")
+
+    @pytest.mark.skipif(not REDMINE_URL, reason="REDMINE_URL not configured")
+    @pytest.mark.integration
+    @pytest.mark.asyncio
+    async def test_list_time_entries_by_project(self):
+        """Test filtering time entries by project."""
+        redmine = _get_redmine_or_none()
+        if redmine is None:
+            pytest.skip("Redmine client not initialized")
+
+        from redmine_mcp_server.redmine_handler import list_time_entries
+
+        projects = list(redmine.project.all())
+        if not projects:
+            pytest.skip("No projects available for testing")
+
+        result = await list_time_entries(
+            project_id=projects[0].identifier, limit=5
+        )
+
+        assert isinstance(result, list)
+        for entry in result:
+            assert "error" not in entry
+
+    @pytest.mark.skipif(not REDMINE_URL, reason="REDMINE_URL not configured")
+    @pytest.mark.integration
+    @pytest.mark.asyncio
+    async def test_list_time_entries_by_current_user(self):
+        """Test filtering time entries by current user."""
+        redmine = _get_redmine_or_none()
+        if redmine is None:
+            pytest.skip("Redmine client not initialized")
+
+        from redmine_mcp_server.redmine_handler import list_time_entries
+
+        result = await list_time_entries(user_id="me", limit=5)
+
+        assert isinstance(result, list)
+        for entry in result:
+            assert "error" not in entry
+
+    @pytest.mark.skipif(not REDMINE_URL, reason="REDMINE_URL not configured")
+    @pytest.mark.integration
+    @pytest.mark.asyncio
+    async def test_list_time_entries_structure(self):
+        """Test that returned time entry dicts have expected keys."""
+        redmine = _get_redmine_or_none()
+        if redmine is None:
+            pytest.skip("Redmine client not initialized")
+
+        from redmine_mcp_server.redmine_handler import list_time_entries
+
+        result = await list_time_entries(limit=1)
+
+        assert isinstance(result, list)
+        if not result:
+            pytest.skip("No time entries found for testing")
+
+        entry = result[0]
+        assert "id" in entry
+        assert "hours" in entry
+        assert "comments" in entry
+        assert "spent_on" in entry
+        assert "user" in entry
+        assert "project" in entry
+        assert "activity" in entry
+        assert isinstance(entry["id"], int)
+        assert isinstance(entry["hours"], (int, float))
+
+    @pytest.mark.skipif(not REDMINE_URL, reason="REDMINE_URL not configured")
+    @pytest.mark.integration
+    @pytest.mark.asyncio
+    async def test_list_time_entries_pagination(self):
+        """Test pagination with limit and offset."""
+        redmine = _get_redmine_or_none()
+        if redmine is None:
+            pytest.skip("Redmine client not initialized")
+
+        from redmine_mcp_server.redmine_handler import list_time_entries
+
+        page1 = await list_time_entries(limit=3, offset=0)
+        page2 = await list_time_entries(limit=3, offset=3)
+
+        assert isinstance(page1, list)
+        assert isinstance(page2, list)
+        assert len(page1) <= 3
+
+        if page1 and page2:
+            page1_ids = {e["id"] for e in page1 if "id" in e}
+            page2_ids = {e["id"] for e in page2 if "id" in e}
+            assert page1_ids.isdisjoint(page2_ids), "Pages should not overlap"
+
+    @pytest.mark.skipif(not REDMINE_URL, reason="REDMINE_URL not configured")
+    @pytest.mark.integration
+    @pytest.mark.asyncio
+    async def test_create_update_time_entry_lifecycle(self):
+        """Integration test for creating and updating a time entry."""
+        redmine = _get_redmine_or_none()
+        if redmine is None:
+            pytest.skip("Redmine client not initialized")
+
+        from redmine_mcp_server.redmine_handler import (
+            create_time_entry,
+            update_time_entry,
+        )
+
+        # Pick the first available project
+        projects = list(redmine.project.all())
+        if not projects:
+            pytest.skip("No projects available for testing")
+        project_id = projects[0].id
+
+        time_entry_id = None
+        try:
+            # 1. Create a time entry
+            create_result = await create_time_entry(
+                hours=0.25,
+                project_id=project_id,
+                comments="Integration test time entry",
+            )
+
+            if "error" in create_result:
+                if (
+                    "denied" in create_result["error"].lower()
+                    or "forbidden" in create_result["error"].lower()
+                ):
+                    pytest.skip(
+                        f"Time tracking not permitted: {create_result['error']}"
+                    )
+                pytest.fail(f"Failed to create time entry: {create_result['error']}")
+
+            assert "id" in create_result
+            assert create_result["hours"] == 0.25
+            time_entry_id = create_result["id"]
+
+            # 2. Update the time entry
+            update_result = await update_time_entry(
+                time_entry_id=time_entry_id,
+                hours=0.5,
+                comments="Integration test time entry (updated)",
+            )
+
+            if "error" in update_result:
+                pytest.fail(f"Failed to update time entry: {update_result['error']}")
+
+            assert update_result["id"] == time_entry_id
+            assert update_result["hours"] == 0.5
+
+        except Exception as e:
+            pytest.fail(f"Integration test failed: {e}")
+        finally:
+            # Clean up
+            if time_entry_id is not None:
+                try:
+                    redmine.time_entry.delete(time_entry_id)
+                except Exception:
+                    pass  # Best effort cleanup
+
+    @pytest.mark.skipif(not REDMINE_URL, reason="REDMINE_URL not configured")
+    @pytest.mark.integration
+    @pytest.mark.asyncio
+    async def test_create_time_entry_validation(self):
+        """Test that validation errors are returned correctly."""
+        redmine = _get_redmine_or_none()
+        if redmine is None:
+            pytest.skip("Redmine client not initialized")
+
+        from redmine_mcp_server.redmine_handler import create_time_entry
+
+        # Missing both project_id and issue_id
+        result = await create_time_entry(hours=1.0)
+        assert "error" in result
+        assert "project_id or issue_id" in result["error"]
+
+        # Negative hours
+        result = await create_time_entry(hours=-1.0, project_id=1)
+        assert "error" in result
+        assert "positive" in result["error"]
+
+
 if __name__ == "__main__":
     # Run integration tests
     pytest.main([__file__, "-v", "-m", "integration", "--tb=short"])

--- a/tests/test_project_members.py
+++ b/tests/test_project_members.py
@@ -6,13 +6,8 @@ Tests for listing project memberships including users, groups, and roles.
 
 import pytest
 from unittest.mock import Mock, patch
-import os
-import sys
 
-# Add the src directory to the path
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
-
-from redmine_mcp_server.redmine_handler import (  # noqa: E402
+from redmine_mcp_server.redmine_handler import (
     list_project_members,
     _membership_to_dict,
 )
@@ -218,15 +213,17 @@ class TestListProjectMembers:
         assert len(result) == 0
 
     @pytest.mark.asyncio
-    async def test_list_members_redmine_not_initialized(self, mock_redmine):
+    async def test_list_members_redmine_not_initialized(self):
         """Test error when Redmine client is not initialized."""
-        with patch("redmine_mcp_server.redmine_handler.redmine", None):
+        with patch(
+            "redmine_mcp_server.redmine_handler._get_redmine_client",
+            side_effect=RuntimeError("No Redmine authentication available"),
+        ):
             result = await list_project_members(project_id=10)
 
         assert isinstance(result, list)
         assert len(result) == 1
         assert "error" in result[0]
-        assert "not initialized" in result[0]["error"]
 
     @pytest.mark.asyncio
     async def test_list_members_project_not_found(self, mock_redmine):

--- a/tests/test_project_members.py
+++ b/tests/test_project_members.py
@@ -1,0 +1,278 @@
+"""
+Test cases for list_project_members tool.
+
+Tests for listing project memberships including users, groups, and roles.
+"""
+
+import pytest
+from unittest.mock import Mock, patch
+import os
+import sys
+
+# Add the src directory to the path
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from redmine_mcp_server.redmine_handler import (  # noqa: E402
+    list_project_members,
+    _membership_to_dict,
+)
+
+
+def make_mock_with_name(id_val, name_val):
+    """Helper to create a Mock with a name attribute (not Mock's internal name)."""
+    m = Mock()
+    m.id = id_val
+    m.name = name_val
+    return m
+
+
+class TestMembershipToDict:
+    """Test cases for _membership_to_dict helper function."""
+
+    def test_user_membership(self):
+        """Test converting a user membership to dict."""
+        mock_membership = Mock()
+        mock_membership.id = 1
+        mock_membership.user = make_mock_with_name(5, "John Doe")
+        mock_membership.group = None
+        mock_membership.project = make_mock_with_name(10, "Test Project")
+        mock_membership.roles = [make_mock_with_name(3, "Developer")]
+
+        result = _membership_to_dict(mock_membership)
+
+        assert result["id"] == 1
+        assert result["user"] == {"id": 5, "name": "John Doe"}
+        assert result["group"] is None
+        assert result["project"] == {"id": 10, "name": "Test Project"}
+        assert len(result["roles"]) == 1
+        assert result["roles"][0] == {"id": 3, "name": "Developer"}
+
+    def test_group_membership(self):
+        """Test converting a group membership to dict."""
+        mock_membership = Mock()
+        mock_membership.id = 2
+        mock_membership.user = None
+        mock_membership.group = make_mock_with_name(15, "Dev Team")
+        mock_membership.project = make_mock_with_name(10, "Test Project")
+        mock_membership.roles = [make_mock_with_name(4, "Manager")]
+
+        result = _membership_to_dict(mock_membership)
+
+        assert result["id"] == 2
+        assert result["user"] is None
+        assert result["group"] == {"id": 15, "name": "Dev Team"}
+        assert result["project"] == {"id": 10, "name": "Test Project"}
+        assert len(result["roles"]) == 1
+        assert result["roles"][0] == {"id": 4, "name": "Manager"}
+
+    def test_multiple_roles(self):
+        """Test membership with multiple roles."""
+        mock_membership = Mock()
+        mock_membership.id = 3
+        mock_membership.user = make_mock_with_name(5, "John Doe")
+        mock_membership.group = None
+        mock_membership.project = make_mock_with_name(10, "Test Project")
+        mock_membership.roles = [
+            make_mock_with_name(3, "Developer"),
+            make_mock_with_name(4, "Reporter"),
+        ]
+
+        result = _membership_to_dict(mock_membership)
+
+        assert len(result["roles"]) == 2
+        assert result["roles"][0] == {"id": 3, "name": "Developer"}
+        assert result["roles"][1] == {"id": 4, "name": "Reporter"}
+
+    def test_no_roles(self):
+        """Test membership with no roles."""
+        mock_membership = Mock()
+        mock_membership.id = 4
+        mock_membership.user = make_mock_with_name(5, "John Doe")
+        mock_membership.group = None
+        mock_membership.project = make_mock_with_name(10, "Test Project")
+        mock_membership.roles = []
+
+        result = _membership_to_dict(mock_membership)
+
+        assert result["roles"] == []
+
+    def test_dict_format_roles(self):
+        """Test roles in dict format (some Redmine versions)."""
+        mock_membership = Mock()
+        mock_membership.id = 5
+        mock_membership.user = make_mock_with_name(5, "John Doe")
+        mock_membership.group = None
+        mock_membership.project = make_mock_with_name(10, "Test Project")
+        mock_membership.roles = [{"id": 3, "name": "Developer"}]
+
+        result = _membership_to_dict(mock_membership)
+
+        assert len(result["roles"]) == 1
+        assert result["roles"][0] == {"id": 3, "name": "Developer"}
+
+    def test_missing_attributes(self):
+        """Test handling of missing attributes."""
+        mock_membership = Mock(spec=[])  # Empty spec, no attributes
+        mock_membership.id = None
+        mock_membership.user = None
+        mock_membership.group = None
+        mock_membership.project = None
+        mock_membership.roles = None
+
+        result = _membership_to_dict(mock_membership)
+
+        assert result["id"] is None
+        assert result["user"] is None
+        assert result["group"] is None
+        assert result["project"] is None
+        assert result["roles"] == []
+
+
+class TestListProjectMembers:
+    """Test cases for list_project_members tool."""
+
+    @pytest.fixture
+    def mock_redmine(self):
+        """Create a mock Redmine client."""
+        with patch("redmine_mcp_server.redmine_handler.redmine") as mock:
+            yield mock
+
+    def create_mock_membership(
+        self, membership_id=1, user_id=5, user_name="John Doe", is_group=False
+    ):
+        """Create a single mock membership."""
+        mock_membership = Mock()
+        mock_membership.id = membership_id
+
+        if is_group:
+            mock_membership.user = None
+            mock_membership.group = make_mock_with_name(user_id, user_name)
+        else:
+            mock_membership.user = make_mock_with_name(user_id, user_name)
+            mock_membership.group = None
+
+        mock_membership.project = make_mock_with_name(10, "Test Project")
+        mock_membership.roles = [make_mock_with_name(3, "Developer")]
+
+        return mock_membership
+
+    @pytest.mark.asyncio
+    async def test_list_members_by_project_id(self, mock_redmine):
+        """Test listing project members by numeric project ID."""
+        mock_memberships = [
+            self.create_mock_membership(1, 5, "John Doe"),
+            self.create_mock_membership(2, 6, "Jane Smith"),
+        ]
+        mock_redmine.project_membership.filter.return_value = mock_memberships
+
+        result = await list_project_members(project_id=10)
+
+        assert isinstance(result, list)
+        assert len(result) == 2
+        assert result[0]["user"]["name"] == "John Doe"
+        assert result[1]["user"]["name"] == "Jane Smith"
+        mock_redmine.project_membership.filter.assert_called_once_with(project_id=10)
+
+    @pytest.mark.asyncio
+    async def test_list_members_by_project_identifier(self, mock_redmine):
+        """Test listing project members by string project identifier."""
+        mock_memberships = [self.create_mock_membership(1, 5, "John Doe")]
+        mock_redmine.project_membership.filter.return_value = mock_memberships
+
+        result = await list_project_members(project_id="my-project")
+
+        assert isinstance(result, list)
+        assert len(result) == 1
+        mock_redmine.project_membership.filter.assert_called_once_with(
+            project_id="my-project"
+        )
+
+    @pytest.mark.asyncio
+    async def test_list_members_includes_groups(self, mock_redmine):
+        """Test that group memberships are included."""
+        mock_memberships = [
+            self.create_mock_membership(1, 5, "John Doe", is_group=False),
+            self.create_mock_membership(2, 15, "Dev Team", is_group=True),
+        ]
+        mock_redmine.project_membership.filter.return_value = mock_memberships
+
+        result = await list_project_members(project_id=10)
+
+        assert len(result) == 2
+        # First is a user
+        assert result[0]["user"] is not None
+        assert result[0]["group"] is None
+        # Second is a group
+        assert result[1]["user"] is None
+        assert result[1]["group"] is not None
+        assert result[1]["group"]["name"] == "Dev Team"
+
+    @pytest.mark.asyncio
+    async def test_list_members_empty_project(self, mock_redmine):
+        """Test listing members of a project with no members."""
+        mock_redmine.project_membership.filter.return_value = []
+
+        result = await list_project_members(project_id=10)
+
+        assert isinstance(result, list)
+        assert len(result) == 0
+
+    @pytest.mark.asyncio
+    async def test_list_members_redmine_not_initialized(self, mock_redmine):
+        """Test error when Redmine client is not initialized."""
+        with patch("redmine_mcp_server.redmine_handler.redmine", None):
+            result = await list_project_members(project_id=10)
+
+        assert isinstance(result, list)
+        assert len(result) == 1
+        assert "error" in result[0]
+        assert "not initialized" in result[0]["error"]
+
+    @pytest.mark.asyncio
+    async def test_list_members_project_not_found(self, mock_redmine):
+        """Test error when project is not found."""
+        from redminelib.exceptions import ResourceNotFoundError
+
+        mock_redmine.project_membership.filter.side_effect = ResourceNotFoundError()
+
+        result = await list_project_members(project_id=999)
+
+        assert isinstance(result, list)
+        assert len(result) == 1
+        assert "error" in result[0]
+
+    @pytest.mark.asyncio
+    async def test_list_members_forbidden(self, mock_redmine):
+        """Test error when user lacks permission."""
+        from redminelib.exceptions import ForbiddenError
+
+        mock_redmine.project_membership.filter.side_effect = ForbiddenError()
+
+        result = await list_project_members(project_id=10)
+
+        assert isinstance(result, list)
+        assert len(result) == 1
+        assert "error" in result[0]
+        assert "Access denied" in result[0]["error"]
+
+    @pytest.mark.asyncio
+    async def test_list_members_includes_roles(self, mock_redmine):
+        """Test that roles are included in membership data."""
+        mock_membership = Mock()
+        mock_membership.id = 1
+        mock_membership.user = make_mock_with_name(5, "John Doe")
+        mock_membership.group = None
+        mock_membership.project = make_mock_with_name(10, "Test Project")
+        mock_membership.roles = [
+            make_mock_with_name(3, "Developer"),
+            make_mock_with_name(4, "Reporter"),
+        ]
+        mock_redmine.project_membership.filter.return_value = [mock_membership]
+
+        result = await list_project_members(project_id=10)
+
+        assert len(result) == 1
+        assert len(result[0]["roles"]) == 2
+        role_names = [r["name"] for r in result[0]["roles"]]
+        assert "Developer" in role_names
+        assert "Reporter" in role_names

--- a/tests/test_time_entries.py
+++ b/tests/test_time_entries.py
@@ -1,0 +1,550 @@
+"""
+Test cases for time entry tools.
+
+Tests for list_time_entries, create_time_entry, and update_time_entry tools.
+"""
+
+import pytest
+from unittest.mock import Mock, patch
+from datetime import datetime
+import os
+import sys
+
+# Add the src directory to the path
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from redmine_mcp_server.redmine_handler import (  # noqa: E402
+    list_time_entries,
+    create_time_entry,
+    update_time_entry,
+    _time_entry_to_dict,
+)
+
+
+def make_mock_with_name(id_val, name_val):
+    """Helper to create a Mock with a name attribute (not Mock's internal name)."""
+    m = Mock()
+    m.id = id_val
+    m.name = name_val
+    return m
+
+
+class TestTimeEntryToDict:
+    """Test cases for _time_entry_to_dict helper function."""
+
+    def test_complete_time_entry(self):
+        """Test converting a complete time entry to dict."""
+        mock_entry = Mock()
+        mock_entry.id = 1
+        mock_entry.hours = 2.5
+        mock_entry.comments = "Bug fix work"
+        mock_entry.spent_on = "2024-03-15"
+        mock_entry.user = make_mock_with_name(5, "John Doe")
+        mock_entry.project = make_mock_with_name(10, "Test Project")
+        mock_entry.issue = Mock(id=123)
+        mock_entry.activity = make_mock_with_name(9, "Development")
+        mock_entry.created_on = datetime(2024, 3, 15, 10, 30, 0)
+        mock_entry.updated_on = datetime(2024, 3, 15, 14, 0, 0)
+
+        result = _time_entry_to_dict(mock_entry)
+
+        assert result["id"] == 1
+        assert result["hours"] == 2.5
+        assert result["comments"] == "Bug fix work"
+        assert result["spent_on"] == "2024-03-15"
+        assert result["user"] == {"id": 5, "name": "John Doe"}
+        assert result["project"] == {"id": 10, "name": "Test Project"}
+        assert result["issue"] == {"id": 123}
+        assert result["activity"] == {"id": 9, "name": "Development"}
+        assert result["created_on"] is not None
+        assert result["updated_on"] is not None
+
+    def test_time_entry_without_issue(self):
+        """Test time entry logged against project without issue."""
+        mock_entry = Mock()
+        mock_entry.id = 2
+        mock_entry.hours = 1.0
+        mock_entry.comments = "Project meeting"
+        mock_entry.spent_on = "2024-03-15"
+        mock_entry.user = make_mock_with_name(5, "John Doe")
+        mock_entry.project = make_mock_with_name(10, "Test Project")
+        mock_entry.issue = None
+        mock_entry.activity = make_mock_with_name(10, "Meeting")
+        mock_entry.created_on = None
+        mock_entry.updated_on = None
+
+        result = _time_entry_to_dict(mock_entry)
+
+        assert result["id"] == 2
+        assert result["issue"] is None
+        assert result["project"] == {"id": 10, "name": "Test Project"}
+
+    def test_time_entry_minimal(self):
+        """Test time entry with minimal data."""
+        mock_entry = Mock()
+        mock_entry.id = 3
+        mock_entry.hours = 0.5
+        mock_entry.comments = ""
+        mock_entry.spent_on = None
+        mock_entry.user = None
+        mock_entry.project = None
+        mock_entry.issue = None
+        mock_entry.activity = None
+        mock_entry.created_on = None
+        mock_entry.updated_on = None
+
+        result = _time_entry_to_dict(mock_entry)
+
+        assert result["id"] == 3
+        assert result["hours"] == 0.5
+        assert result["comments"] == ""
+        assert result["spent_on"] is None
+        assert result["user"] is None
+        assert result["project"] is None
+        assert result["issue"] is None
+        assert result["activity"] is None
+
+
+class TestListTimeEntries:
+    """Test cases for list_time_entries tool."""
+
+    @pytest.fixture
+    def mock_redmine(self):
+        """Create a mock Redmine client."""
+        with patch("redmine_mcp_server.redmine_handler.redmine") as mock:
+            yield mock
+
+    def create_mock_time_entry(
+        self, entry_id=1, hours=2.0, project_id=10, issue_id=None
+    ):
+        """Create a single mock time entry."""
+        mock_entry = Mock()
+        mock_entry.id = entry_id
+        mock_entry.hours = hours
+        mock_entry.comments = f"Work on entry {entry_id}"
+        mock_entry.spent_on = "2024-03-15"
+        mock_entry.user = make_mock_with_name(5, "John Doe")
+        mock_entry.project = make_mock_with_name(project_id, "Test Project")
+        mock_entry.issue = Mock(id=issue_id) if issue_id else None
+        mock_entry.activity = make_mock_with_name(9, "Development")
+        mock_entry.created_on = datetime(2024, 3, 15, 10, 0, 0)
+        mock_entry.updated_on = datetime(2024, 3, 15, 10, 0, 0)
+        return mock_entry
+
+    @pytest.mark.asyncio
+    async def test_list_all_time_entries(self, mock_redmine):
+        """Test listing time entries without filters."""
+        mock_entries = [
+            self.create_mock_time_entry(1, 2.0),
+            self.create_mock_time_entry(2, 1.5),
+        ]
+        mock_redmine.time_entry.filter.return_value = mock_entries
+
+        result = await list_time_entries()
+
+        assert isinstance(result, list)
+        assert len(result) == 2
+        assert result[0]["hours"] == 2.0
+        assert result[1]["hours"] == 1.5
+
+    @pytest.mark.asyncio
+    async def test_list_time_entries_by_project(self, mock_redmine):
+        """Test filtering time entries by project."""
+        mock_entries = [self.create_mock_time_entry(1, 2.0, project_id=10)]
+        mock_redmine.time_entry.filter.return_value = mock_entries
+
+        result = await list_time_entries(project_id=10)
+
+        assert len(result) == 1
+        call_kwargs = mock_redmine.time_entry.filter.call_args[1]
+        assert call_kwargs["project_id"] == 10
+
+    @pytest.mark.asyncio
+    async def test_list_time_entries_by_project_identifier(self, mock_redmine):
+        """Test filtering by string project identifier."""
+        mock_entries = [self.create_mock_time_entry(1, 2.0)]
+        mock_redmine.time_entry.filter.return_value = mock_entries
+
+        await list_time_entries(project_id="my-project")
+
+        call_kwargs = mock_redmine.time_entry.filter.call_args[1]
+        assert call_kwargs["project_id"] == "my-project"
+
+    @pytest.mark.asyncio
+    async def test_list_time_entries_by_issue(self, mock_redmine):
+        """Test filtering time entries by issue."""
+        mock_entries = [self.create_mock_time_entry(1, 2.0, issue_id=123)]
+        mock_redmine.time_entry.filter.return_value = mock_entries
+
+        result = await list_time_entries(issue_id=123)
+
+        assert len(result) == 1
+        call_kwargs = mock_redmine.time_entry.filter.call_args[1]
+        assert call_kwargs["issue_id"] == 123
+
+    @pytest.mark.asyncio
+    async def test_list_time_entries_by_user(self, mock_redmine):
+        """Test filtering time entries by user."""
+        mock_entries = [self.create_mock_time_entry(1, 2.0)]
+        mock_redmine.time_entry.filter.return_value = mock_entries
+
+        await list_time_entries(user_id=5)
+
+        call_kwargs = mock_redmine.time_entry.filter.call_args[1]
+        assert call_kwargs["user_id"] == 5
+
+    @pytest.mark.asyncio
+    async def test_list_time_entries_by_current_user(self, mock_redmine):
+        """Test filtering time entries by 'me' for current user."""
+        mock_entries = [self.create_mock_time_entry(1, 2.0)]
+        mock_redmine.time_entry.filter.return_value = mock_entries
+
+        await list_time_entries(user_id="me")
+
+        call_kwargs = mock_redmine.time_entry.filter.call_args[1]
+        assert call_kwargs["user_id"] == "me"
+
+    @pytest.mark.asyncio
+    async def test_list_time_entries_date_range(self, mock_redmine):
+        """Test filtering time entries by date range."""
+        mock_entries = [self.create_mock_time_entry(1, 2.0)]
+        mock_redmine.time_entry.filter.return_value = mock_entries
+
+        await list_time_entries(from_date="2024-01-01", to_date="2024-03-31")
+
+        call_kwargs = mock_redmine.time_entry.filter.call_args[1]
+        assert call_kwargs["from_date"] == "2024-01-01"
+        assert call_kwargs["to_date"] == "2024-03-31"
+
+    @pytest.mark.asyncio
+    async def test_list_time_entries_pagination(self, mock_redmine):
+        """Test pagination with limit and offset."""
+        mock_entries = [self.create_mock_time_entry(1, 2.0)]
+        mock_redmine.time_entry.filter.return_value = mock_entries
+
+        await list_time_entries(limit=10, offset=20)
+
+        call_kwargs = mock_redmine.time_entry.filter.call_args[1]
+        assert call_kwargs["limit"] == 10
+        assert call_kwargs["offset"] == 20
+
+    @pytest.mark.asyncio
+    async def test_list_time_entries_limit_cap(self, mock_redmine):
+        """Test that limit is capped at 100."""
+        mock_entries = []
+        mock_redmine.time_entry.filter.return_value = mock_entries
+
+        await list_time_entries(limit=500)
+
+        call_kwargs = mock_redmine.time_entry.filter.call_args[1]
+        assert call_kwargs["limit"] == 100
+
+    @pytest.mark.asyncio
+    async def test_list_time_entries_redmine_not_initialized(self, mock_redmine):
+        """Test error when Redmine client is not initialized."""
+        with patch("redmine_mcp_server.redmine_handler.redmine", None):
+            result = await list_time_entries()
+
+        assert isinstance(result, list)
+        assert len(result) == 1
+        assert "error" in result[0]
+        assert "not initialized" in result[0]["error"]
+
+    @pytest.mark.asyncio
+    async def test_list_time_entries_empty_result(self, mock_redmine):
+        """Test listing when no time entries exist."""
+        mock_redmine.time_entry.filter.return_value = []
+
+        result = await list_time_entries(project_id=10)
+
+        assert isinstance(result, list)
+        assert len(result) == 0
+
+
+class TestCreateTimeEntry:
+    """Test cases for create_time_entry tool."""
+
+    @pytest.fixture
+    def mock_redmine(self):
+        """Create a mock Redmine client."""
+        with patch("redmine_mcp_server.redmine_handler.redmine") as mock:
+            yield mock
+
+    def create_mock_time_entry(self, entry_id=1, hours=2.0, issue_id=None):
+        """Create a mock time entry for create response."""
+        mock_entry = Mock()
+        mock_entry.id = entry_id
+        mock_entry.hours = hours
+        mock_entry.comments = "Test work"
+        mock_entry.spent_on = "2024-03-15"
+        mock_entry.user = make_mock_with_name(5, "John Doe")
+        mock_entry.project = make_mock_with_name(10, "Test Project")
+        mock_entry.issue = Mock(id=issue_id) if issue_id else None
+        mock_entry.activity = make_mock_with_name(9, "Development")
+        mock_entry.created_on = datetime(2024, 3, 15, 10, 0, 0)
+        mock_entry.updated_on = datetime(2024, 3, 15, 10, 0, 0)
+        return mock_entry
+
+    @pytest.mark.asyncio
+    async def test_create_time_entry_with_issue(self, mock_redmine):
+        """Test creating a time entry against an issue."""
+        mock_entry = self.create_mock_time_entry(1, 2.5, issue_id=123)
+        mock_redmine.time_entry.create.return_value = mock_entry
+
+        result = await create_time_entry(hours=2.5, issue_id=123, comments="Bug fix")
+
+        assert result["id"] == 1
+        assert result["hours"] == 2.5
+        call_kwargs = mock_redmine.time_entry.create.call_args[1]
+        assert call_kwargs["hours"] == 2.5
+        assert call_kwargs["issue_id"] == 123
+        assert call_kwargs["comments"] == "Bug fix"
+
+    @pytest.mark.asyncio
+    async def test_create_time_entry_with_project(self, mock_redmine):
+        """Test creating a time entry against a project."""
+        mock_entry = self.create_mock_time_entry(1, 1.0)
+        mock_redmine.time_entry.create.return_value = mock_entry
+
+        result = await create_time_entry(
+            hours=1.0, project_id=10, comments="Project meeting"
+        )
+
+        assert result["id"] == 1
+        call_kwargs = mock_redmine.time_entry.create.call_args[1]
+        assert call_kwargs["project_id"] == 10
+
+    @pytest.mark.asyncio
+    async def test_create_time_entry_with_project_identifier(self, mock_redmine):
+        """Test creating time entry using string project identifier."""
+        mock_entry = self.create_mock_time_entry(1, 1.0)
+        mock_redmine.time_entry.create.return_value = mock_entry
+
+        await create_time_entry(hours=1.0, project_id="my-project", comments="Work")
+
+        call_kwargs = mock_redmine.time_entry.create.call_args[1]
+        assert call_kwargs["project_id"] == "my-project"
+
+    @pytest.mark.asyncio
+    async def test_create_time_entry_with_activity(self, mock_redmine):
+        """Test creating time entry with specific activity."""
+        mock_entry = self.create_mock_time_entry(1, 2.0)
+        mock_redmine.time_entry.create.return_value = mock_entry
+
+        await create_time_entry(hours=2.0, issue_id=123, activity_id=9)
+
+        call_kwargs = mock_redmine.time_entry.create.call_args[1]
+        assert call_kwargs["activity_id"] == 9
+
+    @pytest.mark.asyncio
+    async def test_create_time_entry_with_spent_on(self, mock_redmine):
+        """Test creating time entry with specific date."""
+        mock_entry = self.create_mock_time_entry(1, 2.0)
+        mock_redmine.time_entry.create.return_value = mock_entry
+
+        await create_time_entry(hours=2.0, issue_id=123, spent_on="2024-03-15")
+
+        call_kwargs = mock_redmine.time_entry.create.call_args[1]
+        assert call_kwargs["spent_on"] == "2024-03-15"
+
+    @pytest.mark.asyncio
+    async def test_create_time_entry_missing_project_and_issue(self, mock_redmine):
+        """Test error when neither project_id nor issue_id provided."""
+        result = await create_time_entry(hours=2.0)
+
+        assert "error" in result
+        assert "project_id or issue_id" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_create_time_entry_zero_hours(self, mock_redmine):
+        """Test error when hours is zero."""
+        result = await create_time_entry(hours=0, issue_id=123)
+
+        assert "error" in result
+        assert "positive" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_create_time_entry_negative_hours(self, mock_redmine):
+        """Test error when hours is negative."""
+        result = await create_time_entry(hours=-1.0, issue_id=123)
+
+        assert "error" in result
+        assert "positive" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_create_time_entry_redmine_not_initialized(self, mock_redmine):
+        """Test error when Redmine client is not initialized."""
+        with patch("redmine_mcp_server.redmine_handler.redmine", None):
+            result = await create_time_entry(hours=2.0, issue_id=123)
+
+        assert "error" in result
+        assert "not initialized" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_create_time_entry_issue_not_found(self, mock_redmine):
+        """Test error when issue is not found."""
+        from redminelib.exceptions import ResourceNotFoundError
+
+        mock_redmine.time_entry.create.side_effect = ResourceNotFoundError()
+
+        result = await create_time_entry(hours=2.0, issue_id=9999)
+
+        assert "error" in result
+
+    @pytest.mark.asyncio
+    async def test_create_time_entry_decimal_hours(self, mock_redmine):
+        """Test creating time entry with decimal hours."""
+        mock_entry = self.create_mock_time_entry(1, 0.25)
+        mock_redmine.time_entry.create.return_value = mock_entry
+
+        result = await create_time_entry(hours=0.25, issue_id=123)
+
+        assert result["id"] == 1
+        call_kwargs = mock_redmine.time_entry.create.call_args[1]
+        assert call_kwargs["hours"] == 0.25
+
+
+class TestUpdateTimeEntry:
+    """Test cases for update_time_entry tool."""
+
+    @pytest.fixture
+    def mock_redmine(self):
+        """Create a mock Redmine client."""
+        with patch("redmine_mcp_server.redmine_handler.redmine") as mock:
+            yield mock
+
+    def create_mock_time_entry(self, entry_id=1, hours=2.0):
+        """Create a mock time entry for update response."""
+        mock_entry = Mock()
+        mock_entry.id = entry_id
+        mock_entry.hours = hours
+        mock_entry.comments = "Updated work"
+        mock_entry.spent_on = "2024-03-15"
+        mock_entry.user = make_mock_with_name(5, "John Doe")
+        mock_entry.project = make_mock_with_name(10, "Test Project")
+        mock_entry.issue = Mock(id=123)
+        mock_entry.activity = make_mock_with_name(9, "Development")
+        mock_entry.created_on = datetime(2024, 3, 15, 10, 0, 0)
+        mock_entry.updated_on = datetime(2024, 3, 15, 14, 0, 0)
+        return mock_entry
+
+    @pytest.mark.asyncio
+    async def test_update_time_entry_hours(self, mock_redmine):
+        """Test updating time entry hours."""
+        mock_entry = self.create_mock_time_entry(1, 3.0)
+        mock_redmine.time_entry.get.return_value = mock_entry
+
+        result = await update_time_entry(time_entry_id=1, hours=3.0)
+
+        assert result["id"] == 1
+        assert result["hours"] == 3.0
+        mock_redmine.time_entry.update.assert_called_once()
+        call_kwargs = mock_redmine.time_entry.update.call_args[1]
+        assert call_kwargs["hours"] == 3.0
+
+    @pytest.mark.asyncio
+    async def test_update_time_entry_comments(self, mock_redmine):
+        """Test updating time entry comments."""
+        mock_entry = self.create_mock_time_entry(1, 2.0)
+        mock_redmine.time_entry.get.return_value = mock_entry
+
+        await update_time_entry(time_entry_id=1, comments="New description")
+
+        call_kwargs = mock_redmine.time_entry.update.call_args[1]
+        assert call_kwargs["comments"] == "New description"
+
+    @pytest.mark.asyncio
+    async def test_update_time_entry_activity(self, mock_redmine):
+        """Test updating time entry activity."""
+        mock_entry = self.create_mock_time_entry(1, 2.0)
+        mock_redmine.time_entry.get.return_value = mock_entry
+
+        await update_time_entry(time_entry_id=1, activity_id=10)
+
+        call_kwargs = mock_redmine.time_entry.update.call_args[1]
+        assert call_kwargs["activity_id"] == 10
+
+    @pytest.mark.asyncio
+    async def test_update_time_entry_spent_on(self, mock_redmine):
+        """Test updating time entry date."""
+        mock_entry = self.create_mock_time_entry(1, 2.0)
+        mock_redmine.time_entry.get.return_value = mock_entry
+
+        await update_time_entry(time_entry_id=1, spent_on="2024-03-20")
+
+        call_kwargs = mock_redmine.time_entry.update.call_args[1]
+        assert call_kwargs["spent_on"] == "2024-03-20"
+
+    @pytest.mark.asyncio
+    async def test_update_time_entry_multiple_fields(self, mock_redmine):
+        """Test updating multiple fields at once."""
+        mock_entry = self.create_mock_time_entry(1, 4.0)
+        mock_redmine.time_entry.get.return_value = mock_entry
+
+        await update_time_entry(
+            time_entry_id=1,
+            hours=4.0,
+            comments="Extended work",
+            spent_on="2024-03-20",
+        )
+
+        call_kwargs = mock_redmine.time_entry.update.call_args[1]
+        assert call_kwargs["hours"] == 4.0
+        assert call_kwargs["comments"] == "Extended work"
+        assert call_kwargs["spent_on"] == "2024-03-20"
+
+    @pytest.mark.asyncio
+    async def test_update_time_entry_no_fields(self, mock_redmine):
+        """Test error when no fields provided for update."""
+        result = await update_time_entry(time_entry_id=1)
+
+        assert "error" in result
+        assert "No fields" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_update_time_entry_zero_hours(self, mock_redmine):
+        """Test error when hours set to zero."""
+        result = await update_time_entry(time_entry_id=1, hours=0)
+
+        assert "error" in result
+        assert "positive" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_update_time_entry_negative_hours(self, mock_redmine):
+        """Test error when hours set to negative."""
+        result = await update_time_entry(time_entry_id=1, hours=-1.0)
+
+        assert "error" in result
+        assert "positive" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_update_time_entry_not_found(self, mock_redmine):
+        """Test error when time entry not found."""
+        from redminelib.exceptions import ResourceNotFoundError
+
+        mock_redmine.time_entry.update.side_effect = ResourceNotFoundError()
+
+        result = await update_time_entry(time_entry_id=9999, hours=2.0)
+
+        assert "error" in result
+
+    @pytest.mark.asyncio
+    async def test_update_time_entry_redmine_not_initialized(self, mock_redmine):
+        """Test error when Redmine client is not initialized."""
+        with patch("redmine_mcp_server.redmine_handler.redmine", None):
+            result = await update_time_entry(time_entry_id=1, hours=2.0)
+
+        assert "error" in result
+        assert "not initialized" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_update_time_entry_forbidden(self, mock_redmine):
+        """Test error when user lacks permission to update."""
+        from redminelib.exceptions import ForbiddenError
+
+        mock_redmine.time_entry.update.side_effect = ForbiddenError()
+
+        result = await update_time_entry(time_entry_id=1, hours=2.0)
+
+        assert "error" in result
+        assert "Access denied" in result["error"]

--- a/tests/test_time_entries.py
+++ b/tests/test_time_entries.py
@@ -7,13 +7,8 @@ Tests for list_time_entries, create_time_entry, and update_time_entry tools.
 import pytest
 from unittest.mock import Mock, patch
 from datetime import datetime
-import os
-import sys
 
-# Add the src directory to the path
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
-
-from redmine_mcp_server.redmine_handler import (  # noqa: E402
+from redmine_mcp_server.redmine_handler import (
     list_time_entries,
     create_time_entry,
     update_time_entry,
@@ -240,15 +235,17 @@ class TestListTimeEntries:
         assert call_kwargs["limit"] == 100
 
     @pytest.mark.asyncio
-    async def test_list_time_entries_redmine_not_initialized(self, mock_redmine):
+    async def test_list_time_entries_redmine_not_initialized(self):
         """Test error when Redmine client is not initialized."""
-        with patch("redmine_mcp_server.redmine_handler.redmine", None):
+        with patch(
+            "redmine_mcp_server.redmine_handler._get_redmine_client",
+            side_effect=RuntimeError("No Redmine authentication available"),
+        ):
             result = await list_time_entries()
 
         assert isinstance(result, list)
         assert len(result) == 1
         assert "error" in result[0]
-        assert "not initialized" in result[0]["error"]
 
     @pytest.mark.asyncio
     async def test_list_time_entries_empty_result(self, mock_redmine):
@@ -372,13 +369,15 @@ class TestCreateTimeEntry:
         assert "positive" in result["error"]
 
     @pytest.mark.asyncio
-    async def test_create_time_entry_redmine_not_initialized(self, mock_redmine):
+    async def test_create_time_entry_redmine_not_initialized(self):
         """Test error when Redmine client is not initialized."""
-        with patch("redmine_mcp_server.redmine_handler.redmine", None):
+        with patch(
+            "redmine_mcp_server.redmine_handler._get_redmine_client",
+            side_effect=RuntimeError("No Redmine authentication available"),
+        ):
             result = await create_time_entry(hours=2.0, issue_id=123)
 
         assert "error" in result
-        assert "not initialized" in result["error"]
 
     @pytest.mark.asyncio
     async def test_create_time_entry_issue_not_found(self, mock_redmine):
@@ -529,13 +528,15 @@ class TestUpdateTimeEntry:
         assert "error" in result
 
     @pytest.mark.asyncio
-    async def test_update_time_entry_redmine_not_initialized(self, mock_redmine):
+    async def test_update_time_entry_redmine_not_initialized(self):
         """Test error when Redmine client is not initialized."""
-        with patch("redmine_mcp_server.redmine_handler.redmine", None):
+        with patch(
+            "redmine_mcp_server.redmine_handler._get_redmine_client",
+            side_effect=RuntimeError("No Redmine authentication available"),
+        ):
             result = await update_time_entry(time_entry_id=1, hours=2.0)
 
         assert "error" in result
-        assert "not initialized" in result["error"]
 
     @pytest.mark.asyncio
     async def test_update_time_entry_forbidden(self, mock_redmine):


### PR DESCRIPTION
## Summary
- Add 5 new MCP tools: `list_project_members`, `list_time_entries`, `create_time_entry`, `update_time_entry`, `list_time_entry_activities`
- All tools use `_get_redmine_client()` for full OAuth multi-tenant compatibility
- Improve auth mode diagnostics (startup logging, health endpoint, descriptive 401 errors)
- Update README tool count from 17 to 22

## Changes
Based on #72 by @mihajlovicjj with the following additions:

**New Tools:**
- `list_project_members` — list members and roles of a project
- `list_time_entries` — list time entries with filtering by project, issue, user, date
- `create_time_entry` — log time against projects or issues
- `update_time_entry` — modify existing time entries
- `list_time_entry_activities` — discover valid activity IDs for time entry creation

**Bug Fixes:**
- Replaced direct `redmine` variable usage with `_get_redmine_client()` in all tools (required for OAuth mode)
- Fixed `_time_entry_to_dict` to use defensive `getattr()` on nested objects
- Improved OAuth 401 error message to explain auth mode and suggest fix
- Added `auth_mode` to `/health` endpoint and startup logs for diagnostics

**Testing:**
- 55 new unit tests (project members, time entries, enumerations)
- 28 new integration tests covering all 22 MCP tools with zero skips
- 578 unit tests pass total

**Documentation:**
- Updated README with Time Tracking category and tool count (17 → 22)
- Added troubleshooting section for unexpected OAuth/unauthorized errors
- Updated tool-reference.md and CHANGELOG.md

**CI:**
- Prevent duplicate workflow runs on feature branch pushes with open PRs

## Test plan
- [x] All 578 unit tests pass
- [x] Integration tests pass against live Redmine
- [x] Docker deployment tested successfully
- [x] E2E verified: `list_time_entry_activities` → `create_time_entry` with valid activity_id
- [x] Lint and formatting checks pass

### Contributors
- @mihajlovicjj — Original implementation of project members and time tracking tools ([#72](https://github.com/jztan/redmine-mcp-server/pull/72))