### PR TITLE
fix: handle date fields returned as strings by redminelib

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fix `AttributeError: 'str' object has no attribute 'isoformat'` crash when Redmine server returns date fields as pre-formatted strings instead of datetime objects (affects non-UTC timezone configurations and certain Redmine versions)
 
 ## [1.1.1] - 2026-03-31
 ### Security

--- a/src/redmine_mcp_server/redmine_handler.py
+++ b/src/redmine_mcp_server/redmine_handler.py
@@ -813,6 +813,22 @@ def _augment_fields_with_required_custom_fields(
     return updated_fields
 
 
+def _safe_isoformat(val: Any) -> Optional[str]:
+    """Return an ISO-8601 string for a date/datetime value.
+
+    Some Redmine fields arrive as pre-formatted strings instead of
+    ``datetime`` objects.  Calling ``.isoformat()`` on those strings
+    raises ``AttributeError``, so this helper passes strings through
+    unchanged and only calls ``.isoformat()`` on real date/datetime
+    instances.
+    """
+    if val is None:
+        return None
+    if isinstance(val, str):
+        return val
+    return val.isoformat()
+
+
 def _coerce_json_safe(value: Any) -> Any:
     """Convert arbitrary values into JSON-safe data."""
     if value is None or isinstance(value, (str, int, float, bool)):
@@ -892,16 +908,8 @@ def _issue_to_dict(issue: Any, include_custom_fields: bool = False) -> Dict[str,
             if assigned is not None
             else None
         ),
-        "created_on": (
-            issue.created_on.isoformat()
-            if getattr(issue, "created_on", None) is not None
-            else None
-        ),
-        "updated_on": (
-            issue.updated_on.isoformat()
-            if getattr(issue, "updated_on", None) is not None
-            else None
-        ),
+        "created_on": _safe_isoformat(getattr(issue, "created_on", None)),
+        "updated_on": _safe_isoformat(getattr(issue, "updated_on", None)),
     }
 
     if include_custom_fields:
@@ -1196,16 +1204,8 @@ def _issue_to_dict_selective(
             if assigned is not None
             else None
         ),
-        "created_on": (
-            issue.created_on.isoformat()
-            if getattr(issue, "created_on", None) is not None
-            else None
-        ),
-        "updated_on": (
-            issue.updated_on.isoformat()
-            if getattr(issue, "updated_on", None) is not None
-            else None
-        ),
+        "created_on": _safe_isoformat(getattr(issue, "created_on", None)),
+        "updated_on": _safe_isoformat(getattr(issue, "updated_on", None)),
     }
 
     # Return only requested fields (silently skip invalid field names)
@@ -1241,11 +1241,7 @@ def _journals_to_list(issue: Any) -> List[Dict[str, Any]]:
                     else None
                 ),
                 "notes": wrap_insecure_content(notes),
-                "created_on": (
-                    journal.created_on.isoformat()
-                    if getattr(journal, "created_on", None) is not None
-                    else None
-                ),
+                "created_on": _safe_isoformat(getattr(journal, "created_on", None)),
             }
         )
     return journals
@@ -1280,11 +1276,7 @@ def _attachments_to_list(issue: Any) -> List[Dict[str, Any]]:
                     if getattr(attachment, "author", None) is not None
                     else None
                 ),
-                "created_on": (
-                    attachment.created_on.isoformat()
-                    if getattr(attachment, "created_on", None) is not None
-                    else None
-                ),
+                "created_on": _safe_isoformat(getattr(attachment, "created_on", None)),
             }
         )
     return attachments
@@ -1308,16 +1300,8 @@ def _version_to_dict(version: Any) -> Dict[str, Any]:
         "project": (
             {"id": project.id, "name": project.name} if project is not None else None
         ),
-        "created_on": (
-            version.created_on.isoformat()
-            if getattr(version, "created_on", None) is not None
-            else None
-        ),
-        "updated_on": (
-            version.updated_on.isoformat()
-            if getattr(version, "updated_on", None) is not None
-            else None
-        ),
+        "created_on": _safe_isoformat(getattr(version, "created_on", None)),
+        "updated_on": _safe_isoformat(getattr(version, "updated_on", None)),
     }
 
 
@@ -1523,11 +1507,7 @@ async def list_redmine_projects() -> List[Dict[str, Any]]:
                 "name": project.name,
                 "identifier": project.identifier,
                 "description": getattr(project, "description", ""),
