### PR TITLE
feat: Add option to support redmine Agile plugin

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -46,6 +46,13 @@ ATTACHMENT_EXPIRES_MINUTES=60
 # When enabled, write operations (create/update/delete) are blocked
 # REDMINE_MCP_READ_ONLY=false
 
+# RedmineUP Agile plugin support (optional)
+# Set to true to include story_points, agile_sprint_id, agile_position in
+# get_redmine_issue responses and allow story_points in update_redmine_issue.
+# Requires the RedmineUP Agile plugin installed and the 'agile' module enabled
+# per project (Project Settings → Modules → Agile).
+# REDMINE_AGILE_ENABLED=false
+
 # Required custom field autofill (optional)
 # Retries once on relevant create/update validation errors (blank/invalid custom fields)
 # REDMINE_AUTOFILL_REQUIRED_CUSTOM_FIELDS=false

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
-# VsCode and IDE specific files
+# IDE / editor
 .vscode/settings.json
 
-# Python-generated files
+# Python artifacts
 __pycache__/
 *.py[oc]
 build/
@@ -9,20 +9,28 @@ dist/
 wheels/
 *.egg-info
 
-# Test and coverage files
-.coverage
-htmlcov/
-
 # Virtual environments
 .venv
+
+# Test and coverage
+.coverage
+htmlcov/
+coverage.xml
+
+# Local configuration and secrets
 .env
 .env.docker
+.mcpregistry_github_token
+.mcpregistry_registry_token
+
+# Local developer files (not part of the public repo)
 CLAUDE.md
 RELEASE_SOP.md
 .claude
-attachments
-plans
-.mcpregistry_github_token
-.mcpregistry_registry_token
-coverage.xml
 docs_internal/
+docs/superpowers/
+plans/
+docker/test-*/
+
+# Runtime data
+attachments/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `REDMINE_AGILE_ENABLED=true` opt-in support for RedmineUP Agile plugin: `get_redmine_issue` auto-includes `story_points`, `agile_sprint_id`, and `agile_position`; `update_redmine_issue` accepts `story_points` in the `fields` dict
+
 ### Security
 - Bump `fastmcp` from 3.1.1 to 3.2.0, patching CVE-2025-64340 and CVE-2026-27124
 

--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ The server runs on `http://localhost:8000` with the MCP endpoint at `/mcp`, heal
 | `REDMINE_SSL_CERT` | No | – | Path to custom CA certificate file |
 | `REDMINE_SSL_CLIENT_CERT` | No | – | Path to client certificate for mutual TLS |
 | `REDMINE_MCP_READ_ONLY` | No | `false` | Block all write operations (create/update/delete) when set to `true` |
+| `REDMINE_AGILE_ENABLED` | No | `false` | Enable RedmineUP Agile plugin support: `get_redmine_issue` returns `story_points`, `agile_sprint_id`, `agile_position`; `update_redmine_issue` accepts `story_points` |
 | `REDMINE_AUTOFILL_REQUIRED_CUSTOM_FIELDS` | No | `false` | Enable one retry for issue creation by filling missing required custom fields |
 | `REDMINE_REQUIRED_CUSTOM_FIELD_DEFAULTS` | No | `{}` | JSON object mapping required custom field names to fallback values used when creating issues |
 

--- a/README.md
+++ b/README.md
@@ -514,6 +514,6 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 - [Contributing Guide](./docs/contributing.md) - Development setup and guidelines
 - [Changelog](./CHANGELOG.md) - Detailed version history
 - [Roadmap](roadmap.md) - Future development plans
-- [Blog: How I linked a legacy system to a modern AI agent with MCP](https://blog.jztan.com/how-i-linked-a-legacy-system-to-a-modern-ai-agent/) - The story behind this project
-- [Blog: Designing Reliable MCP Servers: 3 Hard Lessons in Agentic Architecture](https://blog.jztan.com/i-gave-my-ai-agent-full-api-access-it-was-a-mistak/) - Lessons learned building this server
-- [Blog: What It Actually Takes to Ship a Production MCP Server for Redmine](https://blog.jztan.com/what-it-actually-takes-to-ship-a-production-mcp-server-for-redmine/) - The full journey from prototype to production
+- [Blog: How I linked a legacy system to a modern AI agent with MCP](https://blog.jztan.com/how-i-linked-a-legacy-system-to-a-modern-ai-agent/?utm_source=github&utm_medium=readme&utm_campaign=redmine-mcp-server) - The story behind this project
+- [Blog: Designing Reliable MCP Servers: 3 Hard Lessons in Agentic Architecture](https://blog.jztan.com/i-gave-my-ai-agent-full-api-access-it-was-a-mistak/?utm_source=github&utm_medium=readme&utm_campaign=redmine-mcp-server) - Lessons learned building this server
+- [Blog: What It Actually Takes to Ship a Production MCP Server for Redmine](https://blog.jztan.com/what-it-actually-takes-to-ship-a-production-mcp-server-for-redmine/?utm_source=github&utm_medium=readme&utm_campaign=redmine-mcp-server) - The full journey from prototype to production

--- a/README.md
+++ b/README.md
@@ -516,3 +516,4 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 - [Roadmap](roadmap.md) - Future development plans
 - [Blog: How I linked a legacy system to a modern AI agent with MCP](https://blog.jztan.com/how-i-linked-a-legacy-system-to-a-modern-ai-agent/) - The story behind this project
 - [Blog: Designing Reliable MCP Servers: 3 Hard Lessons in Agentic Architecture](https://blog.jztan.com/i-gave-my-ai-agent-full-api-access-it-was-a-mistak/) - Lessons learned building this server
+- [Blog: What It Actually Takes to Ship a Production MCP Server for Redmine](https://blog.jztan.com/what-it-actually-takes-to-ship-a-production-mcp-server-for-redmine/) - The full journey from prototype to production

--- a/docs/tool-reference.md
+++ b/docs/tool-reference.md
@@ -372,7 +372,7 @@ Retrieve detailed information about a specific Redmine issue.
 - `include_relations` (boolean, optional): Include issue relations. Default: `false`
 - `include_children` (boolean, optional): Include child issues. Default: `false`
 
-**Returns:** Issue dictionary with details, journals, and attachments
+**Returns:** Issue dictionary with details, journals, and attachments. When `REDMINE_AGILE_ENABLED=true`, also includes `story_points`, `agile_sprint_id`, and `agile_position` from the RedmineUP Agile plugin.
 
 **Example:**
 ```json
@@ -385,6 +385,18 @@ Retrieve detailed information about a specific Redmine issue.
   "custom_fields": [{"id": 6, "name": "Size", "value": "S"}],
   "journals": [...],
   "attachments": [...]
+}
+```
+
+**With `REDMINE_AGILE_ENABLED=true`:**
+```json
+{
+  "id": 123,
+  "subject": "Bug in login form",
+  "story_points": 5,
+  "agile_sprint_id": null,
+  "agile_position": 2,
+  ...
 }
 ```
 
@@ -649,6 +661,8 @@ Updates an existing issue with the provided fields. Blocked when `REDMINE_MCP_RE
 **Note:** You can use either `status_id` or `status_name` in fields. When `status_name` is provided, the tool automatically resolves the corresponding status ID.
 You can also update custom fields by name (for example `{"size": "S"}`) and the tool will resolve them to Redmine `custom_fields` entries using project custom-field metadata. You can still pass explicit `custom_fields` with field IDs.
 
+When `REDMINE_AGILE_ENABLED=true`, you can also pass `story_points` (non-negative integer or `null` to clear) and it will be written via the RedmineUP Agile plugin endpoint. If the plugin is disabled, `story_points` is silently ignored.
+
 **Example:**
 ```python
 # Update issue status using status name
@@ -669,11 +683,19 @@ update_redmine_issue(
     }
 )
 
-# Update Agile/custom field by name
+# Update custom field by name
 update_redmine_issue(
     issue_id=123,
     fields={
         "size": "S"
+    }
+)
+
+# Set story points (requires REDMINE_AGILE_ENABLED=true)
+update_redmine_issue(
+    issue_id=123,
+    fields={
+        "story_points": 8
     }
 )
 ```

--- a/docs/tool-reference.md
+++ b/docs/tool-reference.md
@@ -663,6 +663,8 @@ You can also update custom fields by name (for example `{"size": "S"}`) and the 
 
 When `REDMINE_AGILE_ENABLED=true`, you can also pass `story_points` (non-negative integer or `null` to clear) and it will be written via the RedmineUP Agile plugin endpoint. If the plugin is disabled, `story_points` is silently ignored.
 
+**Note:** `story_points` is always intercepted before custom field resolution, regardless of the `REDMINE_AGILE_ENABLED` setting. If your Redmine instance has a custom field literally named `"story_points"`, it cannot be updated by name through this tool — use explicit `custom_fields` with its field ID instead (e.g. `{"custom_fields": [{"id": 42, "value": "8"}]}`).
+
 **Example:**
 ```python
 # Update issue status using status name

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -463,6 +463,43 @@ This guide covers common issues and solutions for the Redmine MCP Server.
    ATTACHMENT_EXPIRES_MINUTES=120  # Increase expiry time
    ```
 
+### Agile Fields Missing from Issue Results
+
+**Symptoms:**
+- `story_points`, `agile_sprint_id`, `agile_position` not present in `get_redmine_issue` response even though `REDMINE_AGILE_ENABLED=true`
+
+**Solutions:**
+
+1. **Verify `REDMINE_AGILE_ENABLED` is set correctly**
+   ```bash
+   # In .env file
+   REDMINE_AGILE_ENABLED=true
+   ```
+
+2. **Enable the Agile module for the project**
+   - Go to Project Settings → Modules in Redmine
+   - Check the **Agile** checkbox and save
+   - Without this, the agile endpoint returns 403 and fields are silently omitted
+
+3. **Verify the RedmineUP Agile plugin is installed**
+   - Access your Redmine administration panel
+   - Go to Administration → Plugins and confirm the Agile plugin is listed
+
+### Agile Story Points Update Fails
+
+**Symptoms:**
+- `update_redmine_issue` with `story_points` returns an error
+- Error message mentions "Story points is invalid"
+
+**Solutions:**
+
+1. **Use a non-negative integer or `null`**
+   - Valid values: `0`, `1`, `5`, `8`, etc.
+   - Pass `null` to clear story points
+   - Negative values (e.g. `-1`) are rejected by Redmine with a 422 error
+
+2. **Check the Agile module is enabled for the project** (see above)
+
 ### Memory or Performance Issues
 
 **Symptoms:**

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -485,6 +485,27 @@ This guide covers common issues and solutions for the Redmine MCP Server.
    - Access your Redmine administration panel
    - Go to Administration → Plugins and confirm the Agile plugin is listed
 
+### Custom Field Named "story_points" Cannot Be Updated by Name
+
+**Symptoms:**
+- Passing `{"story_points": "value"}` in `update_redmine_issue` has no effect on the custom field
+- The update succeeds but the custom field value does not change
+
+**Cause:**
+The key `story_points` is reserved — it is intercepted before custom field resolution regardless of whether `REDMINE_AGILE_ENABLED` is set. When the plugin is disabled, the value is silently dropped; when enabled, it is routed to the Agile endpoint.
+
+**Solution:**
+Use the explicit `custom_fields` format with the field's numeric ID:
+```python
+update_redmine_issue(
+    issue_id=123,
+    fields={
+        "custom_fields": [{"id": 42, "value": "8"}]
+    }
+)
+```
+Find the field ID via `list_project_issue_custom_fields(project_id)`.
+
 ### Agile Story Points Update Fails
 
 **Symptoms:**

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -476,12 +476,18 @@ This guide covers common issues and solutions for the Redmine MCP Server.
    REDMINE_AGILE_ENABLED=true
    ```
 
-2. **Enable the Agile module for the project**
+2. **Grant Agile permissions to the user's role**
+   - Go to **Administration → Roles and permissions**
+   - Click the role assigned to your API user
+   - Scroll to the **Agile** section and check the relevant permissions (e.g. `View board`)
+   - Save — without this, the agile endpoint returns 403 even if the module is enabled
+
+3. **Enable the Agile module for the project**
    - Go to Project Settings → Modules in Redmine
    - Check the **Agile** checkbox and save
    - Without this, the agile endpoint returns 403 and fields are silently omitted
 
-3. **Verify the RedmineUP Agile plugin is installed**
+4. **Verify the RedmineUP Agile plugin is installed**
    - Access your Redmine administration panel
    - Go to Administration → Plugins and confirm the Agile plugin is listed
 

--- a/src/redmine_mcp_server/redmine_handler.py
+++ b/src/redmine_mcp_server/redmine_handler.py
@@ -1523,6 +1523,13 @@ async def get_redmine_issue(
                 for c in raw
             ]
 
+        if _is_agile_enabled():
+            try:
+                agile = _fetch_agile_data(issue_id)
+                result.update(agile)
+            except Exception:
+                pass  # Silently omit agile fields on any failure
+
         return result
     except Exception as e:
         return _handle_redmine_error(

--- a/src/redmine_mcp_server/redmine_handler.py
+++ b/src/redmine_mcp_server/redmine_handler.py
@@ -552,8 +552,8 @@ def _fetch_agile_data(issue_id: int) -> Dict[str, Any]:
     """
     client = _get_redmine_client()
     url = f"{REDMINE_URL}/issues/{issue_id}/agile_data.json"
-    response = client.engine.request("get", url)
-    agile_data = response.json().get("agile_data", {}) or {}
+    payload = client.engine.request("get", url)
+    agile_data = payload.get("agile_data", {}) or {}
     return {
         "story_points": agile_data.get("story_points"),
         "agile_sprint_id": agile_data.get("agile_sprint_id"),
@@ -2218,8 +2218,9 @@ async def update_redmine_issue(issue_id: int, fields: Dict[str, Any]) -> Dict[st
             logger.warning(f"Error resolving status name '{name}': {e}")
 
     try:
-        update_fields = _map_named_custom_fields_for_update(issue_id, update_fields)
-        _get_redmine_client().issue.update(issue_id, **update_fields)
+        if update_fields:
+            update_fields = _map_named_custom_fields_for_update(issue_id, update_fields)
+            _get_redmine_client().issue.update(issue_id, **update_fields)
         if agile_update_needed:
             try:
                 _apply_agile_story_points(issue_id, story_points)

--- a/src/redmine_mcp_server/redmine_handler.py
+++ b/src/redmine_mcp_server/redmine_handler.py
@@ -1449,6 +1449,10 @@ async def get_redmine_issue(
         key. If ``include_attachments`` is ``True`` and attachments exist they
         will be returned under the ``"attachments"`` key. On failure a dictionary
         with an ``"error"`` key is returned.
+        When ``REDMINE_AGILE_ENABLED=true``, the result also includes
+        ``story_points``, ``agile_sprint_id``, and ``agile_position``
+        fetched from the RedmineUP Agile plugin endpoint (omitted
+        silently on any failure).
     """
 
     # Ensure cleanup task is started (lazy initialization)

--- a/src/redmine_mcp_server/redmine_handler.py
+++ b/src/redmine_mcp_server/redmine_handler.py
@@ -2187,6 +2187,18 @@ async def update_redmine_issue(issue_id: int, fields: Dict[str, Any]) -> Dict[st
 
     update_fields = dict(fields)
 
+    # Extract agile fields — not understood by python-redmine.
+    # Use explicit key presence check so story_points=None (clear) still triggers
+    # the agile endpoint (story_points is not None would skip it).
+    story_points = None
+    agile_update_needed = False
+    if _is_agile_enabled():
+        if "story_points" in update_fields:
+            story_points = update_fields.pop("story_points")
+            agile_update_needed = True
+    else:
+        update_fields.pop("story_points", None)
+
     # Convert status name to id if requested
     if "status_name" in update_fields and "status_id" not in update_fields:
         name = str(update_fields.pop("status_name")).lower()
@@ -2202,6 +2214,8 @@ async def update_redmine_issue(issue_id: int, fields: Dict[str, Any]) -> Dict[st
     try:
         update_fields = _map_named_custom_fields_for_update(issue_id, update_fields)
         _get_redmine_client().issue.update(issue_id, **update_fields)
+        if agile_update_needed:
+            _apply_agile_story_points(issue_id, story_points)
         updated_issue = _get_redmine_client().issue.get(issue_id)
         return _issue_to_dict(updated_issue, include_custom_fields=True)
     except ValidationError as e:
@@ -2250,6 +2264,8 @@ async def update_redmine_issue(issue_id: int, fields: Dict[str, Any]) -> Dict[st
                 missing_names,
             )
             _get_redmine_client().issue.update(issue_id, **retry_fields)
+            if agile_update_needed:
+                _apply_agile_story_points(issue_id, story_points)
             updated_issue = _get_redmine_client().issue.get(issue_id)
             return _issue_to_dict(updated_issue, include_custom_fields=True)
         except Exception as retry_error:

--- a/src/redmine_mcp_server/redmine_handler.py
+++ b/src/redmine_mcp_server/redmine_handler.py
@@ -2177,6 +2177,12 @@ async def update_redmine_issue(issue_id: int, fields: Dict[str, Any]) -> Dict[st
     provided in ``fields``. When present and ``status_id`` is not supplied, the
     function will look up the corresponding status ID and use it for the update.
 
+    When ``REDMINE_AGILE_ENABLED=true``, a ``story_points`` key may also be
+    provided in ``fields``; it is routed to the RedmineUP Agile plugin endpoint
+    separately and is not passed to the standard Redmine update. When
+    ``REDMINE_AGILE_ENABLED=false`` (default), ``story_points`` is silently
+    ignored.
+
     Non-standard keys in ``fields`` are treated as candidate custom-field names.
     When a matching project custom field is found, it is translated into
     ``custom_fields`` entries for Redmine update payloads.
@@ -2215,7 +2221,14 @@ async def update_redmine_issue(issue_id: int, fields: Dict[str, Any]) -> Dict[st
         update_fields = _map_named_custom_fields_for_update(issue_id, update_fields)
         _get_redmine_client().issue.update(issue_id, **update_fields)
         if agile_update_needed:
-            _apply_agile_story_points(issue_id, story_points)
+            try:
+                _apply_agile_story_points(issue_id, story_points)
+            except Exception as agile_e:
+                return _handle_redmine_error(
+                    agile_e,
+                    f"updating agile story_points for issue {issue_id}",
+                    {"resource_type": "issue", "resource_id": issue_id},
+                )
         updated_issue = _get_redmine_client().issue.get(issue_id)
         return _issue_to_dict(updated_issue, include_custom_fields=True)
     except ValidationError as e:
@@ -2265,7 +2278,14 @@ async def update_redmine_issue(issue_id: int, fields: Dict[str, Any]) -> Dict[st
             )
             _get_redmine_client().issue.update(issue_id, **retry_fields)
             if agile_update_needed:
-                _apply_agile_story_points(issue_id, story_points)
+                try:
+                    _apply_agile_story_points(issue_id, story_points)
+                except Exception as agile_e:
+                    return _handle_redmine_error(
+                        agile_e,
+                        f"updating agile story_points for issue {issue_id}",
+                        {"resource_type": "issue", "resource_id": issue_id},
+                    )
             updated_issue = _get_redmine_client().issue.get(issue_id)
             return _issue_to_dict(updated_issue, include_custom_fields=True)
         except Exception as retry_error:

--- a/src/redmine_mcp_server/redmine_handler.py
+++ b/src/redmine_mcp_server/redmine_handler.py
@@ -539,6 +539,46 @@ def _is_read_only_mode() -> bool:
     return _is_true_env("REDMINE_MCP_READ_ONLY", "false")
 
 
+def _is_agile_enabled() -> bool:
+    """Check if RedmineUP Agile plugin support is enabled."""
+    return _is_true_env("REDMINE_AGILE_ENABLED", "false")
+
+
+def _fetch_agile_data(issue_id: int) -> Dict[str, Any]:
+    """Fetch agile fields for an issue from the RedmineUP Agile endpoint.
+
+    Returns a dict with story_points, agile_sprint_id, and agile_position.
+    Raises on any HTTP error (caller is responsible for catching).
+    """
+    client = _get_redmine_client()
+    url = f"{REDMINE_URL}/issues/{issue_id}/agile_data.json"
+    response = client.engine.request("get", url)
+    agile_data = response.json().get("agile_data", {}) or {}
+    return {
+        "story_points": agile_data.get("story_points"),
+        "agile_sprint_id": agile_data.get("agile_sprint_id"),
+        "agile_position": agile_data.get("position"),
+    }
+
+
+def _apply_agile_story_points(issue_id: int, story_points) -> None:
+    """Write story_points for an issue via the RedmineUP Agile endpoint.
+
+    Raises on any HTTP error (caller is responsible for catching).
+    """
+    client = _get_redmine_client()
+    url = f"{REDMINE_URL}/issues/{issue_id}.json"
+    payload = json.dumps(
+        {"issue": {"agile_data_attributes": {"story_points": story_points}}}
+    )
+    client.engine.request(
+        "put",
+        url,
+        headers={"Content-Type": "application/json"},
+        data=payload,
+    )
+
+
 _READ_ONLY_ERROR = {
     "error": "This server is in read-only mode (REDMINE_MCP_READ_ONLY=true). "
     "Write operations are disabled."

--- a/tests/test_agile_support.py
+++ b/tests/test_agile_support.py
@@ -56,15 +56,13 @@ class TestFetchAgileData:
     @patch("redmine_mcp_server.redmine_handler.REDMINE_URL", "http://localhost:3000")
     @patch("redmine_mcp_server.redmine_handler.redmine")
     def test_returns_mapped_fields(self, mock_redmine):
-        mock_response = Mock()
-        mock_response.json.return_value = {
+        mock_redmine.engine.request.return_value = {
             "agile_data": {
                 "story_points": 8,
                 "agile_sprint_id": 3,
                 "position": 2,
             }
         }
-        mock_redmine.engine.request.return_value = mock_response
 
         result = _fetch_agile_data(42)
 
@@ -80,15 +78,13 @@ class TestFetchAgileData:
     @patch("redmine_mcp_server.redmine_handler.REDMINE_URL", "http://localhost:3000")
     @patch("redmine_mcp_server.redmine_handler.redmine")
     def test_handles_null_fields(self, mock_redmine):
-        mock_response = Mock()
-        mock_response.json.return_value = {
+        mock_redmine.engine.request.return_value = {
             "agile_data": {
                 "story_points": None,
                 "agile_sprint_id": None,
                 "position": None,
             }
         }
-        mock_redmine.engine.request.return_value = mock_response
 
         result = _fetch_agile_data(1)
 
@@ -140,15 +136,13 @@ class TestGetRedmineIssueAgile:
     @patch("redmine_mcp_server.redmine_handler.redmine")
     async def test_merges_agile_fields_when_enabled(self, mock_redmine):
         mock_redmine.issue.get.return_value = _make_minimal_issue(1)
-        mock_response = Mock()
-        mock_response.json.return_value = {
+        mock_redmine.engine.request.return_value = {
             "agile_data": {
                 "story_points": 5,
                 "agile_sprint_id": 2,
                 "position": 1,
             }
         }
-        mock_redmine.engine.request.return_value = mock_response
 
         with patch.dict(os.environ, {"REDMINE_AGILE_ENABLED": "true"}):
             result = await get_redmine_issue(1)
@@ -278,6 +272,7 @@ class TestUpdateRedmineIssueAgile:
             result = await update_redmine_issue(1, {"story_points": -1})
 
         assert "error" in result
-        mock_redmine.issue.update.assert_called_once()
+        # story_points is the only field — standard update is skipped entirely
+        mock_redmine.issue.update.assert_not_called()
         # Never reaches issue.get — error returned before that
         mock_redmine.issue.get.assert_not_called()

--- a/tests/test_agile_support.py
+++ b/tests/test_agile_support.py
@@ -17,6 +17,25 @@ from redmine_mcp_server.redmine_handler import (  # noqa: E402
 )
 
 
+def _make_minimal_issue(issue_id: int = 1) -> Mock:
+    """Create a minimal mock issue object accepted by _issue_to_dict."""
+    issue = Mock()
+    issue.id = issue_id
+    issue.subject = "Test Issue"
+    issue.description = "desc"
+    issue.project = None
+    issue.status = None
+    issue.priority = None
+    issue.author = None
+    issue.assigned_to = None
+    issue.created_on = None
+    issue.updated_on = None
+    # Prevent _journals_to_list / _attachments_to_list from crashing
+    issue.journals = []
+    issue.attachments = []
+    return issue
+
+
 class TestIsAgileEnabled:
     def test_false_by_default(self):
         with patch.dict(os.environ, {}, clear=False):
@@ -111,25 +130,6 @@ class TestApplyAgileStoryPoints:
                 {"issue": {"agile_data_attributes": {"story_points": None}}}
             ),
         )
-
-
-def _make_minimal_issue(issue_id: int = 1) -> Mock:
-    """Create a minimal mock issue object accepted by _issue_to_dict."""
-    issue = Mock()
-    issue.id = issue_id
-    issue.subject = "Test Issue"
-    issue.description = "desc"
-    issue.project = None
-    issue.status = None
-    issue.priority = None
-    issue.author = None
-    issue.assigned_to = None
-    issue.created_on = None
-    issue.updated_on = None
-    # Prevent _journals_to_list / _attachments_to_list from crashing
-    issue.journals = []
-    issue.attachments = []
-    return issue
 
 
 class TestGetRedmineIssueAgile:

--- a/tests/test_agile_support.py
+++ b/tests/test_agile_support.py
@@ -14,6 +14,7 @@ from redmine_mcp_server.redmine_handler import (  # noqa: E402
     _fetch_agile_data,
     _apply_agile_story_points,
     get_redmine_issue,
+    update_redmine_issue,
 )
 
 
@@ -185,3 +186,98 @@ class TestGetRedmineIssueAgile:
         assert "error" not in result
         assert result["id"] == 1
         assert "story_points" not in result
+
+
+class TestUpdateRedmineIssueAgile:
+
+    @pytest.mark.asyncio
+    @patch("redmine_mcp_server.redmine_handler.REDMINE_URL", "http://localhost:3000")
+    @patch("redmine_mcp_server.redmine_handler.redmine")
+    async def test_extracts_story_points_and_calls_agile_endpoint(self, mock_redmine):
+        mock_redmine.issue.update.return_value = True
+        mock_redmine.issue.get.return_value = _make_minimal_issue(1)
+        mock_redmine.engine.request.return_value = Mock()
+
+        with patch.dict(os.environ, {"REDMINE_AGILE_ENABLED": "true"}):
+            result = await update_redmine_issue(
+                1, {"subject": "New", "story_points": 8}
+            )
+
+        # story_points must NOT be passed to issue.update
+        mock_redmine.issue.update.assert_called_once_with(1, subject="New")
+        # agile endpoint must be called with correct payload
+        mock_redmine.engine.request.assert_called_once_with(
+            "put",
+            "http://localhost:3000/issues/1.json",
+            headers={"Content-Type": "application/json"},
+            data=json.dumps(
+                {"issue": {"agile_data_attributes": {"story_points": 8}}}
+            ),
+        )
+        assert result["id"] == 1
+
+    @pytest.mark.asyncio
+    @patch("redmine_mcp_server.redmine_handler.REDMINE_URL", "http://localhost:3000")
+    @patch("redmine_mcp_server.redmine_handler.redmine")
+    async def test_null_story_points_clears_field(self, mock_redmine):
+        mock_redmine.issue.update.return_value = True
+        mock_redmine.issue.get.return_value = _make_minimal_issue(1)
+        mock_redmine.engine.request.return_value = Mock()
+
+        with patch.dict(os.environ, {"REDMINE_AGILE_ENABLED": "true"}):
+            await update_redmine_issue(1, {"story_points": None})
+
+        mock_redmine.engine.request.assert_called_once_with(
+            "put",
+            "http://localhost:3000/issues/1.json",
+            headers={"Content-Type": "application/json"},
+            data=json.dumps(
+                {"issue": {"agile_data_attributes": {"story_points": None}}}
+            ),
+        )
+
+    @pytest.mark.asyncio
+    @patch("redmine_mcp_server.redmine_handler.redmine")
+    async def test_story_points_silently_dropped_when_disabled(self, mock_redmine):
+        mock_redmine.issue.update.return_value = True
+        mock_redmine.issue.get.return_value = _make_minimal_issue(1)
+
+        with patch.dict(os.environ, {"REDMINE_AGILE_ENABLED": "false"}):
+            result = await update_redmine_issue(1, {"subject": "X", "story_points": 5})
+
+        # story_points must NOT reach issue.update
+        mock_redmine.issue.update.assert_called_once_with(1, subject="X")
+        # No agile HTTP call
+        mock_redmine.engine.request.assert_not_called()
+        assert result["id"] == 1
+
+    @pytest.mark.asyncio
+    @patch("redmine_mcp_server.redmine_handler.redmine")
+    async def test_no_agile_call_when_story_points_absent(self, mock_redmine):
+        mock_redmine.issue.update.return_value = True
+        mock_redmine.issue.get.return_value = _make_minimal_issue(1)
+
+        with patch.dict(os.environ, {"REDMINE_AGILE_ENABLED": "true"}):
+            result = await update_redmine_issue(1, {"subject": "Only subject"})
+
+        mock_redmine.engine.request.assert_not_called()
+        assert result["id"] == 1
+
+    @pytest.mark.asyncio
+    @patch("redmine_mcp_server.redmine_handler.REDMINE_URL", "http://localhost:3000")
+    @patch("redmine_mcp_server.redmine_handler.redmine")
+    async def test_returns_error_when_agile_call_fails_after_standard_update(
+        self, mock_redmine
+    ):
+        from redminelib.exceptions import ValidationError
+
+        mock_redmine.issue.update.return_value = True
+        mock_redmine.engine.request.side_effect = ValidationError("invalid")
+
+        with patch.dict(os.environ, {"REDMINE_AGILE_ENABLED": "true"}):
+            result = await update_redmine_issue(1, {"story_points": -1})
+
+        assert "error" in result
+        mock_redmine.issue.update.assert_called_once()
+        # Never reaches issue.get — error returned before that
+        mock_redmine.issue.get.assert_not_called()

--- a/tests/test_agile_support.py
+++ b/tests/test_agile_support.py
@@ -1,0 +1,114 @@
+"""Unit tests for RedmineUP Agile plugin support."""
+
+import json
+import os
+import sys
+
+import pytest
+from unittest.mock import Mock, patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from redmine_mcp_server.redmine_handler import (  # noqa: E402
+    _is_agile_enabled,
+    _fetch_agile_data,
+    _apply_agile_story_points,
+    get_redmine_issue,
+    update_redmine_issue,
+)
+
+
+class TestIsAgileEnabled:
+    def test_false_by_default(self):
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("REDMINE_AGILE_ENABLED", None)
+            assert _is_agile_enabled() is False
+
+    def test_true_when_env_set(self):
+        with patch.dict(os.environ, {"REDMINE_AGILE_ENABLED": "true"}):
+            assert _is_agile_enabled() is True
+
+    def test_false_when_env_set_to_false(self):
+        with patch.dict(os.environ, {"REDMINE_AGILE_ENABLED": "false"}):
+            assert _is_agile_enabled() is False
+
+
+class TestFetchAgileData:
+    @patch("redmine_mcp_server.redmine_handler.REDMINE_URL", "http://localhost:3000")
+    @patch("redmine_mcp_server.redmine_handler.redmine")
+    def test_returns_mapped_fields(self, mock_redmine):
+        mock_response = Mock()
+        mock_response.json.return_value = {
+            "agile_data": {
+                "story_points": 8,
+                "agile_sprint_id": 3,
+                "position": 2,
+            }
+        }
+        mock_redmine.engine.request.return_value = mock_response
+
+        result = _fetch_agile_data(42)
+
+        assert result == {
+            "story_points": 8,
+            "agile_sprint_id": 3,
+            "agile_position": 2,
+        }
+        mock_redmine.engine.request.assert_called_once_with(
+            "get", "http://localhost:3000/issues/42/agile_data.json"
+        )
+
+    @patch("redmine_mcp_server.redmine_handler.REDMINE_URL", "http://localhost:3000")
+    @patch("redmine_mcp_server.redmine_handler.redmine")
+    def test_handles_null_fields(self, mock_redmine):
+        mock_response = Mock()
+        mock_response.json.return_value = {
+            "agile_data": {
+                "story_points": None,
+                "agile_sprint_id": None,
+                "position": None,
+            }
+        }
+        mock_redmine.engine.request.return_value = mock_response
+
+        result = _fetch_agile_data(1)
+
+        assert result == {
+            "story_points": None,
+            "agile_sprint_id": None,
+            "agile_position": None,
+        }
+
+
+class TestApplyAgileStoryPoints:
+    @patch("redmine_mcp_server.redmine_handler.REDMINE_URL", "http://localhost:3000")
+    @patch("redmine_mcp_server.redmine_handler.redmine")
+    def test_calls_engine_put_with_correct_payload(self, mock_redmine):
+        mock_redmine.engine.request.return_value = Mock()
+
+        _apply_agile_story_points(42, 8)
+
+        mock_redmine.engine.request.assert_called_once_with(
+            "put",
+            "http://localhost:3000/issues/42.json",
+            headers={"Content-Type": "application/json"},
+            data=json.dumps(
+                {"issue": {"agile_data_attributes": {"story_points": 8}}}
+            ),
+        )
+
+    @patch("redmine_mcp_server.redmine_handler.REDMINE_URL", "http://localhost:3000")
+    @patch("redmine_mcp_server.redmine_handler.redmine")
+    def test_allows_null_to_clear_story_points(self, mock_redmine):
+        mock_redmine.engine.request.return_value = Mock()
+
+        _apply_agile_story_points(42, None)
+
+        mock_redmine.engine.request.assert_called_once_with(
+            "put",
+            "http://localhost:3000/issues/42.json",
+            headers={"Content-Type": "application/json"},
+            data=json.dumps(
+                {"issue": {"agile_data_attributes": {"story_points": None}}}
+            ),
+        )

--- a/tests/test_agile_support.py
+++ b/tests/test_agile_support.py
@@ -4,7 +4,6 @@ import json
 import os
 import sys
 
-import pytest
 from unittest.mock import Mock, patch
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
@@ -13,8 +12,6 @@ from redmine_mcp_server.redmine_handler import (  # noqa: E402
     _is_agile_enabled,
     _fetch_agile_data,
     _apply_agile_story_points,
-    get_redmine_issue,
-    update_redmine_issue,
 )
 
 

--- a/tests/test_agile_support.py
+++ b/tests/test_agile_support.py
@@ -4,6 +4,7 @@ import json
 import os
 import sys
 
+import pytest
 from unittest.mock import Mock, patch
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
@@ -12,6 +13,7 @@ from redmine_mcp_server.redmine_handler import (  # noqa: E402
     _is_agile_enabled,
     _fetch_agile_data,
     _apply_agile_story_points,
+    get_redmine_issue,
 )
 
 
@@ -109,3 +111,77 @@ class TestApplyAgileStoryPoints:
                 {"issue": {"agile_data_attributes": {"story_points": None}}}
             ),
         )
+
+
+def _make_minimal_issue(issue_id: int = 1) -> Mock:
+    """Create a minimal mock issue object accepted by _issue_to_dict."""
+    issue = Mock()
+    issue.id = issue_id
+    issue.subject = "Test Issue"
+    issue.description = "desc"
+    issue.project = None
+    issue.status = None
+    issue.priority = None
+    issue.author = None
+    issue.assigned_to = None
+    issue.created_on = None
+    issue.updated_on = None
+    # Prevent _journals_to_list / _attachments_to_list from crashing
+    issue.journals = []
+    issue.attachments = []
+    return issue
+
+
+class TestGetRedmineIssueAgile:
+
+    @pytest.mark.asyncio
+    @patch("redmine_mcp_server.redmine_handler.REDMINE_URL", "http://localhost:3000")
+    @patch("redmine_mcp_server.redmine_handler.redmine")
+    async def test_merges_agile_fields_when_enabled(self, mock_redmine):
+        mock_redmine.issue.get.return_value = _make_minimal_issue(1)
+        mock_response = Mock()
+        mock_response.json.return_value = {
+            "agile_data": {
+                "story_points": 5,
+                "agile_sprint_id": 2,
+                "position": 1,
+            }
+        }
+        mock_redmine.engine.request.return_value = mock_response
+
+        with patch.dict(os.environ, {"REDMINE_AGILE_ENABLED": "true"}):
+            result = await get_redmine_issue(1)
+
+        assert result["story_points"] == 5
+        assert result["agile_sprint_id"] == 2
+        assert result["agile_position"] == 1
+        mock_redmine.engine.request.assert_called_once_with(
+            "get", "http://localhost:3000/issues/1/agile_data.json"
+        )
+
+    @pytest.mark.asyncio
+    @patch("redmine_mcp_server.redmine_handler.redmine")
+    async def test_no_agile_fields_when_disabled(self, mock_redmine):
+        mock_redmine.issue.get.return_value = _make_minimal_issue(1)
+
+        with patch.dict(os.environ, {"REDMINE_AGILE_ENABLED": "false"}):
+            result = await get_redmine_issue(1)
+
+        assert "story_points" not in result
+        assert "agile_sprint_id" not in result
+        assert "agile_position" not in result
+        mock_redmine.engine.request.assert_not_called()
+
+    @pytest.mark.asyncio
+    @patch("redmine_mcp_server.redmine_handler.REDMINE_URL", "http://localhost:3000")
+    @patch("redmine_mcp_server.redmine_handler.redmine")
+    async def test_silently_omits_agile_on_any_exception(self, mock_redmine):
+        mock_redmine.issue.get.return_value = _make_minimal_issue(1)
+        mock_redmine.engine.request.side_effect = Exception("plugin not installed")
+
+        with patch.dict(os.environ, {"REDMINE_AGILE_ENABLED": "true"}):
+            result = await get_redmine_issue(1)
+
+        assert "error" not in result
+        assert result["id"] == 1
+        assert "story_points" not in result

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1867,6 +1867,167 @@ class TestEnumerationsIntegration:
         assert isinstance(activity["name"], str)
 
 
+_AGILE_SKIP = pytest.mark.skipif(
+    not REDMINE_URL
+    or os.getenv("REDMINE_AGILE_ENABLED", "false").strip().lower()
+    not in {"1", "true", "yes", "on"},
+    reason="REDMINE_URL not configured or REDMINE_AGILE_ENABLED not true",
+)
+
+
+class TestAgilePluginIntegration:
+    """Integration tests for RedmineUP Agile plugin support.
+
+    Requires:
+    - REDMINE_URL configured
+    - REDMINE_AGILE_ENABLED=true
+    - RedmineUP Agile plugin installed on the Redmine server
+    - The 'agile' module enabled for the test project (Project Settings → Modules)
+    """
+
+    def _find_agile_issue_id(self, redmine):
+        """Find an issue in a project with the agile module enabled."""
+        project_id = os.getenv("REDMINE_AGILE_TEST_PROJECT_ID")
+        if project_id:
+            try:
+                issues = redmine.issue.filter(project_id=project_id, limit=1)
+                if issues:
+                    return list(issues)[0].id
+            except Exception:
+                pass
+            pytest.skip(
+                f"No issues found in REDMINE_AGILE_TEST_PROJECT_ID={project_id}"
+            )
+
+        # Fall back: try each project until one returns agile data without 403
+        try:
+            projects = list(redmine.project.all())
+        except Exception:
+            pytest.skip("Could not list projects")
+
+        for project in projects:
+            try:
+                issues = redmine.issue.filter(project_id=project.id, limit=1)
+                issue_list = list(issues)
+                if not issue_list:
+                    continue
+                issue_id = issue_list[0].id
+                # Probe agile endpoint — skip project on 403
+                from redminelib.exceptions import ForbiddenError
+
+                try:
+                    url = f"{REDMINE_URL}/issues/{issue_id}/agile_data.json"
+                    redmine.engine.request("get", url)
+                    return issue_id
+                except ForbiddenError:
+                    continue
+            except Exception:
+                continue
+
+        pytest.skip(
+            "No project with Agile module enabled found. "
+            "Enable the 'agile' module in at least one project."
+        )
+
+    @_AGILE_SKIP
+    @pytest.mark.integration
+    @pytest.mark.asyncio
+    async def test_get_issue_includes_agile_fields(self):
+        """get_redmine_issue returns agile fields when REDMINE_AGILE_ENABLED=true."""
+        redmine = _get_redmine_or_none()
+        if redmine is None:
+            pytest.skip("Redmine client not initialized")
+
+        issue_id = self._find_agile_issue_id(redmine)
+
+        from redmine_mcp_server.redmine_handler import get_redmine_issue
+
+        result = await get_redmine_issue(issue_id)
+
+        assert "error" not in result, f"get_redmine_issue failed: {result}"
+        assert "story_points" in result, "story_points missing from result"
+        assert "agile_sprint_id" in result, "agile_sprint_id missing from result"
+        assert "agile_position" in result, "agile_position missing from result"
+        # Values may be None (not yet set) — presence of keys is what matters
+        assert result.get("story_points") is None or isinstance(
+            result["story_points"], (int, float)
+        )
+
+    @_AGILE_SKIP
+    @pytest.mark.integration
+    @pytest.mark.asyncio
+    async def test_update_story_points_roundtrip(self):
+        """update_redmine_issue sets story_points and get_redmine_issue reads it back."""
+        redmine = _get_redmine_or_none()
+        if redmine is None:
+            pytest.skip("Redmine client not initialized")
+
+        issue_id = self._find_agile_issue_id(redmine)
+
+        from redmine_mcp_server.redmine_handler import (
+            get_redmine_issue,
+            update_redmine_issue,
+        )
+
+        # Set story points to a known value
+        update_result = await update_redmine_issue(issue_id, {"story_points": 5})
+        assert "error" not in update_result, f"update failed: {update_result}"
+
+        # Read back and confirm
+        get_result = await get_redmine_issue(issue_id)
+        assert "error" not in get_result, f"get failed: {get_result}"
+        assert get_result.get("story_points") == 5
+
+    @_AGILE_SKIP
+    @pytest.mark.integration
+    @pytest.mark.asyncio
+    async def test_clear_story_points(self):
+        """update_redmine_issue with story_points=None clears the field."""
+        redmine = _get_redmine_or_none()
+        if redmine is None:
+            pytest.skip("Redmine client not initialized")
+
+        issue_id = self._find_agile_issue_id(redmine)
+
+        from redmine_mcp_server.redmine_handler import (
+            get_redmine_issue,
+            update_redmine_issue,
+        )
+
+        # First set a value so there's something to clear
+        await update_redmine_issue(issue_id, {"story_points": 3})
+
+        # Now clear it
+        update_result = await update_redmine_issue(issue_id, {"story_points": None})
+        assert "error" not in update_result, f"clear failed: {update_result}"
+
+        # Read back and confirm cleared
+        get_result = await get_redmine_issue(issue_id)
+        assert "error" not in get_result
+        assert get_result.get("story_points") is None
+
+    @_AGILE_SKIP
+    @pytest.mark.integration
+    @pytest.mark.asyncio
+    async def test_story_points_not_leaked_to_standard_update(self):
+        """story_points in fields dict does not cause a standard update failure."""
+        redmine = _get_redmine_or_none()
+        if redmine is None:
+            pytest.skip("Redmine client not initialized")
+
+        issue_id = self._find_agile_issue_id(redmine)
+
+        from redmine_mcp_server.redmine_handler import update_redmine_issue
+
+        # Passing story_points together with a standard field must not error
+        result = await update_redmine_issue(
+            issue_id, {"story_points": 8, "notes": "agile integration test"}
+        )
+        assert "error" not in result, (
+            f"Combined story_points + notes update failed: {result}"
+        )
+
+
 if __name__ == "__main__":
     # Run integration tests
     pytest.main([__file__, "-v", "-m", "integration", "--tb=short"])


### PR DESCRIPTION
REDMINE_AGILE_ENABLED=true opt-in support for RedmineUP Agile plugin: get_redmine_issue auto-includes story_points, agile_sprint_id, and agile_position; update_redmine_issue accepts story_points in the fields dict