-                "created_on": (
-                    project.created_on.isoformat()
-                    if getattr(project, "created_on", None) is not None
-                    else None
-                ),
+                "created_on": _safe_isoformat(getattr(project, "created_on", None)),
             }
             for project in projects
         ]
@@ -2699,16 +2679,8 @@ def _time_entry_to_dict(time_entry: Any) -> Dict[str, Any]:
             if activity is not None
             else None
         ),
-        "created_on": (
-            time_entry.created_on.isoformat()
-            if getattr(time_entry, "created_on", None) is not None
-            else None
-        ),
-        "updated_on": (
-            time_entry.updated_on.isoformat()
-            if getattr(time_entry, "updated_on", None) is not None
-            else None
-        ),
+        "created_on": _safe_isoformat(getattr(time_entry, "created_on", None)),
+        "updated_on": _safe_isoformat(getattr(time_entry, "updated_on", None)),
     }
 
 

--- a/tests/test_safe_isoformat.py
+++ b/tests/test_safe_isoformat.py
@@ -1,0 +1,196 @@
+"""
+Test cases for _safe_isoformat helper.
+
+Verifies that date fields returned as strings (by some Redmine server
+configurations) are handled gracefully instead of raising AttributeError.
+"""
+
+from datetime import datetime, date
+from unittest.mock import Mock
+
+from redmine_mcp_server.redmine_handler import (
+    _safe_isoformat,
+    _issue_to_dict,
+    _version_to_dict,
+    _time_entry_to_dict,
+    _journals_to_list,
+    _attachments_to_list,
+)
+
+
+class TestSafeIsoformat:
+    """Unit tests for the _safe_isoformat helper."""
+
+    def test_none_returns_none(self):
+        assert _safe_isoformat(None) is None
+
+    def test_datetime_returns_isoformat(self):
+        dt = datetime(2024, 1, 15, 10, 30, 0)
+        assert _safe_isoformat(dt) == "2024-01-15T10:30:00"
+
+    def test_date_returns_isoformat(self):
+        d = date(2024, 1, 15)
+        assert _safe_isoformat(d) == "2024-01-15"
+
+    def test_string_passed_through(self):
+        s = "2024-01-15T10:30:00+02:00"
+        assert _safe_isoformat(s) == s
+
+    def test_empty_string_passed_through(self):
+        assert _safe_isoformat("") == ""
+
+    def test_iso_string_with_utc_offset(self):
+        s = "2024-01-15T10:30:00Z"
+        assert _safe_isoformat(s) == s
+
+
+def _make_mock_issue(**overrides):
+    """Create a minimal mock issue for testing."""
+    issue = Mock()
+    issue.id = overrides.get("id", 1)
+    issue.subject = overrides.get("subject", "Test")
+    issue.description = overrides.get("description", "Description")
+    issue.project = Mock(id=1, name="Project")
+    issue.status = Mock(id=1, name="New")
+    issue.priority = Mock(id=2, name="Normal")
+    issue.author = Mock(id=1, name="Author")
+    issue.assigned_to = Mock(id=2, name="Assignee")
+    issue.created_on = overrides.get("created_on", None)
+    issue.updated_on = overrides.get("updated_on", None)
+    return issue
+
+
+class TestIssueToDict_StringDates:
+    """Verify _issue_to_dict handles string date fields without crashing."""
+
+    def test_datetime_dates(self):
+        issue = _make_mock_issue(
+            created_on=datetime(2024, 1, 15, 10, 30, 0),
+            updated_on=datetime(2024, 1, 16, 14, 0, 0),
+        )
+        result = _issue_to_dict(issue)
+        assert result["created_on"] == "2024-01-15T10:30:00"
+        assert result["updated_on"] == "2024-01-16T14:00:00"
+
+    def test_string_dates(self):
+        issue = _make_mock_issue(
+            created_on="2024-01-15T10:30:00+02:00",
+            updated_on="2024-01-16T14:00:00+02:00",
+        )
+        result = _issue_to_dict(issue)
+        assert result["created_on"] == "2024-01-15T10:30:00+02:00"
+        assert result["updated_on"] == "2024-01-16T14:00:00+02:00"
+
+    def test_none_dates(self):
+        issue = _make_mock_issue(created_on=None, updated_on=None)
+        result = _issue_to_dict(issue)
+        assert result["created_on"] is None
+        assert result["updated_on"] is None
+
+
+class TestVersionToDict_StringDates:
+    """Verify _version_to_dict handles string date fields without crashing."""
+
+    def _make_mock_version(self, created_on=None, updated_on=None):
+        v = Mock()
+        v.id = 1
+        v.name = "v1.0"
+        v.description = "Release"
+        v.status = "open"
+        v.due_date = "2024-06-01"
+        v.sharing = "none"
+        v.wiki_page_title = ""
+        v.project = Mock(id=1, name="Project")
+        v.created_on = created_on
+        v.updated_on = updated_on
+        return v
+
+    def test_string_dates(self):
+        v = self._make_mock_version(
+            created_on="2024-01-15T10:30:00+02:00",
+            updated_on="2024-02-01T14:30:00+02:00",
+        )
+        result = _version_to_dict(v)
+        assert result["created_on"] == "2024-01-15T10:30:00+02:00"
+        assert result["updated_on"] == "2024-02-01T14:30:00+02:00"
+
+    def test_datetime_dates(self):
+        v = self._make_mock_version(
+            created_on=datetime(2024, 1, 15, 10, 30, 0),
+            updated_on=datetime(2024, 2, 1, 14, 30, 0),
+        )
+        result = _version_to_dict(v)
+        assert result["created_on"] == "2024-01-15T10:30:00"
+        assert result["updated_on"] == "2024-02-01T14:30:00"
+
+
+class TestTimeEntryToDict_StringDates:
+    """Verify _time_entry_to_dict handles string date fields without crashing."""
+
+    def _make_mock_entry(self, created_on=None, updated_on=None):
+        e = Mock()
+        e.id = 1
+        e.hours = 2.5
+        e.comments = "Work"
+        e.spent_on = "2024-03-15"
+        e.user = Mock(id=5)
+        e.user.name = "John"
+        e.project = Mock(id=10)
+        e.project.name = "Project"
+        e.issue = Mock(id=123)
+        e.activity = Mock(id=9)
+        e.activity.name = "Development"
+        e.created_on = created_on
+        e.updated_on = updated_on
+        return e
+
+    def test_string_dates(self):
+        e = self._make_mock_entry(
+            created_on="2024-03-15T10:30:00+02:00",
+            updated_on="2024-03-15T14:00:00+02:00",
+        )
+        result = _time_entry_to_dict(e)
+        assert result["created_on"] == "2024-03-15T10:30:00+02:00"
+        assert result["updated_on"] == "2024-03-15T14:00:00+02:00"
+
+
+class TestJournalsList_StringDates:
+    """Verify _journals_to_list handles string date fields without crashing."""
+
+    def test_string_dates(self):
+        journal = Mock()
+        journal.id = 1
+        journal.notes = "A comment"
+        journal.user = Mock(id=1)
+        journal.user.name = "Author"
+        journal.created_on = "2024-01-15T10:30:00+02:00"
+
+        issue = Mock()
+        issue.journals = [journal]
+
+        result = _journals_to_list(issue)
+        assert len(result) == 1
+        assert result[0]["created_on"] == "2024-01-15T10:30:00+02:00"
+
+
+class TestAttachmentsList_StringDates:
+    """Verify _attachments_to_list handles string date fields without crashing."""
+
+    def test_string_dates(self):
+        attachment = Mock()
+        attachment.id = 1
+        attachment.filename = "file.txt"
+        attachment.filesize = 1024
+        attachment.content_type = "text/plain"
+        attachment.description = ""
+        attachment.content_url = "http://example.com/file.txt"
+        attachment.author = Mock(id=1)
+        attachment.author.name = "Author"
+        attachment.created_on = "2024-01-15T10:30:00+02:00"
+
+        issue = Mock()
+        issue.attachments = [attachment]
+
+        result = _attachments_to_list(issue)
+        assert len(result) == 1
+        assert result[0]["created_on"] == "2024-01-15T10:30:00+02:00"


### PR DESCRIPTION
## Description
Fix AttributeError crash when redminelib returns date fields as pre-formatted
strings instead of datetime objects.

## Related Issue
Reported in production: `list_redmine_projects` fails with
`'str' object has no attribute 'isoformat'` on certain Redmine server
configurations (non-UTC timezone / different Redmine versions).

## Changes Made
- Added `_safe_isoformat()` helper that passes strings through unchanged and
  only calls `.isoformat()` on actual date/datetime instances
- Replaced all 10 bare `.isoformat()` calls on Redmine date fields
  (`created_on`, `updated_on`) across issues, journals, attachments, versions,
  projects, and time entries
- Left locally-constructed datetime `.isoformat()` calls untouched (they are
  always real datetime objects)

## Checklist
- [x] Code follows style guidelines
- [x] Tests added
- [x] CHANGELOG updated
