### PR TITLE
Consolidate and refactor tools for improved management

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -54,20 +54,19 @@ ATTACHMENT_EXPIRES_MINUTES=60
 # REDMINE_AGILE_ENABLED=false
 
 # RedmineUP Checklists plugin support (optional)
-# Set to true to enable get_checklist, update_checklist_item, and
-# mark_checklist_done tools. Requires the RedmineUP Checklists Pro plugin
-# installed on your Redmine instance.
+# Set to true to enable the get_checklist and update_checklist_item tools.
+# Requires the RedmineUP Checklists Pro plugin installed on your Redmine
+# instance.
 # REDMINE_CHECKLISTS_ENABLED=false
 
 # RedmineUP Products plugin support (optional)
-# Set to true to enable list_products, get_product, add_product, edit_product
-# tools. Requires the RedmineUP Products plugin installed on your Redmine
-# instance.
+# Set to true to enable the manage_product tool (action=list/get/create/update).
+# Requires the RedmineUP Products plugin installed on your Redmine instance.
 # REDMINE_PRODUCTS_ENABLED=false
 
 # RedmineUP CRM (Contacts) plugin support (optional)
-# Set to true to enable list_contacts, get_contact, edit_contact, create_contact,
-# delete_contact, assign_contact_to_project, remove_contact_from_project tools.
+# Set to true to enable the manage_contact tool
+# (action=list/get/create/update/delete/assign_to_project/remove_from_project).
 # Requires the RedmineUP CRM plugin installed on your Redmine instance.
 # REDMINE_CRM_ENABLED=false
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Consolidated 35 MCP tools into 9 `manage_X` tools, reducing total tool count from 69 to 43:
+  - `add_project_member`, `update_project_member`, `remove_project_member` -> `manage_project_member(action=...)`
+  - `list_issue_categories`, `create_issue_category`, `update_issue_category`, `delete_issue_category` -> `manage_issue_category(action=...)`
+  - `list_issue_relations`, `create_issue_relation`, `delete_issue_relation` -> `manage_issue_relation(action=...)`
+  - `add_watcher`, `remove_watcher` -> `manage_issue_watcher(action=...)`
+  - `edit_note`, `set_note_private` -> `manage_issue_note(action=...)` (`get_private_notes` kept standalone)
+  - `create_time_entry`, `update_time_entry`, `log_time_for_user` -> `manage_time_entry(action=...)`
+  - `get_redmine_wiki_page`, `create_redmine_wiki_page`, `update_redmine_wiki_page`, `delete_redmine_wiki_page`, `list_wiki_pages`, `rename_wiki_page` -> `manage_redmine_wiki_page(action=...)`
+  - `list_products`, `get_product`, `add_product`, `edit_product` -> `manage_product(action=...)` (still gated by `REDMINE_PRODUCTS_ENABLED=true`)
+  - `list_contacts`, `get_contact`, `create_contact`, `edit_contact`, `delete_contact`, `assign_contact_to_project`, `remove_contact_from_project` -> `manage_contact(action=...)` (still gated by `REDMINE_CRM_ENABLED=true`)
+  - `mark_checklist_done` removed: use `update_checklist_item(is_done=True)` directly
+- `manage_time_entry(action="create", user_id=...)` replaces `log_time_for_user`
+- Verb normalization: `add_product` / `edit_product` map to `manage_product(action="create"|"update")`; `create_contact` / `edit_contact` map to `manage_contact(action="create"|"update")` to match the dominant CRUD pattern in the codebase
+- Response shape change: callers of `mark_checklist_done` previously received `{"is_done": bool}`; the equivalent `update_checklist_item` call returns `{"updated_fields": ["is_done"]}`
+- Read-only mode: write actions within `manage_X` tools are blocked; read actions (`list`, `get`) remain available
 
 ## [1.3.0] - 2026-05-06
 ### Added

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ A Model Context Protocol (MCP) server that integrates with Redmine project manag
 
 ## Features
 
-- **69 MCP Tools**: Issues, projects, time tracking, wiki, Gantt, file operations, membership management, products, contacts (CRM), and more
+- **43 MCP Tools**: Issues, projects, time tracking, wiki, Gantt, file operations, membership management, products, contacts (CRM), and more
 - **Flexible Authentication**: API key, username/password, or OAuth2 per-user tokens
 - **Prompt Injection Protection**: User-controlled content wrapped in boundary tags for safe LLM consumption
 - **Read-Only Mode**: Restrict to read-only operations via `REDMINE_MCP_READ_ONLY` environment variable
@@ -117,9 +117,9 @@ The server runs on `http://localhost:8000` with the MCP endpoint at `/mcp`, heal
 | `REDMINE_SSL_CLIENT_CERT` | No | – | Path to client certificate for mutual TLS |
 | `REDMINE_MCP_READ_ONLY` | No | `false` | Block all write operations (create/update/delete) when set to `true` |
 | `REDMINE_AGILE_ENABLED` | No | `false` | Enable RedmineUP Agile plugin support: `get_redmine_issue` returns `story_points`, `agile_sprint_id`, `agile_position`; `update_redmine_issue` accepts `story_points` |
-| `REDMINE_CHECKLISTS_ENABLED` | No | `false` | Enable RedmineUP Checklists plugin support: `get_checklist`, `update_checklist_item`, `mark_checklist_done` (requires Checklists Pro plugin) |
-| `REDMINE_PRODUCTS_ENABLED` | No | `false` | Enable RedmineUP Products plugin support: `list_products`, `get_product`, `add_product`, `edit_product` |
-| `REDMINE_CRM_ENABLED` | No | `false` | Enable RedmineUP CRM plugin support: `list_contacts`, `get_contact`, `edit_contact`, `create_contact`, `delete_contact`, `assign_contact_to_project`, `remove_contact_from_project` |
+| `REDMINE_CHECKLISTS_ENABLED` | No | `false` | Enable RedmineUP Checklists plugin support: `get_checklist`, `update_checklist_item` (requires Checklists Pro plugin) |
+| `REDMINE_PRODUCTS_ENABLED` | No | `false` | Enable RedmineUP Products plugin support: `manage_product` (action=list/get/create/update) |
+| `REDMINE_CRM_ENABLED` | No | `false` | Enable RedmineUP CRM plugin support: `manage_contact` (action=list/get/create/update/delete/assign_to_project/remove_from_project) |
 | `REDMINE_AUTOFILL_REQUIRED_CUSTOM_FIELDS` | No | `false` | Enable one retry for issue creation by filling missing required custom fields |
 | `REDMINE_REQUIRED_CUSTOM_FIELD_DEFAULTS` | No | `{}` | JSON object mapping required custom field names to fallback values used when creating issues |
 | `REDMINE_ALLOW_PRIVATE_FETCH_URLS` | No | `false` | **Warning:** disables all SSRF protection for attachment fetching. Never set to `true` in production. |

--- a/README.md
+++ b/README.md
@@ -437,9 +437,9 @@ curl http://localhost:8000/health
 
 ## Available Tools
 
-This MCP server provides 69 tools for interacting with Redmine. For detailed documentation, see [Tool Reference](./docs/tool-reference.md).
+This MCP server provides 43 tools for interacting with Redmine. For detailed documentation, see [Tool Reference](./docs/tool-reference.md).
 
-- **Project Management** (11 tools)
+- **Project Management** (9 tools)
   - [`list_redmine_projects`](docs/tool-reference.md#list_redmine_projects) - List all accessible projects
   - [`list_project_issue_custom_fields`](docs/tool-reference.md#list_project_issue_custom_fields) - List issue custom fields configured for a project
   - [`list_redmine_versions`](docs/tool-reference.md#list_redmine_versions) - List versions/milestones for a project
@@ -448,38 +448,27 @@ This MCP server provides 69 tools for interacting with Redmine. For detailed doc
   - [`summarize_project_status`](docs/tool-reference.md#summarize_project_status) - Get comprehensive project status summary
   - [`list_redmine_roles`](docs/tool-reference.md#list_redmine_roles) - List all roles defined in the Redmine instance (for discovering valid `role_ids`)
   - [`get_project_modules`](docs/tool-reference.md#get_project_modules) - Retrieve the enabled modules for a project
-  - [`add_project_member`](docs/tool-reference.md#add_project_member) - Add a user or group as a member with roles
-  - [`update_project_member`](docs/tool-reference.md#update_project_member) - Update the roles of an existing membership
-  - [`remove_project_member`](docs/tool-reference.md#remove_project_member) - Remove a membership from a project
+  - [`manage_project_member`](docs/tool-reference.md#manage_project_member) - Add, update, or remove a project membership
 
-- **Issue Operations** (19 tools)
+- **Issue Operations** (12 tools)
   - [`get_redmine_issue`](docs/tool-reference.md#get_redmine_issue) - Retrieve detailed issue information (supports journal pagination, watchers, relations, children)
   - [`list_redmine_issues`](docs/tool-reference.md#list_redmine_issues) - List issues with flexible filtering (project, status, assignee, etc.)
   - [`search_redmine_issues`](docs/tool-reference.md#search_redmine_issues) - Search issues by text query
   - [`create_redmine_issue`](docs/tool-reference.md#create_redmine_issue) - Create new issues
   - [`update_redmine_issue`](docs/tool-reference.md#update_redmine_issue) - Update existing issues
   - [`copy_issue`](docs/tool-reference.md#copy_issue) - Duplicate an existing issue with optional field overrides
-  - [`list_issue_relations`](docs/tool-reference.md#list_issue_relations) - List all relations for an issue
-  - [`create_issue_relation`](docs/tool-reference.md#create_issue_relation) - Create a relation between two issues (blocks, duplicates, relates, etc.)
-  - [`delete_issue_relation`](docs/tool-reference.md#delete_issue_relation) - Delete an existing issue relation
   - [`list_subtasks`](docs/tool-reference.md#list_subtasks) - List subtasks (child issues) of a given parent
-  - [`add_watcher`](docs/tool-reference.md#add_watcher) - Add a user to the watcher list of an issue
-  - [`remove_watcher`](docs/tool-reference.md#remove_watcher) - Remove a user from the watcher list
-  - [`edit_note`](docs/tool-reference.md#edit_note) - Edit an existing journal note's text and/or privacy
   - [`get_private_notes`](docs/tool-reference.md#get_private_notes) - Retrieve private notes on an issue
-  - [`set_note_private`](docs/tool-reference.md#set_note_private) - Toggle the private/public state of a journal note
-  - [`list_issue_categories`](docs/tool-reference.md#list_issue_categories) - List issue categories for a project
-  - [`create_issue_category`](docs/tool-reference.md#create_issue_category) - Create a new issue category
-  - [`update_issue_category`](docs/tool-reference.md#update_issue_category) - Update an existing issue category
-  - [`delete_issue_category`](docs/tool-reference.md#delete_issue_category) - Delete an issue category (with optional reassignment)
+  - [`manage_issue_relation`](docs/tool-reference.md#manage_issue_relation) - List, create, or delete issue relations
+  - [`manage_issue_watcher`](docs/tool-reference.md#manage_issue_watcher) - Add or remove a watcher on an issue
+  - [`manage_issue_note`](docs/tool-reference.md#manage_issue_note) - Edit a journal note's text or toggle its privacy
+  - [`manage_issue_category`](docs/tool-reference.md#manage_issue_category) - List, create, update, or delete issue categories
   - Note: `get_redmine_issue` can include `custom_fields` and `update_redmine_issue` can update custom fields by name (for example `{"size": "S"}`).
 
-- **Time Tracking** (6 tools)
+- **Time Tracking** (4 tools)
   - [`list_time_entries`](docs/tool-reference.md#list_time_entries) - List time entries with filtering by project, issue, user, and date range
-  - [`create_time_entry`](docs/tool-reference.md#create_time_entry) - Log time against projects or issues
-  - [`update_time_entry`](docs/tool-reference.md#update_time_entry) - Modify existing time entries
+  - [`manage_time_entry`](docs/tool-reference.md#manage_time_entry) - Create or update a time entry (use `user_id` to log on behalf of another user)
   - [`list_time_entry_activities`](docs/tool-reference.md#list_time_entry_activities) - Discover available activity types for time entries
-  - [`log_time_for_user`](docs/tool-reference.md#log_time_for_user) - Create a time entry on behalf of another user (requires `log_time_for_other_users` permission)
   - [`import_time_entries`](docs/tool-reference.md#import_time_entries) - Bulk import time entries via sequential API calls with per-entry error reporting
 
 - **Discovery / Enumeration** (6 tools): help LLMs find valid IDs before calling create/update tools
@@ -490,14 +479,9 @@ This MCP server provides 69 tools for interacting with Redmine. For detailed doc
   - [`get_current_user`](docs/tool-reference.md#get_current_user) - Get the authenticated user's profile (works for non-admins)
   - [`list_redmine_queries`](docs/tool-reference.md#list_redmine_queries) - List saved custom queries (read-only)
 
-- **Search & Wiki** (7 tools)
+- **Search & Wiki** (2 tools)
   - [`search_entire_redmine`](docs/tool-reference.md#search_entire_redmine) - Global search across issues and wiki pages (Redmine 3.3.0+)
-  - [`get_redmine_wiki_page`](docs/tool-reference.md#get_redmine_wiki_page) - Retrieve wiki page content
-  - [`create_redmine_wiki_page`](docs/tool-reference.md#create_redmine_wiki_page) - Create new wiki pages
-  - [`update_redmine_wiki_page`](docs/tool-reference.md#update_redmine_wiki_page) - Update existing wiki pages
-  - [`delete_redmine_wiki_page`](docs/tool-reference.md#delete_redmine_wiki_page) - Delete wiki pages
-  - [`list_wiki_pages`](docs/tool-reference.md#list_wiki_pages) - List all wiki pages in a project (titles, versions, parents)
-  - [`rename_wiki_page`](docs/tool-reference.md#rename_wiki_page) - Rename/move a wiki page (with optional redirect)
+  - [`manage_redmine_wiki_page`](docs/tool-reference.md#manage_redmine_wiki_page) - List, get, create, update, delete, or rename wiki pages
 
 - **File Operations** (5 tools)
   - [`list_files`](docs/tool-reference.md#list_files) - List files uploaded to a project's Files section
@@ -506,28 +490,18 @@ This MCP server provides 69 tools for interacting with Redmine. For detailed doc
   - [`get_redmine_attachment_download_url`](docs/tool-reference.md#get_redmine_attachment_download_url) - Get secure download URLs for attachments
   - [`cleanup_attachment_files`](docs/tool-reference.md#cleanup_attachment_files) - Clean up expired attachment files
 
-- **Checklists** (3 tools, requires `REDMINE_CHECKLISTS_ENABLED=true` + RedmineUP Checklists Pro plugin)
+- **Checklists** (2 tools, requires `REDMINE_CHECKLISTS_ENABLED=true` + RedmineUP Checklists Pro plugin)
   - [`get_checklist`](docs/tool-reference.md#get_checklist) - Retrieve all checklist items for an issue
   - [`update_checklist_item`](docs/tool-reference.md#update_checklist_item) - Update a checklist item's text, done state, or position
-  - [`mark_checklist_done`](docs/tool-reference.md#mark_checklist_done) - Toggle the done/undone state of a checklist item
 
 - **Gantt** (1 tool, no plugin required)
   - [`get_gantt_chart`](docs/tool-reference.md#get_gantt_chart) - Retrieve project timeline data: issues with dates, dependencies, and milestones
 
-- **Products** (4 tools, requires `REDMINE_PRODUCTS_ENABLED=true` + RedmineUP Products plugin)
-  - [`list_products`](docs/tool-reference.md#list_products) - List products (optionally filtered by project)
-  - [`get_product`](docs/tool-reference.md#get_product) - Retrieve a specific product by ID
-  - [`add_product`](docs/tool-reference.md#add_product) - Create a new product
-  - [`edit_product`](docs/tool-reference.md#edit_product) - Update product fields
+- **Products** (1 tool, requires `REDMINE_PRODUCTS_ENABLED=true` + RedmineUP Products plugin)
+  - [`manage_product`](docs/tool-reference.md#manage_product) - List, get, create, or update products
 
-- **Contacts (CRM)** (7 tools, requires `REDMINE_CRM_ENABLED=true` + RedmineUP CRM plugin)
-  - [`list_contacts`](docs/tool-reference.md#list_contacts) - List contacts with optional filters (project, search, tags, assignee)
-  - [`get_contact`](docs/tool-reference.md#get_contact) - Retrieve a single contact by ID
-  - [`edit_contact`](docs/tool-reference.md#edit_contact) - Update contact fields
-  - [`create_contact`](docs/tool-reference.md#create_contact) - Create a new contact in a project
-  - [`delete_contact`](docs/tool-reference.md#delete_contact) - Delete a contact
-  - [`assign_contact_to_project`](docs/tool-reference.md#assign_contact_to_project) - Add a contact to an additional project
-  - [`remove_contact_from_project`](docs/tool-reference.md#remove_contact_from_project) - Remove a contact from a project (does not delete)
+- **Contacts (CRM)** (1 tool, requires `REDMINE_CRM_ENABLED=true` + RedmineUP CRM plugin)
+  - [`manage_contact`](docs/tool-reference.md#manage_contact) - List, get, create, update, delete, or assign/remove project association for contacts
 
 
 ## Docker Deployment

--- a/docs/tool-reference.md
+++ b/docs/tool-reference.md
@@ -432,7 +432,7 @@ List all roles defined in the Redmine instance. Returns basic metadata (`id` and
 ]
 ```
 
-**When to use:** Call this **before** `add_project_member` or `update_project_member` to discover the correct `role_ids`. Role IDs vary between Redmine instances and must not be guessed — calling `add_project_member` with a non-existent role ID returns a validation error from Redmine.
+**When to use:** Call this **before** `manage_project_member(action="add"|"update")` to discover the correct `role_ids`. Role IDs vary between Redmine instances and must not be guessed — calling `manage_project_member` with a non-existent role ID returns a validation error from Redmine.
 
 ---
 
@@ -460,61 +460,43 @@ Retrieve the list of enabled modules for a project (e.g., `issue_tracking`, `tim
 
 ---
 
-### `add_project_member`
+### `manage_project_member`
 
-Add a user or group as a member of a project with assigned roles.
+Add, update, or remove a Redmine project membership.
 
 **Parameters:**
-- `project_id` (integer or string, required): Project identifier.
-- `role_ids` (array of integers, required): List of role IDs to assign (at least one).
-- `user_id` (integer, optional): ID of the user to add.
-- `group_id` (integer, optional): ID of the group to add.
+- `action` (string, required): Operation to perform. Allowed: `add`, `update`, `remove`
+- `project_id` (integer or string): Project identifier. Required for `action="add"`
+- `membership_id` (integer): Membership ID. Required for `action="update"` and `action="remove"`
+- `user_id` (integer): ID of the user. Exactly one of `user_id` or `group_id` required for `action="add"`
+- `group_id` (integer): ID of the group. Exactly one of `user_id` or `group_id` required for `action="add"`
+- `role_ids` (array of integers): Non-empty list of role IDs. Required for `action="add"` and `action="update"`. Use `list_redmine_roles` to discover valid IDs
 
-Exactly one of `user_id` or `group_id` must be provided.
+**Returns:**
+- `add`/`update`: membership dictionary (with `id`, `user`/`group`, `project`, `roles`)
+- `remove`: `{"success": true, "deleted_membership_id": <id>}`
+- Error: `{"error": "..."}`
 
-**Returns:** Dictionary containing the created membership (with `id`, `user`/`group`, `project`, `roles`). On failure, a dict with an `"error"` key.
+**Examples:**
 
-**Example:**
 ```python
 # Add a user as Developer
-add_project_member(project_id="my-project", role_ids=[3], user_id=5)
+manage_project_member(action="add", project_id="my-project", user_id=5, role_ids=[3])
 
 # Add a group with multiple roles
-add_project_member(project_id=10, role_ids=[3, 4], group_id=20)
+manage_project_member(action="add", project_id=10, group_id=20, role_ids=[3, 4])
+
+# Update an existing membership's roles
+manage_project_member(action="update", membership_id=42, role_ids=[3, 4])
+
+# Remove a membership
+manage_project_member(action="remove", membership_id=42)
 ```
 
 **Notes:**
-- Respects `REDMINE_MCP_READ_ONLY`.
-- Role IDs can be discovered from the Redmine web UI at Administration > Roles.
-
----
-
-### `update_project_member`
-
-Update the roles assigned to an existing project membership. Replaces the entire role set.
-
-**Parameters:**
-- `membership_id` (integer, required): ID of the membership (from `list_project_members`).
-- `role_ids` (array of integers, required): New list of role IDs. Must contain at least one.
-
-**Returns:** Dictionary containing the updated membership.
-
-**Notes:**
-- Only role assignments can be updated. To change the user/group of a membership, remove it and add a new one.
-
----
-
-### `remove_project_member`
-
-Remove a membership from a project.
-
-**Parameters:**
-- `membership_id` (integer, required): ID of the membership to remove.
-
-**Returns:** `{"success": true, "deleted_membership_id": <id>}`.
-
-**Notes:**
-- Inherited memberships (from a parent project) cannot be removed directly — Redmine will return a 422. Remove them from the parent project instead.
+- All actions are write operations and respect `REDMINE_MCP_READ_ONLY`.
+- Inherited memberships (from a parent project) cannot be removed directly — Redmine returns a 422. Remove them from the parent project instead.
+- Redmine's API uses the `user_id` field for both users and groups; the tool routes `group_id` through that field automatically.
 
 ---
 
@@ -897,54 +879,42 @@ copy_issue(
 
 ---
 
-### `list_issue_relations`
+### `manage_issue_relation`
 
-List all relations for a given issue.
+List, create, or delete a Redmine issue relation.
 
 **Parameters:**
-- `issue_id` (integer, required): ID of the issue whose relations should be listed.
+- `action` (string, required): Operation to perform. Allowed: `list`, `create`, `delete`
+- `issue_id` (integer): Source issue ID. Required for `action="list"` and `action="create"`
+- `issue_to_id` (integer): Target issue ID. Required for `action="create"`
+- `relation_id` (integer): Relation ID. Required for `action="delete"`
+- `relation_type` (string, optional): One of `relates`, `duplicates`, `duplicated`, `blocks`, `blocked`, `precedes`, `follows`, `copied_to`, `copied_from`. Defaults to `relates` on create
+- `delay` (integer, optional): Delay in days. Only meaningful for `precedes` / `follows`
 
-**Returns:** List of relation dictionaries with `id`, `issue_id`, `issue_to_id`, `relation_type`, and `delay`.
+**Returns:**
+- `list`: array of relation dicts (`id`, `issue_id`, `issue_to_id`, `relation_type`, `delay`)
+- `create`: relation dict
+- `delete`: `{"success": true, "deleted_relation_id": <id>}`
+- Error: `{"error": "..."}`
 
-**Example:**
+**Examples:**
+
 ```python
-list_issue_relations(issue_id=123)
-# [{"id": 5, "issue_id": 123, "issue_to_id": 456, "relation_type": "blocks", "delay": null}]
+# List all relations on an issue
+manage_issue_relation(action="list", issue_id=123)
+
+# Create a "blocks" relation
+manage_issue_relation(action="create", issue_id=123, issue_to_id=456, relation_type="blocks")
+
+# Create a "precedes" relation with a 3-day delay
+manage_issue_relation(action="create", issue_id=1, issue_to_id=2, relation_type="precedes", delay=3)
+
+# Delete a relation by ID
+manage_issue_relation(action="delete", relation_id=42)
 ```
 
----
-
-### `create_issue_relation`
-
-Create a relation between two issues.
-
-**Parameters:**
-- `issue_id` (integer, required): ID of the source issue.
-- `issue_to_id` (integer, required): ID of the target issue.
-- `relation_type` (string, optional): One of `relates`, `duplicates`, `duplicated`, `blocks`, `blocked`, `precedes`, `follows`, `copied_to`, `copied_from`. Default: `relates`.
-- `delay` (integer, optional): Delay in days. Only meaningful for `precedes` / `follows`.
-
-**Returns:** Dictionary containing the newly created relation, or `{"error": "..."}` on failure.
-
-**Example:**
-```python
-create_issue_relation(
-    issue_id=123,
-    issue_to_id=456,
-    relation_type="blocks"
-)
-```
-
----
-
-### `delete_issue_relation`
-
-Delete a relation by its ID (obtained from `list_issue_relations` or `create_issue_relation`).
-
-**Parameters:**
-- `relation_id` (integer, required): ID of the relation to delete.
-
-**Returns:** `{"success": true, "deleted_relation_id": <id>}` on success.
+**Notes:**
+- `list` is allowed in read-only mode; `create` and `delete` are blocked when `REDMINE_MCP_READ_ONLY=true`.
 
 ---
 
@@ -969,44 +939,62 @@ List subtasks (child issues) of a given issue. Includes closed subtasks.
 
 ---
 
-### `add_watcher`
+### `manage_issue_watcher`
 
-Add a user to the watcher list of an issue. Requires Redmine 2.3.0+.
+Add or remove a watcher on a Redmine issue. Requires Redmine 2.3.0+.
 
 **Parameters:**
-- `issue_id` (integer, required): ID of the issue.
-- `user_id` (integer, required): ID of the user to add as a watcher.
+- `action` (string, required): Allowed: `add`, `remove`
+- `issue_id` (integer, required): ID of the issue
+- `user_id` (integer, required): ID of the user to add or remove
 
-**Returns:** `{"success": true, "issue_id": ..., "user_id": ...}` on success.
+**Returns:** `{"success": true, "issue_id": ..., "user_id": ...}` on success; `{"error": "..."}` on failure.
+
+**Examples:**
+
+```python
+manage_issue_watcher(action="add", issue_id=123, user_id=5)
+manage_issue_watcher(action="remove", issue_id=123, user_id=5)
+```
+
+**Notes:**
+- All actions are write operations and respect `REDMINE_MCP_READ_ONLY`.
 
 ---
 
-### `remove_watcher`
+### `manage_issue_note`
 
-Remove a user from the watcher list of an issue.
-
-**Parameters:**
-- `issue_id` (integer, required): ID of the issue.
-- `user_id` (integer, required): ID of the user to remove.
-
-**Returns:** `{"success": true, "issue_id": ..., "user_id": ...}` on success.
-
----
-
-### `edit_note`
-
-Update the text (and optionally the privacy flag) of an existing journal note.
+Edit text or toggle privacy of a Redmine journal entry (issue note). `get_private_notes` is a separate read tool.
 
 **Parameters:**
-- `journal_id` (integer, required): ID of the journal entry (from `get_redmine_issue` with `include_journals=true`).
-- `notes` (string, required): New notes text. May be empty.
-- `private_notes` (boolean, optional): Optionally toggle the private flag on this journal entry.
+- `action` (string, required): Allowed: `edit`, `set_private`
+- `journal_id` (integer, required): ID of the journal entry (from `get_redmine_issue` with `include_journals=true`)
+- `notes` (string): New notes text (may be empty to clear). Required for `action="edit"`
+- `private_notes` (boolean, optional): Optionally toggle the private flag during `edit`
+- `is_private` (boolean): Required for `action="set_private"` — `true` to mark private, `false` to make public
 
-**Returns:** Confirmation dictionary with `success`, `journal_id`, `notes`, and `private_notes`.
+**Returns:**
+- `edit`: `{"success": true, "journal_id": ..., "notes": ..., "private_notes": ...}`
+- `set_private`: `{"success": true, "journal_id": ..., "private_notes": <bool>}`
+- Error: `{"error": "..."}`
+
+**Examples:**
+
+```python
+# Edit a note's text
+manage_issue_note(action="edit", journal_id=42, notes="Updated text")
+
+# Edit text and mark private at the same time
+manage_issue_note(action="edit", journal_id=42, notes="Confidential", private_notes=True)
+
+# Toggle privacy without changing the text
+manage_issue_note(action="set_private", journal_id=42, is_private=True)
+```
 
 **Notes:**
 - Only the `notes` text and `private_notes` flag can be edited. Journal `details` (field-change history) are immutable.
-- If a journal has no `details` and its notes are cleared, Redmine will delete the journal record.
+- If a journal has no `details` and its notes are cleared via `edit`, Redmine will delete the journal record.
+- Both actions are writes and respect `REDMINE_MCP_READ_ONLY`.
 - Requires `edit_issue_notes` / `edit_own_issue_notes` permission (server-enforced).
 
 ---
@@ -1022,66 +1010,43 @@ Retrieve only the private notes (journals with `private_notes=true`) of an issue
 
 ---
 
-### `set_note_private`
+### `manage_issue_category`
 
-Toggle the private/public state of an existing journal note.
-
-**Parameters:**
-- `journal_id` (integer, required): ID of the journal entry.
-- `is_private` (boolean, required): `true` to mark the note private, `false` to make it public.
-
-**Returns:** `{"success": true, "journal_id": ..., "private_notes": <bool>}`.
-
----
-
-### `list_issue_categories`
-
-List all issue categories for a given project.
+List, create, update, or delete a Redmine issue category.
 
 **Parameters:**
-- `project_id` (integer or string, required): Project identifier (numeric ID or string identifier).
+- `action` (string, required): Allowed: `list`, `create`, `update`, `delete`
+- `project_id` (integer or string): Project identifier. Required for `action="list"` and `action="create"`
+- `category_id` (integer): Category ID. Required for `action="update"` and `action="delete"`
+- `name` (string): Category name. Required for `action="create"`, optional for `action="update"` (cannot be blank)
+- `assigned_to_id` (integer, optional): Default assignee user ID. For `create` and `update`
+- `reassign_to_id` (integer, optional): Reassign existing issues to this category ID on `delete`. If omitted, issues become uncategorised
 
-**Returns:** List of category dictionaries with `id`, `name`, `project`, and `assigned_to`.
+**Returns:**
+- `list`: array of category dicts (`id`, `name`, `project`, `assigned_to`)
+- `create`/`update`: category dict
+- `delete`: `{"success": true, "deleted_category_id": ..., "reassigned_to_id": ...}`
+- Error: `{"error": "..."}`
 
----
+**Examples:**
 
-### `create_issue_category`
+```python
+# List all categories in a project
+manage_issue_category(action="list", project_id="my-project")
 
-Create a new issue category in a project.
+# Create a new category with a default assignee
+manage_issue_category(action="create", project_id=10, name="Backend", assigned_to_id=5)
 
-**Parameters:**
-- `project_id` (integer or string, required): Project identifier.
-- `name` (string, required): Category name.
-- `assigned_to_id` (integer, optional): Default assignee user ID for issues in this category.
+# Rename a category
+manage_issue_category(action="update", category_id=3, name="Renamed")
 
-**Returns:** Dictionary containing the created issue category.
+# Delete a category and reassign its issues to another one
+manage_issue_category(action="delete", category_id=3, reassign_to_id=7)
+```
 
----
-
-### `update_issue_category`
-
-Update an existing issue category.
-
-**Parameters:**
-- `category_id` (integer, required): ID of the issue category.
-- `name` (string, optional): New category name.
-- `assigned_to_id` (integer, optional): New default assignee user ID.
-
-**Returns:** Dictionary containing the updated issue category.
-
-**Notes:** At least one of `name` or `assigned_to_id` must be provided.
-
----
-
-### `delete_issue_category`
-
-Delete an issue category.
-
-**Parameters:**
-- `category_id` (integer, required): ID of the issue category.
-- `reassign_to_id` (integer, optional): ID of another category to reassign existing issues to. If omitted, issues in this category become uncategorised.
-
-**Returns:** `{"success": true, "deleted_category_id": ..., "reassigned_to_id": ...}`.
+**Notes:**
+- `list` works in read-only mode; `create`, `update`, and `delete` are blocked when `REDMINE_MCP_READ_ONLY=true`.
+- `update` requires at least one of `name` or `assigned_to_id`.
 
 ---
 
@@ -1138,91 +1103,58 @@ my_entries = list_time_entries(user_id="me")
 
 ---
 
-### `create_time_entry`
+### `manage_time_entry`
 
-Create a new time entry in Redmine. Log time against a project or issue.
+Create or update a Redmine time entry. Replaces `create_time_entry`, `update_time_entry`, and `log_time_for_user`.
 
 **Parameters:**
-- `hours` (float, required): Number of hours spent. Must be positive. Can be decimal (e.g., `1.5`)
-- `project_id` (integer or string, optional): Project to log time against. Required if `issue_id` is not provided
-- `issue_id` (integer, optional): Issue to log time against. If provided, `project_id` is optional
-- `activity_id` (integer, optional): Time entry activity ID (e.g., Development, Design). Uses default if not provided
-- `comments` (string, optional): Description of work performed
-- `spent_on` (string, optional): Date when time was spent (YYYY-MM-DD). Defaults to today
+- `action` (string, required): Allowed: `create`, `update`
+- `hours` (float): Hours spent. Required for `action="create"`; optional for `update` (must be positive if provided)
+- `project_id` (integer or string): Required for `action="create"` if `issue_id` is not provided
+- `issue_id` (integer): Required for `action="create"` if `project_id` is not provided
+- `user_id` (integer, optional): Log on behalf of this user (`create` only). Requires `log_time_for_other_users` permission
+- `time_entry_id` (integer): Entry ID to update. Required for `action="update"`
+- `activity_id` (integer, optional): Activity type (e.g., Development, Design)
+- `comments` (string, optional): Description. Empty string clears the field on `update`
+- `spent_on` (string, optional): Date in `YYYY-MM-DD` format
 
-**Returns:** Created time entry dictionary
+**Returns:**
+- `create`/`update`: time entry dict (`id`, `hours`, `comments`, `spent_on`, `user`, `project`, `issue`, `activity`, etc.)
+- Error: `{"error": "..."}`
 
-**Example:**
-```json
-{
-  "id": 1,
-  "hours": 2.5,
-  "comments": "Bug fix",
-  "spent_on": "2024-03-15",
-  "user": {"id": 5, "name": "John Doe"},
-  "project": {"id": 10, "name": "My Project"},
-  "issue": {"id": 123},
-  "activity": {"id": 9, "name": "Development"}
-}
-```
+**Examples:**
 
-**Usage:**
 ```python
-# Log time against an issue
-create_time_entry(
-    hours=2.5,
-    issue_id=123,
-    comments="Fixed login bug"
-)
+# Log 2.5h against an issue
+manage_time_entry(action="create", hours=2.5, issue_id=123, comments="Fixed login bug")
 
-# Log time against a project with specific date
-create_time_entry(
+# Log 1.0h against a project with explicit activity and date
+manage_time_entry(
+    action="create",
     hours=1.0,
     project_id="my-project",
     activity_id=9,
     comments="Code review",
-    spent_on="2024-03-15"
+    spent_on="2026-04-15",
 )
-```
 
----
-
-### `update_time_entry`
-
-Update an existing time entry in Redmine.
-
-**Parameters:**
-- `time_entry_id` (integer, required): ID of the time entry to update
-- `hours` (float, optional): New hours value. Must be positive if provided
-- `activity_id` (integer, optional): New activity ID
-- `comments` (string, optional): New comments/description
-- `spent_on` (string, optional): New date (YYYY-MM-DD format)
-
-**Returns:** Updated time entry dictionary
-
-**Example:**
-```json
-{
-  "id": 1,
-  "hours": 3.0,
-  "comments": "Extended work on bug fix",
-  "spent_on": "2024-03-15"
-}
-```
-
-**Usage:**
-```python
-# Update hours
-update_time_entry(time_entry_id=1, hours=3.0)
-
-# Update multiple fields
-update_time_entry(
-    time_entry_id=1,
-    hours=4.0,
-    comments="Extended debugging session",
-    spent_on="2024-03-16"
+# Log time on behalf of another user (replaces log_time_for_user)
+manage_time_entry(
+    action="create",
+    hours=2.0,
+    issue_id=123,
+    user_id=7,
+    comments="Pair programming",
 )
+
+# Update an existing entry
+manage_time_entry(action="update", time_entry_id=1, hours=3.0)
 ```
+
+**Notes:**
+- Both actions are write operations and respect `REDMINE_MCP_READ_ONLY`.
+- For bulk imports of multiple entries (timesheets, weekly reports), prefer `import_time_entries` over calling `manage_time_entry(action="create")` in a loop.
+- Some Redmine versions reject `user_id` when the authenticated admin is not a project member (Redmine defects #31587, #32774). The workaround is to add the admin as a project member.
 
 ---
 
@@ -1230,7 +1162,7 @@ update_time_entry(
 
 List available time entry activity types from Redmine.
 
-Use this tool to discover valid `activity_id` values before calling `create_time_entry` or `update_time_entry`.
+Use this tool to discover valid `activity_id` values before calling `manage_time_entry`.
 
 When logging time against a specific project, always call with `project_id` first — project-specific activity IDs differ from global ones and using the wrong ID causes `"Activity is not included in the list"` errors.
 
@@ -1388,39 +1320,6 @@ List all saved custom queries (saved issue filters) visible to the current user.
 
 ---
 
-### `log_time_for_user`
-
-Create a time entry on behalf of another user. Functionally equivalent to `create_time_entry` but with an explicit `user_id` parameter for PM-level workflows (logging time for a teammate).
-
-**Parameters:**
-- `user_id` (integer, required): ID of the user to log time for. Use `list_project_members` to discover valid user IDs for a project.
-- `hours` (number, required): Positive number of hours spent.
-- `project_id` (integer or string, optional): Project to log time against. Required if `issue_id` is not provided.
-- `issue_id` (integer, optional): Issue to log time against.
-- `activity_id` (integer, optional): Activity ID (use `list_time_entry_activities` to discover).
-- `comments` (string, optional): Description of work performed.
-- `spent_on` (string, optional): Date in YYYY-MM-DD format. Defaults to today.
-
-**Returns:** Dictionary containing the created time entry, or `{"error": "..."}` on failure.
-
-**Permission:** Requires `log_time_for_other_users` permission on the target project. The target user must also be a member of that project.
-
-**Example:**
-```python
-log_time_for_user(
-    user_id=7,
-    hours=2.5,
-    issue_id=123,
-    comments="Pair programming session",
-    spent_on="2026-04-15"
-)
-```
-
-**Known Redmine quirks:**
-- Some Redmine versions (defects #31587, #32774) reject `user_id` when the authenticated user is an admin but not a member of the target project. Workaround: add the admin as a project member.
-
----
-
 ### `import_time_entries`
 
 Bulk-import multiple time entries via sequential API calls. Redmine has no native bulk-import endpoint, so each entry is POSTed individually. Per-entry errors are captured so a partial import still yields useful feedback.
@@ -1539,253 +1438,83 @@ search_entire_redmine(query="bug", limit=25, offset=0)
 
 ---
 
-### `get_redmine_wiki_page`
+### `manage_redmine_wiki_page`
 
-Retrieve full wiki page content from a Redmine project.
+List, get, create, update, delete, or rename a Redmine wiki page. Replaces `list_wiki_pages`, `get_redmine_wiki_page`, `create_redmine_wiki_page`, `update_redmine_wiki_page`, `delete_redmine_wiki_page`, and `rename_wiki_page`.
 
 **Parameters:**
-- `project_id` (string or integer, required): Project identifier (ID number or string identifier)
-- `wiki_page_title` (string, required): Wiki page title (e.g., "Installation_Guide")
-- `version` (integer, optional): Specific version number. Default: latest version
-- `include_attachments` (boolean, optional): Include attachment metadata. Default: true
+- `action` (string, required): Allowed: `list`, `get`, `create`, `update`, `delete`, `rename`
+- `project_id` (integer or string, required): Project identifier (numeric ID or short name)
+- `wiki_page_title` (string): Wiki page title. Required for all actions except `list`
+- `version` (integer, optional): Specific version number for `get` (default: latest)
+- `include_attachments` (boolean, optional): Include attachment metadata in `get` response. Default: `true`
+- `text` (string): Page content. Required for `create` and `update`
+- `comments` (string, optional): Change log comment for `create` and `update`
+- `new_title` (string): New title for `rename` (must differ from `wiki_page_title`)
+- `redirect_existing_links` (boolean, optional): When `true` (default), `rename` creates a `WikiRedirect` from the old title to the new title
 
 **Returns:**
-```json
-{
-    "title": "Installation Guide",
-    "text": "# Installation\n\nFollow these steps to install...",
-    "version": 5,
-    "created_on": "2025-01-15T10:00:00Z",
-    "updated_on": "2025-01-20T14:30:00Z",
-    "author": {
-        "id": 123,
-        "name": "John Doe"
-    },
-    "project": {
-        "id": 1,
-        "name": "My Project"
-    },
-    "attachments": [
-        {
-            "id": 456,
-            "filename": "diagram.png",
-            "filesize": 102400,
-            "content_type": "image/png",
-            "description": "Architecture diagram",
-            "created_on": "2025-01-15T10:00:00Z"
-        }
-    ]
-}
-```
+- `list`: array of page metadata dicts (`title`, `version`, `parent_title` if present, `created_on`, `updated_on`) — no body text
+- `get`/`create`/`update`: full wiki page dict (`title`, `text`, `version`, `created_on`, `updated_on`, `author`, `project`, `attachments` when applicable)
+- `delete`: `{"success": true, "title": ..., "message": ...}`
+- `rename`: `{"success": true, ...}` plus the renamed page's metadata
+- Error: `{"error": "..."}`
 
-**Example:**
+**Examples:**
+
 ```python
-# Get latest version
-get_redmine_wiki_page(
-    project_id="my-project",
-    wiki_page_title="Installation_Guide"
-)
+# List all wiki pages in a project (metadata only)
+manage_redmine_wiki_page(action="list", project_id="my-project")
 
-# Get specific version
-get_redmine_wiki_page(
+# Get the latest version of a page (with attachments by default)
+manage_redmine_wiki_page(action="get", project_id="my-project", wiki_page_title="Installation_Guide")
+
+# Get a specific version, no attachments
+manage_redmine_wiki_page(
+    action="get",
     project_id=123,
-    wiki_page_title="Installation",
-    version=3
+    wiki_page_title="Installation_Guide",
+    version=3,
+    include_attachments=False,
 )
 
-# Without attachments
-get_redmine_wiki_page(
-    project_id="docs",
-    wiki_page_title="FAQ",
-    include_attachments=False
-)
-```
-
-**Notes:**
-- Use `get_redmine_attachment_download_url()` to download wiki attachments
-- Supports both string identifiers (e.g., "my-project") and numeric IDs
-
----
-
-### `create_redmine_wiki_page`
-
-Create a new wiki page in a Redmine project. Blocked when `REDMINE_MCP_READ_ONLY=true`.
-
-**Parameters:**
-- `project_id` (string or integer, required): Project identifier (ID number or string identifier)
-- `wiki_page_title` (string, required): Wiki page title (e.g., "Installation_Guide")
-- `text` (string, required): Wiki page content (Textile or Markdown depending on Redmine config)
-- `comments` (string, optional): Comment for the change log. Default: empty
-
-**Returns:**
-```json
-{
-    "title": "New Page",
-    "text": "# New Page\n\nContent here.",
-    "version": 1,
-    "created_on": "2025-01-15T10:00:00Z",
-    "updated_on": "2025-01-15T10:00:00Z",
-    "author": {
-        "id": 123,
-        "name": "John Doe"
-    },
-    "project": {
-        "id": 1,
-        "name": "My Project"
-    }
-}
-```
-
-**Example:**
-```python
-# Create a simple wiki page
-create_redmine_wiki_page(
+# Create a new page
+manage_redmine_wiki_page(
+    action="create",
     project_id="my-project",
     wiki_page_title="Getting_Started",
-    text="# Getting Started\n\nWelcome to the project!"
+    text="# Getting Started\n\nWelcome to the project!",
+    comments="Initial creation",
 )
 
-# Create with change log comment
-create_redmine_wiki_page(
-    project_id=123,
-    wiki_page_title="API_Reference",
-    text="# API Reference\n\n## Endpoints\n...",
-    comments="Initial API documentation"
-)
-```
-
-**Notes:**
-- Wiki page titles typically use underscores instead of spaces
-- Content format (Textile/Markdown) depends on Redmine server configuration
-- Requires wiki edit permissions in the target project
-
----
-
-### `update_redmine_wiki_page`
-
-Update an existing wiki page in a Redmine project. Blocked when `REDMINE_MCP_READ_ONLY=true`.
-
-**Parameters:**
-- `project_id` (string or integer, required): Project identifier (ID number or string identifier)
-- `wiki_page_title` (string, required): Wiki page title (e.g., "Installation_Guide")
-- `text` (string, required): New wiki page content
-- `comments` (string, optional): Comment for the change log. Default: empty
-
-**Returns:**
-```json
-{
-    "title": "Installation Guide",
-    "text": "# Installation\n\nUpdated content...",
-    "version": 6,
-    "created_on": "2025-01-10T10:00:00Z",
-    "updated_on": "2025-01-20T14:30:00Z",
-    "author": {
-        "id": 123,
-        "name": "John Doe"
-    },
-    "project": {
-        "id": 1,
-        "name": "My Project"
-    }
-}
-```
-
-**Example:**
-```python
-# Update wiki page content
-update_redmine_wiki_page(
+# Update an existing page
+manage_redmine_wiki_page(
+    action="update",
     project_id="my-project",
     wiki_page_title="Installation_Guide",
-    text="# Installation\n\nUpdated installation steps..."
+    text="# Installation\n\nUpdated steps...",
+    comments="Refreshed for 2026",
 )
 
-# Update with change log comment
-update_redmine_wiki_page(
-    project_id=123,
-    wiki_page_title="FAQ",
-    text="# FAQ\n\n## New Questions\n...",
-    comments="Added new FAQ entries"
-)
-```
+# Delete a page
+manage_redmine_wiki_page(action="delete", project_id="my-project", wiki_page_title="Obsolete_Page")
 
-**Notes:**
-- Version number increments automatically on each update
-- Redmine maintains version history for rollback
-- Requires wiki edit permissions in the target project
-
----
-
-### `delete_redmine_wiki_page`
-
-Delete a wiki page from a Redmine project. Blocked when `REDMINE_MCP_READ_ONLY=true`.
-
-**Parameters:**
-- `project_id` (string or integer, required): Project identifier (ID number or string identifier)
-- `wiki_page_title` (string, required): Wiki page title to delete
-
-**Returns:**
-```json
-{
-    "success": true,
-    "title": "Obsolete_Page",
-    "message": "Wiki page 'Obsolete_Page' deleted successfully."
-}
-```
-
-**Example:**
-```python
-# Delete a wiki page
-delete_redmine_wiki_page(
+# Rename a page (default: leaves a WikiRedirect)
+manage_redmine_wiki_page(
+    action="rename",
     project_id="my-project",
-    wiki_page_title="Obsolete_Page"
-)
-
-# Delete by numeric project ID
-delete_redmine_wiki_page(
-    project_id=123,
-    wiki_page_title="Old_Documentation"
+    wiki_page_title="Old_Title",
+    new_title="New_Title",
 )
 ```
 
 **Notes:**
-- Deletion is permanent - page and all versions are removed
-- Requires wiki delete permissions in the target project
-- Child pages (if any) may become orphaned
-
----
-
-### `list_wiki_pages`
-
-List all wiki pages in a Redmine project (titles, versions, parents, timestamps). Use [`get_redmine_wiki_page`](#get_redmine_wiki_page) to fetch a page's content.
-
-**Parameters:**
-
-| Parameter | Type | Required | Description |
-|-----------|------|----------|-------------|
-| `project_id` | int or string | Yes | Project identifier (ID or short name) |
-
-**Returns:** A list of wiki page metadata dicts with `title`, `version`, `parent_title` (when present), `created_on`, `updated_on`. On failure, returns a dict with an `error` key.
-
----
-
-### `rename_wiki_page`
-
-Rename (move) an existing wiki page. **Write operation** — blocked when `REDMINE_MCP_READ_ONLY=true`.
-
-Implemented via `PUT /projects/{id}/wiki/{old_title}.json` with the `title` parameter. Redmine requires `text` to be re-sent on every update; the tool fetches the current text automatically. When `redirect_existing_links=True`, Redmine creates a `WikiRedirect` so old links keep working.
-
-**Permission caveat:** Requires the `rename_wiki_pages` permission. If the API user lacks it, Redmine **silently drops the title change** (the body still updates). To detect this, the tool re-fetches the page at the new title after the update and returns an explicit error if the new title is unreachable.
-
-**Parameters:**
-
-| Parameter | Type | Required | Default | Description |
-|-----------|------|----------|---------|-------------|
-| `project_id` | int or string | Yes | – | Project identifier |
-| `old_title` | string | Yes | – | Current wiki page title |
-| `new_title` | string | Yes | – | New title (must differ from old) |
-| `redirect_existing_links` | bool | No | `true` | Create a redirect from old to new title |
-
-**Returns:** Dict with the renamed page's metadata, or an error dict on failure.
+- `list` and `get` are allowed in read-only mode; `create`, `update`, `delete`, and `rename` are blocked when `REDMINE_MCP_READ_ONLY=true`.
+- Wiki page titles typically use underscores instead of spaces.
+- Content format (Textile/Markdown) depends on Redmine server configuration.
+- Use `get_redmine_attachment_download_url` to download wiki attachments.
+- `rename` requires the `rename_wiki_pages` permission. If the API user lacks it, Redmine **silently drops the title change** (the body still updates). The tool re-fetches the page at `new_title` after the update and returns an explicit error if the new title is unreachable.
+- The `rename` action implements `PUT /projects/{id}/wiki/{old_title}.json` and fetches the existing text automatically since Redmine requires `text` on every wiki update.
 
 ---
 
@@ -2021,33 +1750,6 @@ At least one optional parameter must be provided.
 
 ---
 
-### `mark_checklist_done`
-
-Toggle the done/undone state of a checklist item. Convenience tool equivalent to `update_checklist_item(checklist_item_id, is_done=...)`. This is a **write operation** and is blocked in read-only mode.
-
-**Parameters:**
-
-| Parameter | Type | Required | Default | Description |
-|-----------|------|----------|---------|-------------|
-| `checklist_item_id` | int | Yes | – | The ID of the checklist item |
-| `is_done` | bool | No | `true` | `true` to mark as done, `false` to mark undone |
-
-**Returns:**
-
-| Field | Type | Description |
-|-------|------|-------------|
-| `success` | bool | `true` on success |
-| `checklist_item_id` | int | The item's ID |
-| `is_done` | bool | The new done state |
-
-**Error cases:**
-- Read-only mode: returns read-only error
-- Plugin disabled: returns plugin-disabled error
-- Invalid `checklist_item_id`: returns `{"error": "checklist_item_id must be a positive integer."}`
-- Invalid `is_done` type: returns `{"error": "is_done must be a boolean."}`
-
----
-
 ## Gantt Chart
 
 ### `get_gantt_chart`
@@ -2085,65 +1787,60 @@ Use cases: "What's the current timeline for project X?", "Which issues are overd
 
 These tools require the **RedmineUP Products** plugin and `REDMINE_PRODUCTS_ENABLED=true`.
 
-### `list_products`
+### `manage_product`
 
-List products from the Products plugin. Returns a list of product dicts. On failure, returns a dict with an `error` key.
+List, get, create, or update RedmineUP products. Replaces `list_products`, `get_product`, `add_product`, and `edit_product`.
 
-**Parameters:**
-
-| Parameter | Type | Required | Default | Description |
-|-----------|------|----------|---------|-------------|
-| `project_id` | int or string | No | – | Filter by project (omitted = all accessible) |
-| `limit` | int | No | `100` | Max results per call (1–100). Redmine's REST API caps `limit` at 100 server-side; values above are silently clamped. |
-
----
-
-### `get_product`
-
-Retrieve a single product by ID.
+Requires the **RedmineUP Products** plugin and `REDMINE_PRODUCTS_ENABLED=true`.
 
 **Parameters:**
+- `action` (string, required): Allowed: `list`, `get`, `create`, `update`
+- `project_id` (integer or string, optional): For `list`, filters products by project (omitted = all accessible). For `create`, optionally associates the new product with a project
+- `limit` (integer, optional): For `list`, max results per call (default `100`). Redmine caps `limit` at 100 server-side; values above are clamped
+- `product_id` (integer): Required for `get` and `update`
+- `name` (string): Required for `create`
+- `status_id` (integer, optional): For `create`. Must be `1` (Active, default) or `2` (Inactive)
+- `description`, `code` (string, optional): For `create`
+- `price` (float, optional): For `create`
+- `currency` (string, optional): For `create` (e.g., `"USD"`)
+- `category_id` (integer, optional): For `create`
+- `tag_list` (string, optional): For `create`, comma-separated tags
+- `custom_fields` (list, optional): For `create`, list of `{"id": N, "value": ...}` dicts
+- `fields` (dict): For `update`, fields to update. Allowed keys: `name`, `description`, `price`, `currency`, `status_id`, `code`, `project_id`, `category_id`, `tag_list`, `custom_fields`. Unknown keys are silently filtered
 
-| Parameter | Type | Required | Description |
-|-----------|------|----------|-------------|
-| `product_id` | int | Yes | Product ID |
+**Returns:**
+- `list`: array of product dicts
+- `get`/`create`: product dict
+- `update`: `{"success": true, "product_id": N, "updated_fields": [...]}`
+- Error: `{"error": "..."}`
 
-Returns a dict with product metadata, or `{"error": "..."}` on failure.
+**Examples:**
 
----
+```python
+# List products in a project
+manage_product(action="list", project_id="catalog", limit=50)
 
-### `add_product`
+# Fetch a specific product
+manage_product(action="get", product_id=42)
 
-Create a new product. **Write operation** — blocked when `REDMINE_MCP_READ_ONLY=true`.
+# Create a new product
+manage_product(
+    action="create",
+    name="Widget Pro",
+    status_id=1,
+    project_id="catalog",
+    price=49.99,
+    currency="USD",
+    code="WP-001",
+)
 
-**Parameters:**
+# Update a product's price
+manage_product(action="update", product_id=42, fields={"price": 39.99})
+```
 
-| Parameter | Type | Required | Default | Description |
-|-----------|------|----------|---------|-------------|
-| `name` | string | Yes | – | Product name |
-| `status_id` | int | No | `1` | Must be `1` (Active) or `2` (Inactive); other values are rejected. |
-| `project_id` | int or string | No | – | Optional project association |
-| `description`, `code` | string | No | – | Optional descriptive fields |
-| `price` | float | No | – | Optional price |
-| `currency` | string | No | – | Currency code (e.g., "USD") |
-| `category_id` | int | No | – | Product category ID |
-| `tag_list` | string | No | – | Comma-separated tags |
-| `custom_fields` | list | No | – | List of `{"id": N, "value": ...}` dicts |
-
----
-
-### `edit_product`
-
-Update fields on an existing product. **Write operation** — blocked when `REDMINE_MCP_READ_ONLY=true`.
-
-**Parameters:**
-
-| Parameter | Type | Required | Description |
-|-----------|------|----------|-------------|
-| `product_id` | int | Yes | Product ID |
-| `fields` | dict | Yes | Fields to update. Allowed keys: `name`, `description`, `price`, `currency`, `status_id`, `code`, `project_id`, `category_id`, `tag_list`, `custom_fields`. Unknown keys silently filtered. |
-
-Returns `{"success": True, "product_id": N, "updated_fields": [...]}` or an error dict.
+**Notes:**
+- `list` and `get` are allowed in read-only mode; `create` and `update` are blocked when `REDMINE_MCP_READ_ONLY=true`.
+- The plugin does not expose a delete endpoint, so `manage_product` has no `delete` action.
 
 ---
 
@@ -2153,99 +1850,74 @@ These tools require the **RedmineUP CRM** plugin and `REDMINE_CRM_ENABLED=true`.
 
 **Security note:** Contact PII (email, phone, address) is returned as-is to the caller but is never logged via this module's logger.
 
-### `list_contacts`
+### `manage_contact`
 
-List contacts. Visibility scoping is enforced server-side by Redmine.
+List, get, create, update, delete, or change project association for RedmineUP CRM contacts. Replaces `list_contacts`, `get_contact`, `create_contact`, `edit_contact`, `delete_contact`, `assign_contact_to_project`, and `remove_contact_from_project`.
 
-**Parameters:**
-
-| Parameter | Type | Required | Default | Description |
-|-----------|------|----------|---------|-------------|
-| `project_id` | int or string | No | – | Filter by project |
-| `search` | string | No | – | Free-text search (matches name/company/email) |
-| `tags` | string | No | – | Comma-separated tag filter |
-| `assigned_to_id` | int | No | – | Filter by assignee user ID |
-| `limit` | int | No | `100` | Max results per call (1–100). Redmine's REST API caps `limit` at 100 server-side; values above are silently clamped. |
-
-Returns a list of contact dicts.
-
----
-
-### `get_contact`
-
-Retrieve a single contact by ID.
+Requires the **RedmineUP CRM** plugin and `REDMINE_CRM_ENABLED=true`. Visibility scoping is enforced server-side by Redmine.
 
 **Parameters:**
+- `action` (string, required): Allowed: `list`, `get`, `create`, `update`, `delete`, `assign_to_project`, `remove_from_project`
+- `project_id` (integer or string): For `list`, optional project filter. For `create`, required (project to associate the new contact with). For `assign_to_project` / `remove_from_project`, the project to attach to or detach from
+- `search` (string, optional): For `list`, free-text search (matches name/company/email)
+- `tags` (string, optional): For `list`, comma-separated tag filter
+- `assigned_to_id` (integer, optional): For `list`, filter by assignee user ID
+- `limit` (integer, optional): For `list`, max results per call (default `100`, capped at 100 by Redmine)
+- `contact_id` (integer): Required for all actions except `list` and `create`
+- `include` (string, optional): For `get`, comma-separated includes (`notes`, `deals`, `contacts`)
+- `first_name` (string): Required for `create`
+- `last_name`, `company`, `email`, `phone` (string, optional): For `create`
+- `is_company` (boolean, optional): For `create`. `true` to mark as a company entity (default `false`)
+- `visibility` (integer, optional): For `create`. `0`=Project (default), `1`=Public, `2`=Private
+- `fields` (dict): For `update`, fields to update. Allowed keys: `first_name`, `last_name`, `middle_name`, `company`, `job_title`, `phone`, `email`, `website`, `skype_name`, `birthday`, `background`, `address_attributes`, `tag_list`, `is_company`, `assigned_to_id`, `custom_fields`, `visibility`, `project_id`. For `create`, additional fields beyond the named parameters
 
-| Parameter | Type | Required | Description |
-|-----------|------|----------|-------------|
-| `contact_id` | int | Yes | Contact ID |
-| `include` | string | No | Optional comma-separated includes: `notes`, `deals`, `contacts` |
+**Returns:**
+- `list`: array of contact dicts
+- `get`/`create`: contact dict
+- `update`: `{"success": true, "contact_id": N, "updated_fields": [...]}`
+- `delete`: `{"success": true, "contact_id": N, "message": ...}`
+- `assign_to_project` / `remove_from_project`: `{"success": true, "contact_id": N, "project_id": ...}`
+- Error: `{"error": "..."}`
 
----
+**Examples:**
 
-### `edit_contact`
+```python
+# List contacts in a project, filtering by tag and assignee
+manage_contact(
+    action="list",
+    project_id="sales",
+    tags="lead",
+    assigned_to_id=5,
+    limit=50,
+)
 
-Update fields on an existing contact. **Write operation**.
+# Fetch a single contact with related notes and deals
+manage_contact(action="get", contact_id=42, include="notes,deals")
 
-**Parameters:**
+# Create a new contact
+manage_contact(
+    action="create",
+    project_id="sales",
+    first_name="Alice",
+    last_name="Smith",
+    company="ACME",
+    email="alice@example.com",
+    visibility=0,
+)
 
-| Parameter | Type | Required | Description |
-|-----------|------|----------|-------------|
-| `contact_id` | int | Yes | Contact ID |
-| `fields` | dict | Yes | Fields to update. Allowed keys: `first_name`, `last_name`, `middle_name`, `company`, `job_title`, `phone`, `email`, `website`, `skype_name`, `birthday`, `background`, `address_attributes`, `tag_list`, `is_company`, `assigned_to_id`, `custom_fields`, `visibility`, `project_id`. |
+# Update a contact's job title
+manage_contact(action="update", contact_id=42, fields={"job_title": "Director"})
 
----
+# Delete a contact
+manage_contact(action="delete", contact_id=42)
 
-### `create_contact`
+# Add a contact to an additional project (without creating a new record)
+manage_contact(action="assign_to_project", contact_id=42, project_id="support")
 
-Create a new contact. **Write operation**.
+# Remove a contact from a project (does not delete the contact)
+manage_contact(action="remove_from_project", contact_id=42, project_id="support")
+```
 
-**Parameters:**
-
-| Parameter | Type | Required | Default | Description |
-|-----------|------|----------|---------|-------------|
-| `project_id` | int or string | Yes | – | Project to associate the contact with |
-| `first_name` | string | Yes | – | First name |
-| `last_name`, `company`, `email`, `phone` | string | No | – | Common optional fields |
-| `is_company` | bool | No | `false` | `true` to mark as a company entity |
-| `visibility` | int | No | `0` | 0=Project, 1=Public, 2=Private |
-| `fields` | dict | No | – | Additional fields (any allowed contact field) |
-
----
-
-### `delete_contact`
-
-Permanently delete a CRM contact. **Write operation**.
-
-**Parameters:**
-
-| Parameter | Type | Required | Description |
-|-----------|------|----------|-------------|
-| `contact_id` | int | Yes | Contact ID |
-
----
-
-### `assign_contact_to_project`
-
-Add an existing contact to an additional project (does not create a new contact). **Write operation**.
-
-**Parameters:**
-
-| Parameter | Type | Required | Description |
-|-----------|------|----------|-------------|
-| `contact_id` | int | Yes | Contact ID |
-| `project_id` | int or string | Yes | Project to associate with |
-
----
-
-### `remove_contact_from_project`
-
-Remove a contact from a project without deleting the contact. **Write operation**.
-
-**Parameters:**
-
-| Parameter | Type | Required | Description |
-|-----------|------|----------|-------------|
-| `contact_id` | int | Yes | Contact ID |
-| `project_id` | int or string | Yes | Project to remove from |
+**Notes:**
+- `list` and `get` are allowed in read-only mode; `create`, `update`, `delete`, `assign_to_project`, and `remove_from_project` are blocked when `REDMINE_MCP_READ_ONLY=true`.
+- **PII handling:** contact `email`, `phone`, `address`, `birthday`, `website` are returned as-is to the caller; the module never logs them. Error messages reference only `contact_id`. User-controlled display fields (`first_name`, `last_name`, `middle_name`, `company`, `job_title`, `background`, `assigned_to.name`) are wrapped in `<insecure-content>` boundary tags so downstream LLMs treat them as untrusted data.

--- a/docs/tool-reference.md
+++ b/docs/tool-reference.md
@@ -154,12 +154,23 @@ Block all write operations by setting the `REDMINE_MCP_READ_ONLY` environment va
 REDMINE_MCP_READ_ONLY=true
 ```
 
-When enabled, the following tools return an error instead of executing:
+When enabled, the following tools return an error instead of executing
+(write actions only — read actions within the same tool still work):
+
+**Fully blocked (all actions are writes):**
 - `create_redmine_issue`
 - `update_redmine_issue`
-- `create_redmine_wiki_page`
-- `update_redmine_wiki_page`
-- `delete_redmine_wiki_page`
+- `manage_project_member` — all actions
+- `manage_issue_watcher` — all actions
+- `manage_issue_note` — all actions
+- `manage_time_entry` — all actions
+
+**Partially blocked (read actions still work):**
+- `manage_redmine_wiki_page` — `create`, `update`, `delete`, `rename` blocked; `list`, `get` allowed
+- `manage_issue_category` — `create`, `update`, `delete` blocked; `list` allowed
+- `manage_issue_relation` — `create`, `delete` blocked; `list` allowed
+- `manage_product` — `create`, `update` blocked; `list`, `get` allowed (also requires `REDMINE_PRODUCTS_ENABLED=true`)
+- `manage_contact` — `create`, `update`, `delete`, `assign_to_project`, `remove_from_project` blocked; `list`, `get` allowed (also requires `REDMINE_CRM_ENABLED=true`)
 
 All read tools (`get_redmine_issue`, `list_redmine_issues`, `list_redmine_projects`, etc.) and local operations (`cleanup_attachment_files`) continue to work normally.
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -706,8 +706,8 @@ docker logs -f <container-id>
    REDMINE_MCP_READ_ONLY=false
    ```
 2. If read-only is intentional (e.g., shared/demo instance), use only read tools:
-   - `get_redmine_issue`, `list_redmine_issues`, `list_redmine_projects`, `search_redmine_issues`, `search_entire_redmine`, `get_redmine_wiki_page`, etc.
-3. Blocked tools in read-only mode: `create_redmine_issue`, `update_redmine_issue`, `create_redmine_wiki_page`, `update_redmine_wiki_page`, `delete_redmine_wiki_page`
+   - `get_redmine_issue`, `list_redmine_issues`, `list_redmine_projects`, `search_redmine_issues`, `search_entire_redmine`, `manage_redmine_wiki_page(action="list"|"get")`, etc.
+3. Blocked tools in read-only mode: `create_redmine_issue`, `update_redmine_issue`, plus the write actions of every `manage_X` tool (e.g., `manage_redmine_wiki_page(action="create"|"update"|"delete"|"rename")`, `manage_issue_category(action="create"|"update"|"delete")`, `manage_project_member`, `manage_issue_watcher`, `manage_issue_note`, `manage_time_entry`, `manage_product(action="create"|"update")`, `manage_contact(action="create"|"update"|"delete"|"assign_to_project"|"remove_from_project")`). See [Read-Only Mode](./tool-reference.md#read-only-mode) in the tool reference for the full breakdown.
 
 #### "list_my_redmine_issues not found" / Import errors after upgrade
 

--- a/roadmap.md
+++ b/roadmap.md
@@ -63,9 +63,9 @@ GA release. Prompt injection protection with `<insecure-content>` boundary tags;
 ## 📅 Planned Releases
 
 ### v2.0.0 — Tool Consolidation (next)
-*Priority: High | Effort: Medium | Status: Designed; implementation plan ready*
+*Priority: High | Effort: Medium | Status: Implementation complete on `refactor/tool-consolidation` branch; pending merge to `develop` and release*
 
-Reduce tool count from 69 to ~43 by folding CRUD-style tools into `manage_X(action=...)` tools following the `manage_redmine_version` pattern. No functionality is lost; old tool names are removed.
+Reduce tool count from 69 to 43 by folding CRUD-style tools into `manage_X(action=...)` tools following the `manage_redmine_version` pattern. No functionality is lost; old tool names are removed.
 
 **The 9 new `manage_X` tools** (replacing 35 existing tools):
 
@@ -82,10 +82,10 @@ Reduce tool count from 69 to ~43 by folding CRUD-style tools into `manage_X(acti
 | `manage_contact` | `list_contacts`, `get_contact`, `create_contact`, `edit_contact`, `delete_contact`, `assign_contact_to_project`, `remove_contact_from_project` |
 
 **Tasks:**
-- [ ] Land 9 `manage_X` implementations behind a feature branch off post-v1.3 `develop`
-- [ ] Reorganize per-tool tests into per-`manage_X` test classes
-- [ ] Drop `mark_checklist_done` (use `update_checklist_item(is_done=True)` directly)
-- [ ] Update `docs/tool-reference.md`, `README.md`, `CHANGELOG.md` with migration guide
+- [x] Land 9 `manage_X` implementations behind a feature branch off post-v1.3 `develop`
+- [x] Reorganize per-tool tests into per-`manage_X` test classes
+- [x] Drop `mark_checklist_done` (use `update_checklist_item(is_done=True)` directly)
+- [x] Update `docs/tool-reference.md`, `README.md`, `CHANGELOG.md` with migration guide
 - [ ] Open public heads-up issue before merging
 
 **What stays the same:** the four most-used issue tools (`get_redmine_issue`, `list_redmine_issues`, `create_redmine_issue`, `update_redmine_issue`), `get_gantt_chart`, `get_private_notes`, all discovery/enumeration tools, all file operations, auth, SSL, plugin gating.

--- a/src/redmine_mcp_server/redmine_handler.py
+++ b/src/redmine_mcp_server/redmine_handler.py
@@ -5983,60 +5983,6 @@ async def update_checklist_item(
         )
 
 
-@mcp.tool()
-async def mark_checklist_done(
-    checklist_item_id: int,
-    is_done: bool = True,
-) -> Dict[str, Any]:
-    """Toggle the done/undone state of a checklist item.
-
-    Convenience tool that marks a checklist item as done or undone.
-    Equivalent to ``update_checklist_item(checklist_item_id, is_done=...)``.
-
-    Requires the RedmineUP Checklists plugin and
-    ``REDMINE_CHECKLISTS_ENABLED=true``. This is a write operation and
-    is blocked when ``REDMINE_MCP_READ_ONLY=true``.
-
-    Args:
-        checklist_item_id: The ID of the checklist item.
-        is_done: ``True`` to mark as done (default), ``False`` to mark undone.
-
-    Returns:
-        A success dict, or an error dict on failure.
-    """
-    if _is_read_only_mode():
-        return dict(_READ_ONLY_ERROR)
-
-    if not _is_checklists_enabled():
-        return {
-            "error": (
-                "Checklist support is disabled. "
-                "Set REDMINE_CHECKLISTS_ENABLED=true to enable it."
-            )
-        }
-
-    if not _is_positive_int(checklist_item_id):
-        return {"error": "checklist_item_id must be a positive integer."}
-
-    if not isinstance(is_done, bool):
-        return {"error": "is_done must be a boolean."}
-
-    try:
-        _update_checklist_item_api(checklist_item_id, {"is_done": is_done})
-        return {
-            "success": True,
-            "checklist_item_id": checklist_item_id,
-            "is_done": is_done,
-        }
-    except Exception as e:
-        return _handle_redmine_error(
-            e,
-            f"marking checklist item {checklist_item_id} "
-            f"as {'done' if is_done else 'undone'}",
-            {"resource_type": "checklist_item", "resource_id": checklist_item_id},
-        )
-
-
 # ---------------------------------------------------------------------------
 # Products tools (requires RedmineUP Products plugin)
 # ---------------------------------------------------------------------------

--- a/src/redmine_mcp_server/redmine_handler.py
+++ b/src/redmine_mcp_server/redmine_handler.py
@@ -2944,106 +2944,105 @@ async def copy_issue(
 
 
 @mcp.tool()
-async def list_issue_relations(
-    issue_id: int,
-) -> Union[List[Dict[str, Any]], Dict[str, Any]]:
-    """List all relations for a given Redmine issue.
-
-    Args:
-        issue_id: ID of the issue whose relations should be listed.
-
-    Returns:
-        List of relation dictionaries. On failure, a dict with an
-        ``"error"`` key is returned.
-    """
-    try:
-        relations = _get_redmine_client().issue_relation.filter(issue_id=issue_id)
-        return [_issue_relation_to_dict(r) for r in _iter_capped(relations)]
-    except Exception as e:
-        return _handle_redmine_error(
-            e,
-            f"listing relations for issue {issue_id}",
-            {"resource_type": "issue", "resource_id": issue_id},
-        )
-
-
-@mcp.tool()
-async def create_issue_relation(
-    issue_id: int,
-    issue_to_id: int,
-    relation_type: str = "relates",
+async def manage_issue_relation(
+    action: str,
+    issue_id: Optional[int] = None,
+    issue_to_id: Optional[int] = None,
+    relation_id: Optional[int] = None,
+    relation_type: Optional[str] = None,
     delay: Optional[int] = None,
-) -> Dict[str, Any]:
-    """Create a relation between two Redmine issues.
+) -> Union[List[Dict[str, Any]], Dict[str, Any]]:
+    """List, create, or delete a Redmine issue relation.
 
     Args:
-        issue_id: ID of the source issue.
-        issue_to_id: ID of the target issue to relate to.
-        relation_type: Type of relation. Must be one of: ``relates``,
-            ``duplicates``, ``duplicated``, ``blocks``, ``blocked``,
-            ``precedes``, ``follows``, ``copied_to``, ``copied_from``.
-            Defaults to ``relates``.
-        delay: Optional delay in days (only meaningful for ``precedes``
-            and ``follows`` relation types).
+        action: One of: ``list``, ``create``, ``delete``.
+        issue_id: Source issue ID. Required for ``list`` and ``create``.
+        issue_to_id: Target issue ID. Required for ``create``.
+        relation_id: Relation ID. Required for ``delete``.
+        relation_type: One of: ``relates``, ``duplicates``, ``duplicated``,
+            ``blocks``, ``blocked``, ``precedes``, ``follows``,
+            ``copied_to``, ``copied_from``. Defaults to ``relates`` for
+            ``create``.
+        delay: Delay in days for ``precedes`` / ``follows`` relations.
 
     Returns:
-        Dictionary containing the newly created relation. On failure a
-        dict with an ``"error"`` key is returned.
+        ``list``: list of relation dicts.
+        ``create``: relation dict.
+        ``delete``: ``{"success": True, "deleted_relation_id": ...}``.
+        On error: ``{"error": "..."}``.
     """
-    if _is_read_only_mode():
-        return dict(_READ_ONLY_ERROR)
+    _valid_actions = {"list", "create", "delete"}
+    if action not in _valid_actions:
+        return {"error": f"Invalid action '{action}'. Allowed: list, create, delete"}
 
-    if relation_type not in _VALID_ISSUE_RELATION_TYPES:
-        return {
-            "error": (
-                f"Invalid relation_type '{relation_type}'. Must be one of: "
-                f"{', '.join(sorted(_VALID_ISSUE_RELATION_TYPES))}."
+    if action == "list":
+        if issue_id is None:
+            return {"error": "issue_id is required for action 'list'"}
+        try:
+            relations = _get_redmine_client().issue_relation.filter(issue_id=issue_id)
+            return [_issue_relation_to_dict(r) for r in _iter_capped(relations)]
+        except Exception as e:
+            return _handle_redmine_error(
+                e,
+                f"listing relations for issue {issue_id}",
+                {"resource_type": "issue", "resource_id": issue_id},
             )
-        }
 
-    try:
-        params: Dict[str, Any] = {
-            "issue_id": issue_id,
-            "issue_to_id": issue_to_id,
-            "relation_type": relation_type,
-        }
-        if delay is not None:
-            params["delay"] = delay
+    elif action == "create":
+        if issue_id is None:
+            return {"error": "issue_id is required for action 'create'"}
+        if issue_to_id is None:
+            return {"error": "issue_to_id is required for action 'create'"}
 
-        relation = _get_redmine_client().issue_relation.create(**params)
-        return _issue_relation_to_dict(relation)
-    except Exception as e:
-        return _handle_redmine_error(
-            e,
-            f"creating relation from issue {issue_id} to {issue_to_id}",
-            {"resource_type": "issue", "resource_id": issue_id},
-        )
+        _rt = relation_type if relation_type is not None else "relates"
+        if _rt not in _VALID_ISSUE_RELATION_TYPES:
+            return {
+                "error": (
+                    f"Invalid relation_type '{_rt}'. Must be one of: "
+                    f"{', '.join(sorted(_VALID_ISSUE_RELATION_TYPES))}."
+                )
+            }
 
+        if _is_read_only_mode():
+            return dict(_READ_ONLY_ERROR)
 
-@mcp.tool()
-async def delete_issue_relation(relation_id: int) -> Dict[str, Any]:
-    """Delete a Redmine issue relation by its ID.
+        await _ensure_cleanup_started()
 
-    Args:
-        relation_id: ID of the relation to delete (the ``id`` field returned
-            by ``list_issue_relations`` or ``create_issue_relation``).
+        try:
+            params: Dict[str, Any] = {
+                "issue_id": issue_id,
+                "issue_to_id": issue_to_id,
+                "relation_type": _rt,
+            }
+            if delay is not None:
+                params["delay"] = delay
+            relation = _get_redmine_client().issue_relation.create(**params)
+            return _issue_relation_to_dict(relation)
+        except Exception as e:
+            return _handle_redmine_error(
+                e,
+                f"creating relation from issue {issue_id} to {issue_to_id}",
+                {"resource_type": "issue", "resource_id": issue_id},
+            )
 
-    Returns:
-        Dictionary with ``success: true`` on success. On failure a dict
-        with an ``"error"`` key is returned.
-    """
-    if _is_read_only_mode():
-        return dict(_READ_ONLY_ERROR)
+    else:  # action == "delete"
+        if relation_id is None:
+            return {"error": "relation_id is required for action 'delete'"}
 
-    try:
-        _get_redmine_client().issue_relation.delete(relation_id)
-        return {"success": True, "deleted_relation_id": relation_id}
-    except Exception as e:
-        return _handle_redmine_error(
-            e,
-            f"deleting relation {relation_id}",
-            {"resource_type": "relation", "resource_id": relation_id},
-        )
+        if _is_read_only_mode():
+            return dict(_READ_ONLY_ERROR)
+
+        await _ensure_cleanup_started()
+
+        try:
+            _get_redmine_client().issue_relation.delete(relation_id)
+            return {"success": True, "deleted_relation_id": relation_id}
+        except Exception as e:
+            return _handle_redmine_error(
+                e,
+                f"deleting relation {relation_id}",
+                {"resource_type": "relation", "resource_id": relation_id},
+            )
 
 
 @mcp.tool()
@@ -3080,75 +3079,47 @@ async def list_subtasks(
 
 
 @mcp.tool()
-async def add_watcher(issue_id: int, user_id: int) -> Dict[str, Any]:
-    """Add a user to the watcher list of a Redmine issue.
-
-    Requires Redmine 2.3.0+.
+async def manage_issue_watcher(
+    action: str,
+    issue_id: int,
+    user_id: int,
+) -> Dict[str, Any]:
+    """Add or remove a watcher on a Redmine issue. Requires Redmine 2.3.0+.
 
     Args:
+        action: One of: ``add``, ``remove``.
         issue_id: ID of the issue.
-        user_id: ID of the user to add as a watcher.
+        user_id: ID of the user to add or remove as a watcher.
 
     Returns:
-        Dictionary with ``success: true`` on success. On failure a dict
-        with an ``"error"`` key is returned.
+        ``{"success": True, "issue_id": ..., "user_id": ...}`` on success.
+        On error: ``{"error": "..."}``.
     """
-    if _is_read_only_mode():
-        return dict(_READ_ONLY_ERROR)
+    _valid_actions = {"add", "remove"}
+    if action not in _valid_actions:
+        return {"error": f"Invalid action '{action}'. Allowed: add, remove"}
 
     if not _is_positive_int(issue_id):
         return {"error": "issue_id must be a positive integer."}
     if not _is_positive_int(user_id):
         return {"error": "user_id must be a positive integer."}
 
-    try:
-        issue = _get_redmine_client().issue.get(issue_id)
-        issue.watcher.add(user_id)
-        return {
-            "success": True,
-            "issue_id": issue_id,
-            "user_id": user_id,
-        }
-    except Exception as e:
-        return _handle_redmine_error(
-            e,
-            f"adding watcher {user_id} to issue {issue_id}",
-            {"resource_type": "issue", "resource_id": issue_id},
-        )
-
-
-@mcp.tool()
-async def remove_watcher(issue_id: int, user_id: int) -> Dict[str, Any]:
-    """Remove a user from the watcher list of a Redmine issue.
-
-    Args:
-        issue_id: ID of the issue.
-        user_id: ID of the user to remove from watchers.
-
-    Returns:
-        Dictionary with ``success: true`` on success. On failure a dict
-        with an ``"error"`` key is returned.
-    """
     if _is_read_only_mode():
         return dict(_READ_ONLY_ERROR)
 
-    if not _is_positive_int(issue_id):
-        return {"error": "issue_id must be a positive integer."}
-    if not _is_positive_int(user_id):
-        return {"error": "user_id must be a positive integer."}
+    await _ensure_cleanup_started()
 
     try:
         issue = _get_redmine_client().issue.get(issue_id)
-        issue.watcher.remove(user_id)
-        return {
-            "success": True,
-            "issue_id": issue_id,
-            "user_id": user_id,
-        }
+        if action == "add":
+            issue.watcher.add(user_id)
+        else:
+            issue.watcher.remove(user_id)
+        return {"success": True, "issue_id": issue_id, "user_id": user_id}
     except Exception as e:
         return _handle_redmine_error(
             e,
-            f"removing watcher {user_id} from issue {issue_id}",
+            f"{action}ing watcher {user_id} on issue {issue_id}",
             {"resource_type": "issue", "resource_id": issue_id},
         )
 

--- a/src/redmine_mcp_server/redmine_handler.py
+++ b/src/redmine_mcp_server/redmine_handler.py
@@ -3125,56 +3125,81 @@ async def manage_issue_watcher(
 
 
 @mcp.tool()
-async def edit_note(
+async def manage_issue_note(
+    action: str,
     journal_id: int,
-    notes: str,
+    notes: Optional[str] = None,
     private_notes: Optional[bool] = None,
+    is_private: Optional[bool] = None,
 ) -> Dict[str, Any]:
-    """Update the text (and optionally privacy) of an existing journal note.
+    """Edit text or toggle privacy of a Redmine journal (issue note).
 
-    Redmine exposes ``PUT /journals/{id}.json`` for editing journal notes.
-    Only the ``notes`` text and the ``private_notes`` flag can be edited;
-    journal ``details`` (field-change history) are immutable.
-
-    Note: If a journal has no details attached and its notes are cleared,
-    Redmine will delete the journal record.
+    Both actions are writes and are blocked in read-only mode.
 
     Args:
-        journal_id: ID of the journal entry to update.
-        notes: New notes text (may be empty to clear notes).
-        private_notes: Optionally toggle the private flag on this journal
-            entry. When omitted, the existing flag is preserved.
+        action: One of: ``edit``, ``set_private``.
+        journal_id: ID of the journal entry (required for both actions).
+        notes: New notes text for ``edit`` (required; may be empty string
+            to clear the note).
+        private_notes: Optionally toggle private flag during ``edit``.
+        is_private: Required for ``set_private`` -- ``True`` to mark
+            private, ``False`` to make public.
 
     Returns:
-        Dictionary confirming the update. On failure a dict with an
-        ``"error"`` key is returned.
+        ``edit``: ``{"success": True, "journal_id": ..., "notes": ...,
+        "private_notes": ...}``.
+        ``set_private``: ``{"success": True, "journal_id": ...,
+        "private_notes": <bool>}``.
+        On error: ``{"error": "..."}``.
     """
+    _valid_actions = {"edit", "set_private"}
+    if action not in _valid_actions:
+        return {"error": f"Invalid action '{action}'. Allowed: edit, set_private"}
+
     if _is_read_only_mode():
         return dict(_READ_ONLY_ERROR)
 
-    try:
-        params: Dict[str, Any] = {"notes": notes}
-        if private_notes is not None:
-            params["private_notes"] = bool(private_notes)
+    if action == "edit":
+        if notes is None:
+            return {"error": "notes is required for action 'edit'"}
+        try:
+            params: Dict[str, Any] = {"notes": notes}
+            if private_notes is not None:
+                params["private_notes"] = bool(private_notes)
+            _get_redmine_client().issue_journal.update(journal_id, **params)
+            return {
+                "success": True,
+                "journal_id": journal_id,
+                "notes": notes,
+                "private_notes": (
+                    bool(private_notes) if private_notes is not None else None
+                ),
+            }
+        except Exception as e:
+            return _handle_redmine_error(
+                e,
+                f"editing journal {journal_id}",
+                {"resource_type": "journal", "resource_id": journal_id},
+            )
 
-        client = _get_redmine_client()
-        # python-redmine's IssueJournal supports update via
-        # PUT /journals/{id}.json with a {"journal": {...}} envelope.
-        client.issue_journal.update(journal_id, **params)
-        return {
-            "success": True,
-            "journal_id": journal_id,
-            "notes": notes,
-            "private_notes": (
-                bool(private_notes) if private_notes is not None else None
-            ),
-        }
-    except Exception as e:
-        return _handle_redmine_error(
-            e,
-            f"editing journal {journal_id}",
-            {"resource_type": "journal", "resource_id": journal_id},
-        )
+    else:  # action == "set_private"
+        if is_private is None:
+            return {"error": "is_private is required for action 'set_private'"}
+        try:
+            _get_redmine_client().issue_journal.update(
+                journal_id, private_notes=bool(is_private)
+            )
+            return {
+                "success": True,
+                "journal_id": journal_id,
+                "private_notes": bool(is_private),
+            }
+        except Exception as e:
+            return _handle_redmine_error(
+                e,
+                f"updating privacy of journal {journal_id}",
+                {"resource_type": "journal", "resource_id": journal_id},
+            )
 
 
 @mcp.tool()
@@ -3219,40 +3244,6 @@ async def get_private_notes(issue_id: int) -> List[Dict[str, Any]]:
                 {"resource_type": "issue", "resource_id": issue_id},
             )
         ]
-
-
-@mcp.tool()
-async def set_note_private(
-    journal_id: int,
-    is_private: bool,
-) -> Dict[str, Any]:
-    """Toggle the private/public state of an existing journal note.
-
-    Args:
-        journal_id: ID of the journal entry to update.
-        is_private: True to mark the note private, False to make it public.
-
-    Returns:
-        Dictionary confirming the change. On failure a dict with an
-        ``"error"`` key is returned.
-    """
-    if _is_read_only_mode():
-        return dict(_READ_ONLY_ERROR)
-
-    try:
-        client = _get_redmine_client()
-        client.issue_journal.update(journal_id, private_notes=bool(is_private))
-        return {
-            "success": True,
-            "journal_id": journal_id,
-            "private_notes": bool(is_private),
-        }
-    except Exception as e:
-        return _handle_redmine_error(
-            e,
-            f"updating privacy of journal {journal_id}",
-            {"resource_type": "journal", "resource_id": journal_id},
-        )
 
 
 @mcp.tool()

--- a/src/redmine_mcp_server/redmine_handler.py
+++ b/src/redmine_mcp_server/redmine_handler.py
@@ -3285,153 +3285,143 @@ async def set_note_private(
 
 
 @mcp.tool()
-async def list_issue_categories(
-    project_id: Union[str, int],
-) -> Union[List[Dict[str, Any]], Dict[str, Any]]:
-    """List all issue categories for a given Redmine project.
-
-    Args:
-        project_id: Project identifier (numeric ID or string identifier).
-
-    Returns:
-        List of issue category dictionaries. On failure a dict with an
-        ``"error"`` key is returned.
-    """
-    try:
-        categories = _get_redmine_client().issue_category.filter(project_id=project_id)
-        return [_issue_category_to_dict(c) for c in _iter_capped(categories)]
-    except Exception as e:
-        return _handle_redmine_error(
-            e,
-            f"listing issue categories for project {project_id}",
-            {"resource_type": "project", "resource_id": project_id},
-        )
-
-
-@mcp.tool()
-async def create_issue_category(
-    project_id: Union[str, int],
-    name: str,
-    assigned_to_id: Optional[int] = None,
-) -> Dict[str, Any]:
-    """Create a new issue category in a Redmine project.
-
-    Args:
-        project_id: Project identifier (numeric ID or string identifier).
-        name: Category name (required).
-        assigned_to_id: Optional default assignee user ID for issues in
-            this category.
-
-    Returns:
-        Dictionary containing the created issue category. On failure a
-        dict with an ``"error"`` key is returned.
-    """
-    if _is_read_only_mode():
-        return dict(_READ_ONLY_ERROR)
-
-    if not name or not name.strip():
-        return {"error": "Category 'name' is required."}
-
-    try:
-        params: Dict[str, Any] = {
-            "project_id": project_id,
-            "name": name.strip(),
-        }
-        if assigned_to_id is not None:
-            params["assigned_to_id"] = assigned_to_id
-
-        category = _get_redmine_client().issue_category.create(**params)
-        return _issue_category_to_dict(category)
-    except Exception as e:
-        return _handle_redmine_error(
-            e,
-            f"creating issue category in project {project_id}",
-            {"resource_type": "project", "resource_id": project_id},
-        )
-
-
-@mcp.tool()
-async def update_issue_category(
-    category_id: int,
+async def manage_issue_category(
+    action: str,
+    project_id: Optional[Union[str, int]] = None,
+    category_id: Optional[int] = None,
     name: Optional[str] = None,
     assigned_to_id: Optional[int] = None,
-) -> Dict[str, Any]:
-    """Update an existing Redmine issue category.
-
-    Args:
-        category_id: ID of the issue category to update.
-        name: New category name (optional).
-        assigned_to_id: New default assignee user ID (optional).
-
-    Returns:
-        Dictionary containing the updated issue category. On failure a
-        dict with an ``"error"`` key is returned.
-    """
-    if _is_read_only_mode():
-        return dict(_READ_ONLY_ERROR)
-
-    params: Dict[str, Any] = {}
-    if name is not None:
-        stripped = name.strip()
-        if not stripped:
-            return {"error": "Category 'name' cannot be empty."}
-        params["name"] = stripped
-    if assigned_to_id is not None:
-        params["assigned_to_id"] = assigned_to_id
-
-    if not params:
-        return {"error": "No fields provided for update."}
-
-    try:
-        client = _get_redmine_client()
-        client.issue_category.update(category_id, **params)
-        updated = client.issue_category.get(category_id)
-        return _issue_category_to_dict(updated)
-    except Exception as e:
-        return _handle_redmine_error(
-            e,
-            f"updating issue category {category_id}",
-            {"resource_type": "issue_category", "resource_id": category_id},
-        )
-
-
-@mcp.tool()
-async def delete_issue_category(
-    category_id: int,
     reassign_to_id: Optional[int] = None,
-) -> Dict[str, Any]:
-    """Delete a Redmine issue category.
+) -> Union[List[Dict[str, Any]], Dict[str, Any]]:
+    """List, create, update, or delete a Redmine issue category.
 
     Args:
-        category_id: ID of the issue category to delete.
-        reassign_to_id: Optional ID of another category to reassign existing
-            issues to. When omitted, issues in this category become
-            uncategorised.
+        action: One of: ``list``, ``create``, ``update``, ``delete``.
+        project_id: Project ID or identifier. Required for ``list`` and
+            ``create``.
+        category_id: Category ID. Required for ``update`` and ``delete``.
+        name: Category name. Required for ``create``, optional for
+            ``update`` (cannot be blank).
+        assigned_to_id: Default assignee user ID. Optional for ``create``
+            and ``update``.
+        reassign_to_id: Reassign existing issues to this category ID on
+            ``delete``. Optional.
 
     Returns:
-        Dictionary with ``success: true`` on success. On failure a dict
-        with an ``"error"`` key is returned.
+        ``list``: list of category dicts.
+        ``create``/``update``: category dict.
+        ``delete``: ``{"success": True, "deleted_category_id": ...,
+        "reassigned_to_id": ...}``.
+        On error: ``{"error": "..."}``.
     """
-    if _is_read_only_mode():
-        return dict(_READ_ONLY_ERROR)
-
-    try:
-        params: Dict[str, Any] = {}
-        if reassign_to_id is not None:
-            params["reassign_to_id"] = reassign_to_id
-
-        _get_redmine_client().issue_category.delete(category_id, **params)
+    _valid_actions = {"list", "create", "update", "delete"}
+    if action not in _valid_actions:
         return {
-            "success": True,
-            "deleted_category_id": category_id,
-            "reassigned_to_id": reassign_to_id,
+            "error": (
+                f"Invalid action '{action}'. " "Allowed: list, create, update, delete"
+            )
         }
-    except Exception as e:
-        return _handle_redmine_error(
-            e,
-            f"deleting issue category {category_id}",
-            {"resource_type": "issue_category", "resource_id": category_id},
-        )
+
+    if action == "list":
+        if project_id is None:
+            return {"error": "project_id is required for action 'list'"}
+        try:
+            categories = _get_redmine_client().issue_category.filter(
+                project_id=project_id
+            )
+            return [_issue_category_to_dict(c) for c in _iter_capped(categories)]
+        except Exception as e:
+            return _handle_redmine_error(
+                e,
+                f"listing issue categories for project {project_id}",
+                {"resource_type": "project", "resource_id": project_id},
+            )
+
+    elif action == "create":
+        if project_id is None:
+            return {"error": "project_id is required for action 'create'"}
+        if not name or not name.strip():
+            return {"error": "Category 'name' is required."}
+
+        if _is_read_only_mode():
+            return dict(_READ_ONLY_ERROR)
+
+        await _ensure_cleanup_started()
+
+        try:
+            params: Dict[str, Any] = {
+                "project_id": project_id,
+                "name": name.strip(),
+            }
+            if assigned_to_id is not None:
+                params["assigned_to_id"] = assigned_to_id
+            category = _get_redmine_client().issue_category.create(**params)
+            return _issue_category_to_dict(category)
+        except Exception as e:
+            return _handle_redmine_error(
+                e,
+                f"creating issue category in project {project_id}",
+                {"resource_type": "project", "resource_id": project_id},
+            )
+
+    elif action == "update":
+        if category_id is None:
+            return {"error": "category_id is required for action 'update'"}
+
+        update_params: Dict[str, Any] = {}
+        if name is not None:
+            stripped = name.strip()
+            if not stripped:
+                return {"error": "Category 'name' cannot be empty."}
+            update_params["name"] = stripped
+        if assigned_to_id is not None:
+            update_params["assigned_to_id"] = assigned_to_id
+
+        if not update_params:
+            return {"error": "No fields provided for update."}
+
+        if _is_read_only_mode():
+            return dict(_READ_ONLY_ERROR)
+
+        await _ensure_cleanup_started()
+
+        try:
+            client = _get_redmine_client()
+            client.issue_category.update(category_id, **update_params)
+            updated = client.issue_category.get(category_id)
+            return _issue_category_to_dict(updated)
+        except Exception as e:
+            return _handle_redmine_error(
+                e,
+                f"updating issue category {category_id}",
+                {"resource_type": "issue_category", "resource_id": category_id},
+            )
+
+    else:  # action == "delete"
+        if category_id is None:
+            return {"error": "category_id is required for action 'delete'"}
+
+        if _is_read_only_mode():
+            return dict(_READ_ONLY_ERROR)
+
+        await _ensure_cleanup_started()
+
+        try:
+            params = {}
+            if reassign_to_id is not None:
+                params["reassign_to_id"] = reassign_to_id
+            _get_redmine_client().issue_category.delete(category_id, **params)
+            return {
+                "success": True,
+                "deleted_category_id": category_id,
+                "reassigned_to_id": reassign_to_id,
+            }
+        except Exception as e:
+            return _handle_redmine_error(
+                e,
+                f"deleting issue category {category_id}",
+                {"resource_type": "issue_category", "resource_id": category_id},
+            )
 
 
 @mcp.tool()

--- a/src/redmine_mcp_server/redmine_handler.py
+++ b/src/redmine_mcp_server/redmine_handler.py
@@ -3897,302 +3897,236 @@ def _wiki_page_to_dict(
 
 
 @mcp.tool()
-async def get_redmine_wiki_page(
+async def manage_redmine_wiki_page(
+    action: str,
     project_id: Union[str, int],
-    wiki_page_title: str,
+    wiki_page_title: Optional[str] = None,
     version: Optional[int] = None,
     include_attachments: bool = True,
-) -> Dict[str, Any]:
-    """
-    Retrieve full wiki page content from Redmine.
+    text: Optional[str] = None,
+    comments: Optional[str] = None,
+    new_title: Optional[str] = None,
+    redirect_existing_links: bool = True,
+) -> Union[List[Dict[str, Any]], Dict[str, Any]]:
+    """List, get, create, update, delete, or rename a Redmine wiki page.
 
     Args:
-        project_id: Project identifier (ID number or string identifier)
-        wiki_page_title: Wiki page title (e.g., "Installation_Guide")
-        version: Specific version number (None = latest version)
-        include_attachments: Include attachment metadata in response
+        action: One of: ``list``, ``get``, ``create``, ``update``,
+            ``delete``, ``rename``.
+        project_id: Project identifier (required for all actions).
+        wiki_page_title: Wiki page title. Required for all actions
+            except ``list``.
+        version: Specific version to retrieve (``get`` only, optional).
+        include_attachments: Include attachment metadata in ``get``
+            response. Default ``True``.
+        text: Page content. Required for ``create`` and ``update``.
+        comments: Change log comment. Optional for ``create`` and
+            ``update``.
+        new_title: New title for the page (required for ``rename``).
+        redirect_existing_links: When ``True`` (default), the rename
+            creates a redirect from ``wiki_page_title`` to ``new_title``.
+            Passed to the API as ``"1"`` / ``"0"``.
 
     Returns:
-        Dictionary containing full wiki page content and metadata
-
-    Note:
-        Use get_redmine_attachment_download_url() to download attachments.
+        ``list``: list of page metadata dicts (no body text).
+        ``get`` / ``create`` / ``update``: wiki page dict.
+        ``delete``: ``{"success": True, "title": ..., "message": ...}``.
+        ``rename``: ``{"success": True, ...}`` with the renamed page's
+        metadata to confirm the title change actually applied.
+        On error: ``{"error": "..."}``.
     """
+    _valid_actions = {"list", "get", "create", "update", "delete", "rename"}
+    if action not in _valid_actions:
+        return {
+            "error": (
+                f"Invalid action '{action}'. "
+                "Allowed: list, get, create, update, delete, rename"
+            )
+        }
 
-    try:
+    if action == "list":
+        try:
+            client = _get_redmine_client()
+            pages = client.wiki_page.filter(project_id=project_id)
+            items: List[Dict[str, Any]] = []
+            for page in _iter_capped(pages):
+                entry: Dict[str, Any] = {
+                    "title": getattr(page, "title", None),
+                    "version": getattr(page, "version", None),
+                    "created_on": _safe_isoformat(getattr(page, "created_on", None)),
+                    "updated_on": _safe_isoformat(getattr(page, "updated_on", None)),
+                }
+                parent = getattr(page, "parent", None)
+                if parent is not None:
+                    entry["parent_title"] = getattr(parent, "title", None)
+                items.append(entry)
+            return items
+        except Exception as e:
+            return _handle_redmine_error(
+                e,
+                f"listing wiki pages in project {project_id}",
+                {"resource_type": "wiki pages", "resource_id": project_id},
+            )
+
+    # All non-list actions require wiki_page_title.
+    if not isinstance(wiki_page_title, str) or not wiki_page_title.strip():
+        return {
+            "error": (
+                f"wiki_page_title is required for action '{action}' "
+                "and must be a non-empty string."
+            )
+        }
+
+    if action == "get":
+        try:
+            if version:
+                wiki_page = _get_redmine_client().wiki_page.get(
+                    wiki_page_title, project_id=project_id, version=version
+                )
+            else:
+                wiki_page = _get_redmine_client().wiki_page.get(
+                    wiki_page_title, project_id=project_id
+                )
+            return _wiki_page_to_dict(wiki_page, include_attachments)
+        except Exception as e:
+            return _handle_redmine_error(
+                e,
+                f"fetching wiki page '{wiki_page_title}' in project {project_id}",
+                {"resource_type": "wiki page", "resource_id": wiki_page_title},
+            )
+
+    elif action == "create":
+        if text is None:
+            return {"error": "text is required for action 'create'"}
+
+        if _is_read_only_mode():
+            return dict(_READ_ONLY_ERROR)
+
         await _ensure_cleanup_started()
 
-        # Retrieve wiki page
-        if version:
-            wiki_page = _get_redmine_client().wiki_page.get(
-                wiki_page_title, project_id=project_id, version=version
+        try:
+            wiki_page = _get_redmine_client().wiki_page.create(
+                project_id=project_id,
+                title=wiki_page_title,
+                text=text,
+                comments=comments if comments else None,
             )
-        else:
+            return _wiki_page_to_dict(wiki_page)
+        except Exception as e:
+            return _handle_redmine_error(
+                e,
+                f"creating wiki page '{wiki_page_title}' in project {project_id}",
+                {"resource_type": "wiki page", "resource_id": wiki_page_title},
+            )
+
+    elif action == "update":
+        if text is None:
+            return {"error": "text is required for action 'update'"}
+
+        if _is_read_only_mode():
+            return dict(_READ_ONLY_ERROR)
+
+        await _ensure_cleanup_started()
+
+        try:
+            _get_redmine_client().wiki_page.update(
+                wiki_page_title,
+                project_id=project_id,
+                text=text,
+                comments=comments if comments else None,
+            )
             wiki_page = _get_redmine_client().wiki_page.get(
                 wiki_page_title, project_id=project_id
             )
+            return _wiki_page_to_dict(wiki_page)
+        except Exception as e:
+            return _handle_redmine_error(
+                e,
+                f"updating wiki page '{wiki_page_title}' in project {project_id}",
+                {"resource_type": "wiki page", "resource_id": wiki_page_title},
+            )
 
-        return _wiki_page_to_dict(wiki_page, include_attachments)
+    elif action == "delete":
+        if _is_read_only_mode():
+            return dict(_READ_ONLY_ERROR)
 
-    except Exception as e:
-        return _handle_redmine_error(
-            e,
-            f"fetching wiki page '{wiki_page_title}' in project {project_id}",
-            {"resource_type": "wiki page", "resource_id": wiki_page_title},
-        )
-
-
-@mcp.tool()
-async def create_redmine_wiki_page(
-    project_id: Union[str, int],
-    wiki_page_title: str,
-    text: str,
-    comments: str = "",
-) -> Dict[str, Any]:
-    """
-    Create a new wiki page in a Redmine project.
-
-    Args:
-        project_id: Project identifier (ID number or string identifier)
-        wiki_page_title: Wiki page title (e.g., "Installation_Guide")
-        text: Wiki page content (Textile or Markdown depending on Redmine config)
-        comments: Optional comment for the change log
-
-    Returns:
-        Dictionary containing created wiki page metadata, or error dict on failure
-    """
-
-    if _is_read_only_mode():
-        return dict(_READ_ONLY_ERROR)
-
-    try:
         await _ensure_cleanup_started()
-
-        # Create wiki page
-        wiki_page = _get_redmine_client().wiki_page.create(
-            project_id=project_id,
-            title=wiki_page_title,
-            text=text,
-            comments=comments if comments else None,
-        )
-
-        return _wiki_page_to_dict(wiki_page)
-
-    except Exception as e:
-        return _handle_redmine_error(
-            e,
-            f"creating wiki page '{wiki_page_title}' in project {project_id}",
-            {"resource_type": "wiki page", "resource_id": wiki_page_title},
-        )
-
-
-@mcp.tool()
-async def update_redmine_wiki_page(
-    project_id: Union[str, int],
-    wiki_page_title: str,
-    text: str,
-    comments: str = "",
-) -> Dict[str, Any]:
-    """
-    Update an existing wiki page in a Redmine project.
-
-    Args:
-        project_id: Project identifier (ID number or string identifier)
-        wiki_page_title: Wiki page title (e.g., "Installation_Guide")
-        text: New wiki page content
-        comments: Optional comment for the change log
-
-    Returns:
-        Dictionary containing updated wiki page metadata, or error dict on failure
-    """
-
-    if _is_read_only_mode():
-        return dict(_READ_ONLY_ERROR)
-
-    try:
-        await _ensure_cleanup_started()
-
-        # Update wiki page
-        _get_redmine_client().wiki_page.update(
-            wiki_page_title,
-            project_id=project_id,
-            text=text,
-            comments=comments if comments else None,
-        )
-
-        # Fetch updated page to return current state
-        wiki_page = _get_redmine_client().wiki_page.get(
-            wiki_page_title, project_id=project_id
-        )
-
-        return _wiki_page_to_dict(wiki_page)
-
-    except Exception as e:
-        return _handle_redmine_error(
-            e,
-            f"updating wiki page '{wiki_page_title}' in project {project_id}",
-            {"resource_type": "wiki page", "resource_id": wiki_page_title},
-        )
-
-
-@mcp.tool()
-async def delete_redmine_wiki_page(
-    project_id: Union[str, int],
-    wiki_page_title: str,
-) -> Dict[str, Any]:
-    """
-    Delete a wiki page from a Redmine project.
-
-    Args:
-        project_id: Project identifier (ID number or string identifier)
-        wiki_page_title: Wiki page title to delete
-
-    Returns:
-        Dictionary with success status, or error dict on failure
-    """
-
-    if _is_read_only_mode():
-        return dict(_READ_ONLY_ERROR)
-
-    try:
-        await _ensure_cleanup_started()
-
-        # Delete wiki page
-        _get_redmine_client().wiki_page.delete(wiki_page_title, project_id=project_id)
-
-        return {
-            "success": True,
-            "title": wiki_page_title,
-            "message": f"Wiki page '{wiki_page_title}' deleted successfully.",
-        }
-
-    except Exception as e:
-        return _handle_redmine_error(
-            e,
-            f"deleting wiki page '{wiki_page_title}' in project {project_id}",
-            {"resource_type": "wiki page", "resource_id": wiki_page_title},
-        )
-
-
-@mcp.tool()
-async def list_wiki_pages(
-    project_id: Union[str, int],
-) -> Union[List[Dict[str, Any]], Dict[str, Any]]:
-    """List all wiki pages in a Redmine project.
-
-    Returns metadata for every wiki page (title, version, parent, timestamps),
-    not the page text. Use ``get_redmine_wiki_page`` to fetch a page's content.
-
-    Args:
-        project_id: Project identifier (ID number or string identifier).
-
-    Returns:
-        A list of wiki page metadata dicts. On failure, a dict with an
-        ``error`` key.
-    """
-    try:
-        client = _get_redmine_client()
-        pages = client.wiki_page.filter(project_id=project_id)
-        items: List[Dict[str, Any]] = []
-        for page in _iter_capped(pages):
-            entry: Dict[str, Any] = {
-                "title": getattr(page, "title", None),
-                "version": getattr(page, "version", None),
-                "created_on": _safe_isoformat(getattr(page, "created_on", None)),
-                "updated_on": _safe_isoformat(getattr(page, "updated_on", None)),
-            }
-            parent = getattr(page, "parent", None)
-            if parent is not None:
-                entry["parent_title"] = getattr(parent, "title", None)
-            items.append(entry)
-        return items
-    except Exception as e:
-        return _handle_redmine_error(
-            e,
-            f"listing wiki pages in project {project_id}",
-            {"resource_type": "wiki pages", "resource_id": project_id},
-        )
-
-
-@mcp.tool()
-async def rename_wiki_page(
-    project_id: Union[str, int],
-    old_title: str,
-    new_title: str,
-    redirect_existing_links: bool = True,
-) -> Dict[str, Any]:
-    """Rename (move) an existing wiki page to a new title.
-
-    Renames the page by sending a ``PUT /projects/{id}/wiki/{old_title}.json``
-    request with the new ``title`` parameter. Redmine requires the ``text``
-    field to be re-sent on every update; this tool fetches the current text
-    automatically. When ``redirect_existing_links`` is ``True`` (the default),
-    Redmine creates a ``WikiRedirect`` so that links to the old title keep
-    working.
-
-    Requires the ``rename_wiki_pages`` permission. If the API user lacks
-    this permission, Redmine **silently drops** the title change. To detect
-    that case, this tool re-fetches the page after the update and verifies
-    the rename succeeded — returning an explicit error if not.
-
-    This is a write operation and is blocked when ``REDMINE_MCP_READ_ONLY=true``.
-
-    Args:
-        project_id: Project identifier (ID number or string identifier).
-        old_title: Current wiki page title.
-        new_title: New title for the page.
-        redirect_existing_links: When ``True``, create a redirect from
-            ``old_title`` to ``new_title`` (default ``True``).
-
-    Returns:
-        Dict with the renamed page's metadata, or an error dict on failure.
-    """
-    if _is_read_only_mode():
-        return dict(_READ_ONLY_ERROR)
-
-    if not isinstance(old_title, str) or not old_title.strip():
-        return {"error": "old_title must be a non-empty string."}
-    if not isinstance(new_title, str) or not new_title.strip():
-        return {"error": "new_title must be a non-empty string."}
-    if old_title == new_title:
-        return {"error": "new_title must differ from old_title."}
-
-    try:
-        client = _get_redmine_client()
-
-        existing = client.wiki_page.get(old_title, project_id=project_id)
-        existing_text = getattr(existing, "text", "") or ""
-
-        update_kwargs: Dict[str, Any] = {
-            "project_id": project_id,
-            "title": new_title,
-            "text": existing_text,
-        }
-        if redirect_existing_links:
-            update_kwargs["redirect_existing_links"] = "1"
-
-        client.wiki_page.update(old_title, **update_kwargs)
 
         try:
-            renamed = client.wiki_page.get(new_title, project_id=project_id)
-        except Exception:
+            _get_redmine_client().wiki_page.delete(
+                wiki_page_title, project_id=project_id
+            )
             return {
-                "error": (
-                    "Rename appeared to succeed but the page is not "
-                    f"reachable at '{new_title}'. The API user may lack "
-                    "the 'rename_wiki_pages' permission (Redmine silently "
-                    "drops the title change in that case)."
-                )
+                "success": True,
+                "title": wiki_page_title,
+                "message": f"Wiki page '{wiki_page_title}' deleted successfully.",
             }
+        except Exception as e:
+            return _handle_redmine_error(
+                e,
+                f"deleting wiki page '{wiki_page_title}' in project {project_id}",
+                {"resource_type": "wiki page", "resource_id": wiki_page_title},
+            )
 
-        return _wiki_page_to_dict(renamed, include_attachments=False)
-    except Exception as e:
-        return _handle_redmine_error(
-            e,
-            f"renaming wiki page '{old_title}' to '{new_title}' "
-            f"in project {project_id}",
-            {"resource_type": "wiki page", "resource_id": old_title},
-        )
+    else:  # action == "rename"
+        # Title validation runs before the read-only check so the
+        # per-action structure matches the rest of this tool. The original
+        # PR #98 ``rename_wiki_page`` checked read-only first; that ordering
+        # only differs from this one when an invalid ``new_title`` is sent
+        # while read-only mode is on.
+        if not isinstance(new_title, str) or not new_title.strip():
+            return {"error": "new_title must be a non-empty string."}
+        if new_title == wiki_page_title:
+            return {"error": "new_title must differ from wiki_page_title."}
+
+        if _is_read_only_mode():
+            return dict(_READ_ONLY_ERROR)
+
+        await _ensure_cleanup_started()
+
+        try:
+            client = _get_redmine_client()
+
+            # Redmine requires `text` on every wiki update; preserve the
+            # existing body so the rename is a pure title change.
+            existing = client.wiki_page.get(wiki_page_title, project_id=project_id)
+            existing_text = getattr(existing, "text", "") or ""
+
+            update_kwargs: Dict[str, Any] = {
+                "project_id": project_id,
+                "title": new_title,
+                "text": existing_text,
+            }
+            if redirect_existing_links:
+                update_kwargs["redirect_existing_links"] = "1"
+
+            client.wiki_page.update(wiki_page_title, **update_kwargs)
+
+            # If the API user lacks `rename_wiki_pages`, Redmine silently
+            # drops the title change. Re-fetch at the new title to confirm.
+            try:
+                renamed = client.wiki_page.get(new_title, project_id=project_id)
+            except Exception:
+                return {
+                    "error": (
+                        "Rename appeared to succeed but the page is not "
+                        f"reachable at '{new_title}'. The API user may lack "
+                        "the 'rename_wiki_pages' permission (Redmine "
+                        "silently drops the title change in that case)."
+                    )
+                }
+
+            renamed_dict = _wiki_page_to_dict(renamed, include_attachments=False)
+            return {"success": True, **renamed_dict}
+        except Exception as e:
+            return _handle_redmine_error(
+                e,
+                (
+                    f"renaming wiki page '{wiki_page_title}' to "
+                    f"'{new_title}' in project {project_id}"
+                ),
+                {"resource_type": "wiki page", "resource_id": wiki_page_title},
+            )
 
 
 @mcp.tool()

--- a/src/redmine_mcp_server/redmine_handler.py
+++ b/src/redmine_mcp_server/redmine_handler.py
@@ -5989,90 +5989,13 @@ async def update_checklist_item(
 
 
 @mcp.tool()
-async def list_products(
+async def manage_product(
+    action: str,
     project_id: Optional[Union[str, int]] = None,
     limit: int = 100,
-) -> Union[List[Dict[str, Any]], Dict[str, Any]]:
-    """List products from the RedmineUP Products plugin.
-
-    Requires the RedmineUP Products plugin and ``REDMINE_PRODUCTS_ENABLED=true``.
-
-    Args:
-        project_id: Optional project identifier to filter products by project.
-            When omitted, returns products across all projects accessible
-            to the API user.
-        limit: Maximum number of products to return per call (1-100, default
-            100). Redmine's REST API caps `limit` at 100; values above that
-            are clamped.
-
-    Returns:
-        List of product dicts (id, name, description, price, currency,
-        status_id, project, category, tags, code, timestamps).
-        On failure, a dict with an ``error`` key.
-    """
-    if not _is_products_enabled():
-        return dict(_PRODUCTS_DISABLED_ERROR)
-
-    if not isinstance(limit, int) or isinstance(limit, bool) or limit < 1:
-        return {"error": "limit must be a positive integer."}
-    limit = min(limit, _REDMINE_API_PAGE_CAP)
-    if project_id is not None and not _is_valid_project_id(project_id):
-        return {
-            "error": (
-                "project_id must be a non-empty string identifier or "
-                "positive integer."
-            )
-        }
-
-    try:
-        client = _get_redmine_client()
-        if project_id is not None:
-            url = f"{REDMINE_URL}/projects/{project_id}/products.json"
-        else:
-            url = f"{REDMINE_URL}/products.json"
-        payload = client.engine.request("get", url, params={"limit": limit})
-        raw = payload.get("products", []) if isinstance(payload, dict) else []
-        return [_product_to_dict(p) for p in raw[:limit]]
-    except Exception as e:
-        return _handle_redmine_error(
-            e,
-            f"listing products (project_id={project_id})",
-            {"resource_type": "products", "resource_id": project_id},
-        )
-
-
-@mcp.tool()
-async def get_product(product_id: int) -> Dict[str, Any]:
-    """Retrieve a single RedmineUP product by ID.
-
-    Requires the RedmineUP Products plugin and ``REDMINE_PRODUCTS_ENABLED=true``.
-    """
-    if not _is_products_enabled():
-        return dict(_PRODUCTS_DISABLED_ERROR)
-    if not _is_positive_int(product_id):
-        return {"error": "product_id must be a positive integer."}
-
-    try:
-        client = _get_redmine_client()
-        url = f"{REDMINE_URL}/products/{product_id}.json"
-        payload = client.engine.request("get", url)
-        product = payload.get("product", {}) if isinstance(payload, dict) else {}
-        if not product:
-            return {"error": f"Product {product_id} not found."}
-        return _product_to_dict(product)
-    except Exception as e:
-        return _handle_redmine_error(
-            e,
-            f"fetching product {product_id}",
-            {"resource_type": "product", "resource_id": product_id},
-        )
-
-
-@mcp.tool()
-async def add_product(
-    name: str,
+    product_id: Optional[int] = None,
+    name: Optional[str] = None,
     status_id: int = 1,
-    project_id: Optional[Union[str, int]] = None,
     description: Optional[str] = None,
     price: Optional[float] = None,
     currency: Optional[str] = None,
@@ -6080,100 +6003,123 @@ async def add_product(
     category_id: Optional[int] = None,
     tag_list: Optional[str] = None,
     custom_fields: Optional[List[Dict[str, Any]]] = None,
-) -> Dict[str, Any]:
-    """Create a new RedmineUP product.
+    fields: Optional[Dict[str, Any]] = None,
+) -> Union[List[Dict[str, Any]], Dict[str, Any]]:
+    """RedmineUP Products plugin tool. Combined CRUD-by-action.
 
-    Requires the RedmineUP Products plugin, ``REDMINE_PRODUCTS_ENABLED=true``,
-    and is blocked when ``REDMINE_MCP_READ_ONLY=true``.
-
-    Args:
-        name: Product name (required).
-        status_id: 1=Active (default), 2=Inactive.
-        project_id: Optional project to associate the product with.
-        description, price, currency, code: Optional fields.
-        category_id: Optional product category ID.
-        tag_list: Comma-separated tag list (e.g., "alpha,beta").
-        custom_fields: Optional list of ``{"id": N, "value": ...}`` dicts.
-
-    Returns:
-        Dict with the created product, or error dict on failure.
+    Actions: ``list``, ``get``, ``create``, ``update``.
+    Requires ``REDMINE_PRODUCTS_ENABLED=true`` and the RedmineUP Products
+    plugin.
     """
-    if _is_read_only_mode():
-        return dict(_READ_ONLY_ERROR)
     if not _is_products_enabled():
         return dict(_PRODUCTS_DISABLED_ERROR)
-    if not isinstance(name, str) or not name.strip():
-        return {"error": "name must be a non-empty string."}
-    if isinstance(status_id, bool) or status_id not in (1, 2):
-        return {"error": "status_id must be 1 (Active) or 2 (Inactive)."}
 
-    body: Dict[str, Any] = {"name": name, "status_id": status_id}
-    if project_id is not None:
-        body["project_id"] = project_id
-    if description is not None:
-        body["description"] = description
-    if price is not None:
-        body["price"] = price
-    if currency is not None:
-        body["currency"] = currency
-    if code is not None:
-        body["code"] = code
-    if category_id is not None:
-        if not _is_positive_int(category_id):
-            return {"error": "category_id must be a positive integer."}
-        body["category_id"] = category_id
-    if tag_list is not None:
-        body["tag_list"] = tag_list
-    if custom_fields is not None:
-        body["custom_fields"] = custom_fields
+    _valid_actions = {"list", "get", "create", "update"}
+    if action not in _valid_actions:
+        return {
+            "error": (
+                f"Invalid action '{action}'. " f"Allowed: {sorted(_valid_actions)}"
+            )
+        }
 
-    try:
-        client = _get_redmine_client()
-        url = f"{REDMINE_URL}/products.json"
-        payload = client.engine.request(
-            "post",
-            url,
-            headers={"Content-Type": "application/json"},
-            data=json.dumps({"product": body}),
-        )
-        product = payload.get("product", {}) if isinstance(payload, dict) else {}
-        return _product_to_dict(product) if product else {"success": True}
-    except Exception as e:
-        return _handle_redmine_error(
-            e,
-            f"creating product '{name}'",
-            {"resource_type": "product", "resource_id": name},
-        )
+    if action == "list":
+        if not isinstance(limit, int) or isinstance(limit, bool) or limit < 1:
+            return {"error": "limit must be a positive integer."}
+        limit = min(limit, _REDMINE_API_PAGE_CAP)
+        if project_id is not None and not _is_valid_project_id(project_id):
+            return {
+                "error": (
+                    "project_id must be a non-empty string identifier or "
+                    "positive integer."
+                )
+            }
+        try:
+            client = _get_redmine_client()
+            url = (
+                f"{REDMINE_URL}/projects/{project_id}/products.json"
+                if project_id is not None
+                else f"{REDMINE_URL}/products.json"
+            )
+            payload = client.engine.request("get", url, params={"limit": limit})
+            raw = payload.get("products", []) if isinstance(payload, dict) else []
+            return [_product_to_dict(p) for p in raw[:limit]]
+        except Exception as e:
+            return _handle_redmine_error(
+                e,
+                f"listing products (project_id={project_id})",
+                {"resource_type": "products", "resource_id": project_id},
+            )
 
+    if action == "get":
+        if not _is_positive_int(product_id):
+            return {"error": "product_id must be a positive integer."}
+        try:
+            client = _get_redmine_client()
+            url = f"{REDMINE_URL}/products/{product_id}.json"
+            payload = client.engine.request("get", url)
+            product = payload.get("product", {}) if isinstance(payload, dict) else {}
+            if not product:
+                return {"error": f"Product {product_id} not found."}
+            return _product_to_dict(product)
+        except Exception as e:
+            return _handle_redmine_error(
+                e,
+                f"fetching product {product_id}",
+                {"resource_type": "product", "resource_id": product_id},
+            )
 
-@mcp.tool()
-async def edit_product(
-    product_id: int,
-    fields: Dict[str, Any],
-) -> Dict[str, Any]:
-    """Update fields on an existing RedmineUP product.
-
-    Requires the RedmineUP Products plugin, ``REDMINE_PRODUCTS_ENABLED=true``,
-    and is blocked when ``REDMINE_MCP_READ_ONLY=true``.
-
-    Args:
-        product_id: The ID of the product to update.
-        fields: Dict of fields to update. Supported keys: name, description,
-            price, currency, status_id, code, project_id, category_id,
-            tag_list, custom_fields. Unknown keys are silently filtered out.
-
-    Returns:
-        Success dict with the updated fields, or error dict on failure.
-    """
+    # write actions below
     if _is_read_only_mode():
         return dict(_READ_ONLY_ERROR)
-    if not _is_products_enabled():
-        return dict(_PRODUCTS_DISABLED_ERROR)
+    await _ensure_cleanup_started()
+
+    if action == "create":
+        if not isinstance(name, str) or not name.strip():
+            return {"error": "name must be a non-empty string."}
+        if isinstance(status_id, bool) or status_id not in (1, 2):
+            return {"error": "status_id must be 1 (Active) or 2 (Inactive)."}
+        body: Dict[str, Any] = {"name": name, "status_id": status_id}
+        if project_id is not None:
+            body["project_id"] = project_id
+        if description is not None:
+            body["description"] = description
+        if price is not None:
+            body["price"] = price
+        if currency is not None:
+            body["currency"] = currency
+        if code is not None:
+            body["code"] = code
+        if category_id is not None:
+            if not _is_positive_int(category_id):
+                return {"error": "category_id must be a positive integer."}
+            body["category_id"] = category_id
+        if tag_list is not None:
+            body["tag_list"] = tag_list
+        if custom_fields is not None:
+            body["custom_fields"] = custom_fields
+        try:
+            client = _get_redmine_client()
+            url = f"{REDMINE_URL}/products.json"
+            payload = client.engine.request(
+                "post",
+                url,
+                headers={"Content-Type": "application/json"},
+                data=json.dumps({"product": body}),
+            )
+            product = payload.get("product", {}) if isinstance(payload, dict) else {}
+            return _product_to_dict(product) if product else {"success": True}
+        except Exception as e:
+            return _handle_redmine_error(
+                e,
+                f"creating product '{name}'",
+                {"resource_type": "product", "resource_id": name},
+            )
+
+    # action == "update"
     if not _is_positive_int(product_id):
         return {"error": "product_id must be a positive integer."}
     if not isinstance(fields, dict) or not fields:
         return {"error": "fields must be a non-empty dict."}
-
     filtered = {k: v for k, v in fields.items() if k in _PRODUCT_WRITABLE_FIELDS}
     if not filtered:
         return {
@@ -6182,7 +6128,6 @@ async def edit_product(
                 f"{sorted(_PRODUCT_WRITABLE_FIELDS)}"
             )
         }
-
     try:
         client = _get_redmine_client()
         url = f"{REDMINE_URL}/products/{product_id}.json"

--- a/src/redmine_mcp_server/redmine_handler.py
+++ b/src/redmine_mcp_server/redmine_handler.py
@@ -5212,151 +5212,113 @@ async def list_time_entries(
 
 
 @mcp.tool()
-async def create_time_entry(
-    hours: float,
+async def manage_time_entry(
+    action: str,
+    hours: Optional[float] = None,
     project_id: Optional[Union[str, int]] = None,
     issue_id: Optional[int] = None,
-    activity_id: Optional[int] = None,
-    comments: str = "",
-    spent_on: Optional[str] = None,
-) -> Dict[str, Any]:
-    """Create a new time entry in Redmine.
-
-    Log time against a project or issue. Either project_id or issue_id
-    must be provided. If issue_id is provided, the time entry will be
-    associated with that issue's project.
-
-    Args:
-        hours: Number of hours spent (required). Can be decimal (e.g., 1.5).
-        project_id: Project to log time against (ID or identifier).
-            Required if issue_id is not provided.
-        issue_id: Issue to log time against. If provided, project_id is optional.
-        activity_id: Time entry activity ID (e.g., Development, Design).
-            If not provided, Redmine uses the default activity.
-        comments: Description of work performed.
-        spent_on: Date when time was spent (YYYY-MM-DD). Defaults to today.
-
-    Returns:
-        Dictionary containing the created time entry, or error dict on failure.
-
-    Examples:
-        >>> await create_time_entry(hours=2.5, issue_id=123, comments="Bug fix")
-        {"id": 1, "hours": 2.5, "issue": {"id": 123}, ...}
-
-        >>> await create_time_entry(
-        ...     hours=1.0,
-        ...     project_id="my-project",
-        ...     activity_id=9,
-        ...     comments="Code review",
-        ...     spent_on="2024-03-15"
-        ... )
-        {"id": 2, "hours": 1.0, "project": {"id": 1, "name": "My Project"}, ...}
-    """
-    if _is_read_only_mode():
-        return dict(_READ_ONLY_ERROR)
-
-    if project_id is None and issue_id is None:
-        return {"error": "Either project_id or issue_id must be provided."}
-
-    hours_error = _validate_hours(hours)
-    if hours_error is not None:
-        return {"error": hours_error}
-
-    try:
-        # Build create parameters
-        params: Dict[str, Any] = {
-            "hours": hours,
-        }
-
-        if project_id is not None:
-            params["project_id"] = project_id
-        if issue_id is not None:
-            params["issue_id"] = issue_id
-        if activity_id is not None:
-            params["activity_id"] = activity_id
-        if comments:
-            params["comments"] = comments
-        if spent_on is not None:
-            params["spent_on"] = spent_on
-
-        time_entry = _get_redmine_client().time_entry.create(**params)
-        return _time_entry_to_dict(time_entry)
-
-    except Exception as e:
-        context = {}
-        if issue_id:
-            context = {"resource_type": "issue", "resource_id": issue_id}
-        elif project_id:
-            context = {"resource_type": "project", "resource_id": project_id}
-        return _handle_redmine_error(e, "creating time entry", context)
-
-
-@mcp.tool()
-async def update_time_entry(
-    time_entry_id: int,
-    hours: Optional[float] = None,
+    user_id: Optional[int] = None,
+    time_entry_id: Optional[int] = None,
     activity_id: Optional[int] = None,
     comments: Optional[str] = None,
     spent_on: Optional[str] = None,
 ) -> Dict[str, Any]:
-    """Update an existing time entry in Redmine.
-
-    Modify hours, activity, comments, or date of an existing time entry.
-    Only provided fields will be updated.
+    """Create or update a Redmine time entry.
 
     Args:
-        time_entry_id: ID of the time entry to update (required).
-        hours: New hours value. Must be positive if provided.
-        activity_id: New activity ID.
-        comments: New comments/description.
-        spent_on: New date (YYYY-MM-DD format).
+        action: One of: ``create``, ``update``.
+        hours: Hours spent. Required for ``create``; optional for
+            ``update`` (must be positive if provided).
+        project_id: Project to log against. Required for ``create`` if
+            ``issue_id`` is not provided.
+        issue_id: Issue to log against. Required for ``create`` if
+            ``project_id`` is not provided.
+        user_id: Log on behalf of this user (``create`` only). Requires
+            ``log_time_for_other_users`` permission.
+        time_entry_id: Entry to update. Required for ``update``.
+        activity_id: Activity ID (optional for both actions).
+        comments: Description. Empty string clears the field on
+            ``update``.
+        spent_on: Date in ``YYYY-MM-DD`` format (optional).
 
     Returns:
-        Dictionary containing the updated time entry, or error dict on failure.
-
-    Examples:
-        >>> await update_time_entry(time_entry_id=1, hours=3.0)
-        {"id": 1, "hours": 3.0, ...}
-
-        >>> await update_time_entry(
-        ...     time_entry_id=1,
-        ...     comments="Updated description",
-        ...     spent_on="2024-03-16"
-        ... )
-        {"id": 1, "comments": "Updated description", ...}
+        Time entry dictionary, or ``{"error": "..."}``.
     """
-    if hours is not None and hours <= 0:
-        return {"error": "Hours must be a positive number."}
+    _valid_actions = {"create", "update"}
+    if action not in _valid_actions:
+        return {"error": f"Invalid action '{action}'. Allowed: create, update"}
 
-    try:
-        # Build update parameters
-        params: Dict[str, Any] = {}
+    if _is_read_only_mode():
+        return dict(_READ_ONLY_ERROR)
 
+    await _ensure_cleanup_started()
+
+    if action == "create":
+        if project_id is None and issue_id is None:
+            return {"error": "Either project_id or issue_id must be provided."}
+
+        hours_error = _validate_hours(hours)
+        if hours_error is not None:
+            return {"error": hours_error}
+
+        if user_id is not None and not _is_positive_int(user_id):
+            return {"error": "user_id must be a positive integer."}
+
+        try:
+            params: Dict[str, Any] = {"hours": hours}
+            if project_id is not None:
+                params["project_id"] = project_id
+            if issue_id is not None:
+                params["issue_id"] = issue_id
+            if user_id is not None:
+                params["user_id"] = user_id
+            if activity_id is not None:
+                params["activity_id"] = activity_id
+            if comments is not None:
+                params["comments"] = comments
+            if spent_on is not None:
+                params["spent_on"] = spent_on
+            time_entry = _get_redmine_client().time_entry.create(**params)
+            return _time_entry_to_dict(time_entry)
+        except Exception as e:
+            context = {}
+            if issue_id:
+                context = {"resource_type": "issue", "resource_id": issue_id}
+            elif project_id:
+                context = {"resource_type": "project", "resource_id": project_id}
+            return _handle_redmine_error(e, "creating time entry", context)
+
+    else:  # action == "update"
+        if time_entry_id is None:
+            return {"error": "time_entry_id is required for action 'update'"}
+
+        update_params: Dict[str, Any] = {}
         if hours is not None:
-            params["hours"] = hours
+            hours_error = _validate_hours(hours)
+            if hours_error is not None:
+                return {"error": hours_error}
+            update_params["hours"] = hours
         if activity_id is not None:
-            params["activity_id"] = activity_id
+            update_params["activity_id"] = activity_id
         if comments is not None:
-            params["comments"] = comments
+            update_params["comments"] = comments
         if spent_on is not None:
-            params["spent_on"] = spent_on
+            update_params["spent_on"] = spent_on
 
-        if not params:
+        if not update_params:
             return {"error": "No fields provided for update."}
 
-        client = _get_redmine_client()
-        client.time_entry.update(time_entry_id, **params)
-
-        # Fetch and return updated entry
-        updated_entry = client.time_entry.get(time_entry_id)
-        return _time_entry_to_dict(updated_entry)
-
-    except Exception as e:
-        return _handle_redmine_error(
-            e,
-            f"updating time entry {time_entry_id}",
-            {"resource_type": "time entry", "resource_id": time_entry_id},
-        )
+        try:
+            client = _get_redmine_client()
+            client.time_entry.update(time_entry_id, **update_params)
+            updated = client.time_entry.get(time_entry_id)
+            return _time_entry_to_dict(updated)
+        except Exception as e:
+            return _handle_redmine_error(
+                e,
+                f"updating time entry {time_entry_id}",
+                {"resource_type": "time entry", "resource_id": time_entry_id},
+            )
 
 
 @mcp.tool()
@@ -5760,101 +5722,13 @@ def _validate_hours(value: Any) -> Optional[str]:
 
 
 @mcp.tool()
-async def log_time_for_user(
-    user_id: int,
-    hours: float,
-    project_id: Optional[Union[str, int]] = None,
-    issue_id: Optional[int] = None,
-    activity_id: Optional[int] = None,
-    comments: str = "",
-    spent_on: Optional[str] = None,
-) -> Dict[str, Any]:
-    """Create a time entry on behalf of another user.
-
-    Logs time against a project or issue with the given ``user_id`` as
-    the owner instead of the authenticated user. The authenticated user
-    must have the ``log_time_for_other_users`` permission on the target
-    project, and the target user must be a member of that project.
-
-    Note: This is functionally ``create_time_entry`` with a ``user_id``
-    parameter. It is provided as a dedicated tool to make PM-level
-    workflows explicit (logging time on behalf of a teammate).
-
-    Args:
-        user_id: ID of the user to log time for. Use ``list_project_members``
-            to discover valid user IDs for a project.
-        hours: Number of hours spent (must be positive).
-        project_id: Project to log time against (ID or identifier).
-            Required if ``issue_id`` is not provided.
-        issue_id: Issue to log time against. If provided, ``project_id``
-            is optional.
-        activity_id: Time entry activity ID. Use ``list_time_entry_activities``
-            to discover valid IDs. Defaults to Redmine's default activity.
-        comments: Description of work performed.
-        spent_on: Date when time was spent (YYYY-MM-DD). Defaults to today.
-
-    Returns:
-        Dictionary containing the created time entry. On failure a dict
-        with an ``"error"`` key is returned.
-
-    Known Redmine quirks:
-        - Some Redmine versions reject the ``user_id`` parameter when the
-          authenticated user is an admin but NOT a member of the target
-          project (defects #31587, #32774). The workaround is to add the
-          admin as a project member.
-    """
-    if _is_read_only_mode():
-        return dict(_READ_ONLY_ERROR)
-
-    if not _is_positive_int(user_id):
-        return {"error": "user_id must be a positive integer."}
-
-    if project_id is None and issue_id is None:
-        return {"error": "Either project_id or issue_id must be provided."}
-
-    hours_error = _validate_hours(hours)
-    if hours_error is not None:
-        return {"error": hours_error}
-
-    try:
-        params: Dict[str, Any] = {
-            "hours": hours,
-            "user_id": user_id,
-        }
-        if project_id is not None:
-            params["project_id"] = project_id
-        if issue_id is not None:
-            params["issue_id"] = issue_id
-        if activity_id is not None:
-            params["activity_id"] = activity_id
-        if comments:
-            params["comments"] = comments
-        if spent_on is not None:
-            params["spent_on"] = spent_on
-
-        time_entry = _get_redmine_client().time_entry.create(**params)
-        return _time_entry_to_dict(time_entry)
-    except Exception as e:
-        context = {}
-        if issue_id:
-            context = {"resource_type": "issue", "resource_id": issue_id}
-        elif project_id:
-            context = {"resource_type": "project", "resource_id": project_id}
-        return _handle_redmine_error(
-            e,
-            f"logging time for user {user_id}",
-            context,
-        )
-
-
-@mcp.tool()
 async def import_time_entries(
     entries: Union[List[Dict[str, Any]], str],
     stop_on_error: bool = False,
 ) -> Dict[str, Any]:
     """Bulk import multiple time entries in a single call.
 
-    **Use this tool (NOT ``create_time_entry`` in a loop) whenever the
+    **Use this tool (NOT ``manage_time_entry(action="create")`` in a loop) whenever the
     user asks to:**
         - import a timesheet / weekly timesheet / monthly report
         - bulk log, batch log, or log multiple entries at once
@@ -5863,11 +5737,12 @@ async def import_time_entries(
         - log the same activity for multiple team members at once
         - log a day's work spanning multiple issues
 
-    **Prefer this tool over calling ``create_time_entry`` N times** — it
-    reports partial failures via a ``succeeded``/``failed`` summary and
-    supports ``stop_on_error`` for transactional-style behaviour. Calling
-    ``create_time_entry`` in a loop gives no aggregate feedback and cannot
-    continue past per-entry errors gracefully.
+    **Prefer this tool over calling ``manage_time_entry(action="create")``
+    N times** -- it reports partial failures via a
+    ``succeeded``/``failed`` summary and supports ``stop_on_error`` for
+    transactional-style behaviour. Calling
+    ``manage_time_entry(action="create")`` in a loop gives no aggregate
+    feedback and cannot continue past per-entry errors gracefully.
 
     Redmine has no native bulk-import endpoint, so this tool creates each
     entry individually via ``POST /time_entries.json`` under the hood.
@@ -5875,9 +5750,10 @@ async def import_time_entries(
     partial import still yields useful feedback.
 
     Each entry must be a dict (or JSON object) with the standard
-    ``create_time_entry`` fields: ``hours`` (required), plus at least one
-    of ``project_id``/``issue_id``. Optional fields: ``user_id`` (to log
-    on behalf of a teammate), ``activity_id``, ``comments``, ``spent_on``.
+    ``manage_time_entry(action="create")`` fields: ``hours`` (required),
+    plus at least one of ``project_id``/``issue_id``. Optional fields:
+    ``user_id`` (to log on behalf of a teammate), ``activity_id``,
+    ``comments``, ``spent_on``.
 
     Args:
         entries: List of time entry dicts, OR a JSON array string. Capped

--- a/src/redmine_mcp_server/redmine_handler.py
+++ b/src/redmine_mcp_server/redmine_handler.py
@@ -4391,157 +4391,144 @@ async def get_project_modules(
 
 
 @mcp.tool()
-async def add_project_member(
-    project_id: Union[str, int],
-    role_ids: List[int],
+async def manage_project_member(
+    action: str,
+    project_id: Optional[Union[str, int]] = None,
+    membership_id: Optional[int] = None,
     user_id: Optional[int] = None,
     group_id: Optional[int] = None,
+    role_ids: Optional[List[int]] = None,
 ) -> Dict[str, Any]:
-    """Add a user or group as a member of a project with assigned roles.
-
-    Exactly one of ``user_id`` or ``group_id`` must be provided.
+    """Add, update, or remove a Redmine project membership.
 
     Args:
-        project_id: Project identifier (numeric ID or string identifier).
-        role_ids: List of role IDs to assign (at least one required).
-            Use the ``list_redmine_roles`` tool to discover valid role IDs
-            before calling this tool — role IDs vary between Redmine
-            instances and must not be guessed.
-        user_id: ID of the user to add as a member.
-        group_id: ID of the group to add as a member.
+        action: Operation to perform. One of: ``add``, ``update``, ``remove``.
+        project_id: Project ID or identifier. Required for ``action="add"``.
+        membership_id: Membership ID. Required for ``action="update"`` and
+            ``action="remove"``.
+        user_id: User ID. Exactly one of ``user_id`` or ``group_id`` required
+            for ``action="add"``.
+        group_id: Group ID. Exactly one of ``user_id`` or ``group_id`` required
+            for ``action="add"``.
+        role_ids: Non-empty list of role IDs. Required for ``action="add"``
+            and ``action="update"``. Use ``list_redmine_roles`` to discover
+            valid role IDs.
 
     Returns:
-        Dictionary containing the created membership. On failure a dict
-        with an ``"error"`` key is returned.
+        For ``add``/``update``: membership dictionary.
+        For ``remove``: ``{"success": True, "deleted_membership_id": ...}``.
+        On error: ``{"error": "..."}``.
     """
-    if _is_read_only_mode():
-        return dict(_READ_ONLY_ERROR)
+    _valid_actions = {"add", "update", "remove"}
+    if action not in _valid_actions:
+        return {"error": (f"Invalid action '{action}'. Allowed: add, update, remove")}
 
-    if (user_id is None) == (group_id is None):
-        return {"error": "Exactly one of user_id or group_id must be provided."}
+    if action == "add":
+        if project_id is None:
+            return {"error": "project_id is required for action 'add'"}
+        if (user_id is None) == (group_id is None):
+            return {"error": "Exactly one of user_id or group_id must be provided."}
+        principal_candidate = user_id if user_id is not None else group_id
+        if not _is_positive_int(principal_candidate):
+            return {"error": "user_id / group_id must be a positive integer."}
+        if not role_ids:
+            return {
+                "error": (
+                    "At least one role_id must be provided. "
+                    "Use `list_redmine_roles` to discover valid role IDs."
+                )
+            }
+        if not isinstance(role_ids, list) or not all(
+            _is_positive_int(r) for r in role_ids
+        ):
+            return {
+                "error": (
+                    "role_ids must be a list of positive integers. "
+                    "Use `list_redmine_roles` to discover valid role IDs."
+                )
+            }
 
-    principal_candidate = user_id if user_id is not None else group_id
-    if not _is_positive_int(principal_candidate):
-        return {"error": "user_id / group_id must be a positive integer."}
+        if _is_read_only_mode():
+            return dict(_READ_ONLY_ERROR)
 
-    if not role_ids:
-        return {
-            "error": (
-                "At least one role_id must be provided. "
-                "Use `list_redmine_roles` to discover valid role IDs."
+        await _ensure_cleanup_started()
+
+        # Redmine's POST /projects/{id}/memberships endpoint uses `user_id`
+        # for BOTH users and groups (shared principal ID namespace).
+        principal_id = user_id if user_id is not None else group_id
+
+        try:
+            membership = _get_redmine_client().project_membership.create(
+                project_id=project_id,
+                user_id=principal_id,
+                role_ids=role_ids,
             )
-        }
-    if not isinstance(role_ids, list) or not all(_is_positive_int(r) for r in role_ids):
-        return {
-            "error": (
-                "role_ids must be a list of positive integers. "
-                "Use `list_redmine_roles` to discover valid role IDs."
+            return _membership_to_dict(membership)
+        except Exception as e:
+            return _handle_redmine_error(
+                e,
+                f"adding member to project {project_id}",
+                {"resource_type": "project", "resource_id": project_id},
             )
-        }
 
-    # Redmine's POST /projects/{id}/memberships endpoint uses `user_id` for
-    # BOTH users and groups — they share the same principal ID namespace.
-    # There is no separate `group_id` parameter in the API, so we always
-    # forward group_id via the `user_id` field.
-    principal_id = user_id if user_id is not None else group_id
+    elif action == "update":
+        if membership_id is None:
+            return {"error": "membership_id is required for action 'update'"}
+        if not role_ids:
+            return {
+                "error": (
+                    "At least one role_id must be provided. "
+                    "Use `list_redmine_roles` to discover valid role IDs."
+                )
+            }
+        if not isinstance(role_ids, list) or not all(
+            _is_positive_int(r) for r in role_ids
+        ):
+            return {
+                "error": (
+                    "role_ids must be a list of positive integers. "
+                    "Use `list_redmine_roles` to discover valid role IDs."
+                )
+            }
 
-    try:
-        membership = _get_redmine_client().project_membership.create(
-            project_id=project_id,
-            user_id=principal_id,
-            role_ids=role_ids,
-        )
-        return _membership_to_dict(membership)
-    except Exception as e:
-        return _handle_redmine_error(
-            e,
-            f"adding member to project {project_id}",
-            {"resource_type": "project", "resource_id": project_id},
-        )
+        if _is_read_only_mode():
+            return dict(_READ_ONLY_ERROR)
 
+        await _ensure_cleanup_started()
 
-@mcp.tool()
-async def update_project_member(
-    membership_id: int,
-    role_ids: List[int],
-) -> Dict[str, Any]:
-    """Update the roles assigned to an existing project membership.
-
-    Only role assignments can be updated via the API. To change the user
-    or group of a membership, delete and recreate it.
-
-    Args:
-        membership_id: ID of the membership to update (obtained from
-            ``list_project_members``).
-        role_ids: New list of role IDs to assign. Replaces the existing set.
-            Use the ``list_redmine_roles`` tool to discover valid role IDs
-            before calling this tool.
-
-    Returns:
-        Dictionary containing the updated membership. On failure a dict
-        with an ``"error"`` key is returned.
-    """
-    if _is_read_only_mode():
-        return dict(_READ_ONLY_ERROR)
-
-    if not role_ids:
-        return {
-            "error": (
-                "At least one role_id must be provided. "
-                "Use `list_redmine_roles` to discover valid role IDs."
+        try:
+            client = _get_redmine_client()
+            client.project_membership.update(membership_id, role_ids=role_ids)
+            updated = client.project_membership.get(membership_id)
+            return _membership_to_dict(updated)
+        except Exception as e:
+            return _handle_redmine_error(
+                e,
+                f"updating project membership {membership_id}",
+                {"resource_type": "membership", "resource_id": membership_id},
             )
-        }
-    if not isinstance(role_ids, list) or not all(_is_positive_int(r) for r in role_ids):
-        return {
-            "error": (
-                "role_ids must be a list of positive integers. "
-                "Use `list_redmine_roles` to discover valid role IDs."
+
+    else:  # action == "remove"
+        if membership_id is None:
+            return {"error": "membership_id is required for action 'remove'"}
+
+        if _is_read_only_mode():
+            return dict(_READ_ONLY_ERROR)
+
+        await _ensure_cleanup_started()
+
+        try:
+            _get_redmine_client().project_membership.delete(membership_id)
+            return {
+                "success": True,
+                "deleted_membership_id": membership_id,
+            }
+        except Exception as e:
+            return _handle_redmine_error(
+                e,
+                f"removing project membership {membership_id}",
+                {"resource_type": "membership", "resource_id": membership_id},
             )
-        }
-
-    try:
-        client = _get_redmine_client()
-        client.project_membership.update(membership_id, role_ids=role_ids)
-        updated = client.project_membership.get(membership_id)
-        return _membership_to_dict(updated)
-    except Exception as e:
-        return _handle_redmine_error(
-            e,
-            f"updating project membership {membership_id}",
-            {"resource_type": "membership", "resource_id": membership_id},
-        )
-
-
-@mcp.tool()
-async def remove_project_member(membership_id: int) -> Dict[str, Any]:
-    """Remove a membership from a project.
-
-    Note: Inherited memberships (from a parent project) cannot be removed
-    directly — Redmine will return a 422 error. Remove them from the
-    parent project instead.
-
-    Args:
-        membership_id: ID of the membership to remove.
-
-    Returns:
-        Dictionary with ``success: true`` on success. On failure a dict
-        with an ``"error"`` key is returned.
-    """
-    if _is_read_only_mode():
-        return dict(_READ_ONLY_ERROR)
-
-    try:
-        _get_redmine_client().project_membership.delete(membership_id)
-        return {
-            "success": True,
-            "deleted_membership_id": membership_id,
-        }
-    except Exception as e:
-        return _handle_redmine_error(
-            e,
-            f"removing project membership {membership_id}",
-            {"resource_type": "membership", "resource_id": membership_id},
-        )
 
 
 # ---------------------------------------------------------------------------

--- a/src/redmine_mcp_server/redmine_handler.py
+++ b/src/redmine_mcp_server/redmine_handler.py
@@ -6307,169 +6307,16 @@ async def get_gantt_chart(
 
 
 @mcp.tool()
-async def list_contacts(
+async def manage_contact(
+    action: str,
     project_id: Optional[Union[str, int]] = None,
     search: Optional[str] = None,
     tags: Optional[str] = None,
     assigned_to_id: Optional[int] = None,
     limit: int = 100,
-) -> Union[List[Dict[str, Any]], Dict[str, Any]]:
-    """List contacts from the RedmineUP CRM plugin.
-
-    Requires the RedmineUP CRM plugin and ``REDMINE_CRM_ENABLED=true``.
-    Visibility is enforced by Redmine: results are scoped to the
-    authenticated user's accessible projects.
-
-    Args:
-        project_id: Optional project identifier filter.
-        search: Optional free-text search (matches name, company, email).
-        tags: Optional comma-separated tag filter.
-        assigned_to_id: Optional filter by assigned user ID.
-        limit: Maximum results per call (1-100, default 100). Redmine's
-            REST API caps `limit` at 100; values above that are clamped.
-
-    Returns:
-        List of contact dicts. On failure, dict with ``error``.
-    """
-    if not _is_crm_enabled():
-        return dict(_CRM_DISABLED_ERROR)
-    if not isinstance(limit, int) or isinstance(limit, bool) or limit < 1:
-        return {"error": "limit must be a positive integer."}
-    limit = min(limit, _REDMINE_API_PAGE_CAP)
-    if project_id is not None and not _is_valid_project_id(project_id):
-        return {
-            "error": (
-                "project_id must be a non-empty string identifier or "
-                "positive integer."
-            )
-        }
-
-    params: Dict[str, Any] = {"limit": limit}
-    if project_id is not None:
-        params["project_id"] = project_id
-    if search is not None:
-        params["search"] = search
-    if tags is not None:
-        params["tags"] = tags
-    if assigned_to_id is not None:
-        if not _is_positive_int(assigned_to_id):
-            return {"error": "assigned_to_id must be a positive integer."}
-        params["assigned_to_id"] = assigned_to_id
-
-    try:
-        client = _get_redmine_client()
-        url = f"{REDMINE_URL}/contacts.json"
-        payload = client.engine.request("get", url, params=params)
-        raw = payload.get("contacts", []) if isinstance(payload, dict) else []
-        return [_contact_to_dict(c) for c in raw[:limit]]
-    except Exception as e:
-        return _handle_redmine_error(
-            e,
-            "listing contacts",
-            {"resource_type": "contacts"},
-        )
-
-
-@mcp.tool()
-async def get_contact(
-    contact_id: int,
+    contact_id: Optional[int] = None,
     include: Optional[str] = None,
-) -> Dict[str, Any]:
-    """Retrieve a single CRM contact by ID.
-
-    Requires the RedmineUP CRM plugin and ``REDMINE_CRM_ENABLED=true``.
-
-    Args:
-        contact_id: The contact ID.
-        include: Optional comma-separated includes (``notes``, ``deals``,
-            ``contacts``).
-    """
-    if not _is_crm_enabled():
-        return dict(_CRM_DISABLED_ERROR)
-    if not _is_positive_int(contact_id):
-        return {"error": "contact_id must be a positive integer."}
-
-    try:
-        client = _get_redmine_client()
-        url = f"{REDMINE_URL}/contacts/{contact_id}.json"
-        params: Dict[str, Any] = {}
-        if include:
-            params["include"] = include
-        payload = client.engine.request("get", url, params=params)
-        contact = payload.get("contact", {}) if isinstance(payload, dict) else {}
-        if not contact:
-            return {"error": f"Contact {contact_id} not found."}
-        return _contact_to_dict(contact)
-    except Exception as e:
-        return _handle_redmine_error(
-            e,
-            f"fetching contact {contact_id}",
-            {"resource_type": "contact", "resource_id": contact_id},
-        )
-
-
-@mcp.tool()
-async def edit_contact(
-    contact_id: int,
-    fields: Dict[str, Any],
-) -> Dict[str, Any]:
-    """Update fields on an existing CRM contact.
-
-    Requires the RedmineUP CRM plugin, ``REDMINE_CRM_ENABLED=true``, and
-    is blocked when ``REDMINE_MCP_READ_ONLY=true``.
-
-    Args:
-        contact_id: Contact ID to update.
-        fields: Dict of fields. Allowed: first_name, last_name, middle_name,
-            company, job_title, phone, email, website, skype_name, birthday,
-            background, address_attributes, tag_list, is_company,
-            assigned_to_id, custom_fields, visibility, project_id.
-            Unknown fields are silently filtered.
-    """
-    if _is_read_only_mode():
-        return dict(_READ_ONLY_ERROR)
-    if not _is_crm_enabled():
-        return dict(_CRM_DISABLED_ERROR)
-    if not _is_positive_int(contact_id):
-        return {"error": "contact_id must be a positive integer."}
-    if not isinstance(fields, dict) or not fields:
-        return {"error": "fields must be a non-empty dict."}
-
-    filtered = {k: v for k, v in fields.items() if k in _CONTACT_WRITABLE_FIELDS}
-    if not filtered:
-        return {
-            "error": (
-                "No writable fields provided. Allowed fields: "
-                f"{sorted(_CONTACT_WRITABLE_FIELDS)}"
-            )
-        }
-
-    try:
-        client = _get_redmine_client()
-        url = f"{REDMINE_URL}/contacts/{contact_id}.json"
-        client.engine.request(
-            "put",
-            url,
-            headers={"Content-Type": "application/json"},
-            data=json.dumps({"contact": filtered}),
-        )
-        return {
-            "success": True,
-            "contact_id": contact_id,
-            "updated_fields": list(filtered.keys()),
-        }
-    except Exception as e:
-        return _handle_redmine_error(
-            e,
-            f"updating contact {contact_id}",
-            {"resource_type": "contact", "resource_id": contact_id},
-        )
-
-
-@mcp.tool()
-async def create_contact(
-    project_id: Union[str, int],
-    first_name: str,
+    first_name: Optional[str] = None,
     last_name: Optional[str] = None,
     company: Optional[str] = None,
     email: Optional[str] = None,
@@ -6477,161 +6324,198 @@ async def create_contact(
     is_company: bool = False,
     visibility: int = 0,
     fields: Optional[Dict[str, Any]] = None,
-) -> Dict[str, Any]:
-    """Create a new CRM contact in a project.
+) -> Union[List[Dict[str, Any]], Dict[str, Any]]:
+    """RedmineUP CRM (Contacts) plugin tool. Combined CRUD-by-action.
 
-    Requires the RedmineUP CRM plugin, ``REDMINE_CRM_ENABLED=true``, and
-    is blocked when ``REDMINE_MCP_READ_ONLY=true``.
+    Actions: ``list``, ``get``, ``create``, ``update``, ``delete``,
+    ``assign_to_project``, ``remove_from_project``.
 
-    Args:
-        project_id: Project to associate the contact with (required).
-        first_name: First name (required).
-        last_name, company, email, phone: Common optional fields.
-        is_company: ``True`` to mark this as a company entity.
-        visibility: 0=Project (default), 1=Public, 2=Private.
-        fields: Optional dict of additional fields (any key from the
-            contacts writable field set).
+    Requires ``REDMINE_CRM_ENABLED=true`` and the RedmineUP CRM plugin.
     """
-    if _is_read_only_mode():
-        return dict(_READ_ONLY_ERROR)
     if not _is_crm_enabled():
         return dict(_CRM_DISABLED_ERROR)
-    if not isinstance(first_name, str) or not first_name.strip():
-        return {"error": "first_name must be a non-empty string."}
-    if not isinstance(is_company, bool):
-        return {"error": "is_company must be a boolean."}
-    if visibility not in (0, 1, 2):
-        return {"error": "visibility must be 0 (Project), 1 (Public), or 2 (Private)."}
 
-    body: Dict[str, Any] = {
-        "project_id": project_id,
-        "first_name": first_name,
-        "is_company": is_company,
-        "visibility": visibility,
+    _valid_actions = {
+        "list",
+        "get",
+        "create",
+        "update",
+        "delete",
+        "assign_to_project",
+        "remove_from_project",
     }
-    if last_name is not None:
-        body["last_name"] = last_name
-    if company is not None:
-        body["company"] = company
-    if email is not None:
-        body["email"] = email
-    if phone is not None:
-        body["phone"] = phone
-    if fields:
-        for k, v in fields.items():
-            if k in _CONTACT_WRITABLE_FIELDS:
-                body[k] = v
-
-    try:
-        client = _get_redmine_client()
-        url = f"{REDMINE_URL}/contacts.json"
-        payload = client.engine.request(
-            "post",
-            url,
-            headers={"Content-Type": "application/json"},
-            data=json.dumps({"contact": body}),
-        )
-        contact = payload.get("contact", {}) if isinstance(payload, dict) else {}
-        return _contact_to_dict(contact) if contact else {"success": True}
-    except Exception as e:
-        return _handle_redmine_error(
-            e,
-            "creating contact",
-            {"resource_type": "contact"},
-        )
-
-
-@mcp.tool()
-async def delete_contact(contact_id: int) -> Dict[str, Any]:
-    """Delete a CRM contact.
-
-    Requires the RedmineUP CRM plugin, ``REDMINE_CRM_ENABLED=true``, and
-    is blocked when ``REDMINE_MCP_READ_ONLY=true``.
-    """
-    if _is_read_only_mode():
-        return dict(_READ_ONLY_ERROR)
-    if not _is_crm_enabled():
-        return dict(_CRM_DISABLED_ERROR)
-    if not _is_positive_int(contact_id):
-        return {"error": "contact_id must be a positive integer."}
-
-    try:
-        client = _get_redmine_client()
-        url = f"{REDMINE_URL}/contacts/{contact_id}.json"
-        client.engine.request("delete", url)
-        return {
-            "success": True,
-            "contact_id": contact_id,
-            "message": f"Contact {contact_id} deleted.",
-        }
-    except Exception as e:
-        return _handle_redmine_error(
-            e,
-            f"deleting contact {contact_id}",
-            {"resource_type": "contact", "resource_id": contact_id},
-        )
-
-
-@mcp.tool()
-async def assign_contact_to_project(
-    contact_id: int,
-    project_id: Union[str, int],
-) -> Dict[str, Any]:
-    """Add an existing CRM contact to an additional project.
-
-    Requires the RedmineUP CRM plugin, ``REDMINE_CRM_ENABLED=true``, and
-    is blocked when ``REDMINE_MCP_READ_ONLY=true``.
-    """
-    if _is_read_only_mode():
-        return dict(_READ_ONLY_ERROR)
-    if not _is_crm_enabled():
-        return dict(_CRM_DISABLED_ERROR)
-    if not _is_positive_int(contact_id):
-        return {"error": "contact_id must be a positive integer."}
-    if not _is_valid_project_id(project_id):
+    if action not in _valid_actions:
         return {
             "error": (
-                "project_id must be a non-empty string identifier or "
-                "positive integer."
+                f"Invalid action '{action}'. " f"Allowed: {sorted(_valid_actions)}"
             )
         }
 
-    try:
-        client = _get_redmine_client()
-        url = f"{REDMINE_URL}/contacts/{contact_id}/projects.json"
-        client.engine.request(
-            "post",
-            url,
-            headers={"Content-Type": "application/json"},
-            data=json.dumps({"project": {"id": project_id}}),
-        )
-        return {
-            "success": True,
-            "contact_id": contact_id,
+    # --- read actions ---
+
+    if action == "list":
+        if not isinstance(limit, int) or isinstance(limit, bool) or limit < 1:
+            return {"error": "limit must be a positive integer."}
+        limit = min(limit, _REDMINE_API_PAGE_CAP)
+        if project_id is not None and not _is_valid_project_id(project_id):
+            return {
+                "error": (
+                    "project_id must be a non-empty string identifier or "
+                    "positive integer."
+                )
+            }
+        params: Dict[str, Any] = {"limit": limit}
+        if project_id is not None:
+            params["project_id"] = project_id
+        if search is not None:
+            params["search"] = search
+        if tags is not None:
+            params["tags"] = tags
+        if assigned_to_id is not None:
+            if not _is_positive_int(assigned_to_id):
+                return {"error": "assigned_to_id must be a positive integer."}
+            params["assigned_to_id"] = assigned_to_id
+        try:
+            client = _get_redmine_client()
+            url = f"{REDMINE_URL}/contacts.json"
+            payload = client.engine.request("get", url, params=params)
+            raw = payload.get("contacts", []) if isinstance(payload, dict) else []
+            return [_contact_to_dict(c) for c in raw[:limit]]
+        except Exception as e:
+            return _handle_redmine_error(
+                e, "listing contacts", {"resource_type": "contacts"}
+            )
+
+    if action == "get":
+        if not _is_positive_int(contact_id):
+            return {"error": "contact_id must be a positive integer."}
+        try:
+            client = _get_redmine_client()
+            url = f"{REDMINE_URL}/contacts/{contact_id}.json"
+            params = {}
+            if include:
+                params["include"] = include
+            payload = client.engine.request("get", url, params=params)
+            contact = payload.get("contact", {}) if isinstance(payload, dict) else {}
+            if not contact:
+                return {"error": f"Contact {contact_id} not found."}
+            return _contact_to_dict(contact)
+        except Exception as e:
+            return _handle_redmine_error(
+                e,
+                f"fetching contact {contact_id}",
+                {"resource_type": "contact", "resource_id": contact_id},
+            )
+
+    # --- write actions ---
+    if _is_read_only_mode():
+        return dict(_READ_ONLY_ERROR)
+    await _ensure_cleanup_started()
+
+    if action == "create":
+        if not _is_valid_project_id(project_id):
+            return {
+                "error": (
+                    "project_id is required and must be a non-empty string "
+                    "identifier or positive integer."
+                )
+            }
+        if not isinstance(first_name, str) or not first_name.strip():
+            return {"error": "first_name must be a non-empty string."}
+        if not isinstance(is_company, bool):
+            return {"error": "is_company must be a boolean."}
+        if visibility not in (0, 1, 2):
+            return {
+                "error": "visibility must be 0 (Project), 1 (Public), or 2 (Private)."
+            }
+        body: Dict[str, Any] = {
             "project_id": project_id,
+            "first_name": first_name,
+            "is_company": is_company,
+            "visibility": visibility,
         }
-    except Exception as e:
-        return _handle_redmine_error(
-            e,
-            f"assigning contact {contact_id} to project {project_id}",
-            {"resource_type": "contact", "resource_id": contact_id},
-        )
+        if last_name is not None:
+            body["last_name"] = last_name
+        if company is not None:
+            body["company"] = company
+        if email is not None:
+            body["email"] = email
+        if phone is not None:
+            body["phone"] = phone
+        if fields:
+            for k, v in fields.items():
+                if k in _CONTACT_WRITABLE_FIELDS:
+                    body[k] = v
+        try:
+            client = _get_redmine_client()
+            url = f"{REDMINE_URL}/contacts.json"
+            payload = client.engine.request(
+                "post",
+                url,
+                headers={"Content-Type": "application/json"},
+                data=json.dumps({"contact": body}),
+            )
+            contact = payload.get("contact", {}) if isinstance(payload, dict) else {}
+            return _contact_to_dict(contact) if contact else {"success": True}
+        except Exception as e:
+            return _handle_redmine_error(
+                e, "creating contact", {"resource_type": "contact"}
+            )
 
+    if action == "update":
+        if not _is_positive_int(contact_id):
+            return {"error": "contact_id must be a positive integer."}
+        if not isinstance(fields, dict) or not fields:
+            return {"error": "fields must be a non-empty dict."}
+        filtered = {k: v for k, v in fields.items() if k in _CONTACT_WRITABLE_FIELDS}
+        if not filtered:
+            return {
+                "error": (
+                    "No writable fields provided. Allowed fields: "
+                    f"{sorted(_CONTACT_WRITABLE_FIELDS)}"
+                )
+            }
+        try:
+            client = _get_redmine_client()
+            url = f"{REDMINE_URL}/contacts/{contact_id}.json"
+            client.engine.request(
+                "put",
+                url,
+                headers={"Content-Type": "application/json"},
+                data=json.dumps({"contact": filtered}),
+            )
+            return {
+                "success": True,
+                "contact_id": contact_id,
+                "updated_fields": list(filtered.keys()),
+            }
+        except Exception as e:
+            return _handle_redmine_error(
+                e,
+                f"updating contact {contact_id}",
+                {"resource_type": "contact", "resource_id": contact_id},
+            )
 
-@mcp.tool()
-async def remove_contact_from_project(
-    contact_id: int,
-    project_id: Union[str, int],
-) -> Dict[str, Any]:
-    """Remove a CRM contact from a project (does not delete the contact).
+    if action == "delete":
+        if not _is_positive_int(contact_id):
+            return {"error": "contact_id must be a positive integer."}
+        try:
+            client = _get_redmine_client()
+            url = f"{REDMINE_URL}/contacts/{contact_id}.json"
+            client.engine.request("delete", url)
+            return {
+                "success": True,
+                "contact_id": contact_id,
+                "message": f"Contact {contact_id} deleted.",
+            }
+        except Exception as e:
+            return _handle_redmine_error(
+                e,
+                f"deleting contact {contact_id}",
+                {"resource_type": "contact", "resource_id": contact_id},
+            )
 
-    Requires the RedmineUP CRM plugin, ``REDMINE_CRM_ENABLED=true``, and
-    is blocked when ``REDMINE_MCP_READ_ONLY=true``.
-    """
-    if _is_read_only_mode():
-        return dict(_READ_ONLY_ERROR)
-    if not _is_crm_enabled():
-        return dict(_CRM_DISABLED_ERROR)
+    # action in {"assign_to_project", "remove_from_project"}
     if not _is_positive_int(contact_id):
         return {"error": "contact_id must be a positive integer."}
     if not _is_valid_project_id(project_id):
@@ -6642,6 +6526,29 @@ async def remove_contact_from_project(
             )
         }
 
+    if action == "assign_to_project":
+        try:
+            client = _get_redmine_client()
+            url = f"{REDMINE_URL}/contacts/{contact_id}/projects.json"
+            client.engine.request(
+                "post",
+                url,
+                headers={"Content-Type": "application/json"},
+                data=json.dumps({"project": {"id": project_id}}),
+            )
+            return {
+                "success": True,
+                "contact_id": contact_id,
+                "project_id": project_id,
+            }
+        except Exception as e:
+            return _handle_redmine_error(
+                e,
+                f"assigning contact {contact_id} to project {project_id}",
+                {"resource_type": "contact", "resource_id": contact_id},
+            )
+
+    # action == "remove_from_project"
     try:
         client = _get_redmine_client()
         url = f"{REDMINE_URL}/contacts/{contact_id}/projects/{project_id}.json"

--- a/tests/test_checklist_support.py
+++ b/tests/test_checklist_support.py
@@ -15,7 +15,6 @@ from redmine_mcp_server.redmine_handler import (  # noqa: E402
     _update_checklist_item_api,
     get_checklist,
     update_checklist_item,
-    mark_checklist_done,
 )
 
 # ---------------------------------------------------------------------------
@@ -362,101 +361,20 @@ class TestUpdateChecklistItem:
 
 
 # ---------------------------------------------------------------------------
-# mark_checklist_done tool
+# Removed: mark_checklist_done — use update_checklist_item(is_done=...) directly.
 # ---------------------------------------------------------------------------
 
 
-class TestMarkChecklistDone:
+class TestUpdateChecklistItemIsDone:
+    """Confirms the mark_checklist_done use case is preserved via
+    update_checklist_item(is_done=...)."""
+
     @pytest.mark.asyncio
     @patch("redmine_mcp_server.redmine_handler.REDMINE_URL", "http://localhost:3000")
     @patch("redmine_mcp_server.redmine_handler.redmine")
-    async def test_marks_done(self, mock_redmine):
+    async def test_update_is_done_true(self, mock_redmine):
         mock_redmine.engine.request.return_value = True
-
         with patch.dict(os.environ, {"REDMINE_CHECKLISTS_ENABLED": "true"}):
-            result = await mark_checklist_done(checklist_item_id=10)
-
+            result = await update_checklist_item(checklist_item_id=10, is_done=True)
         assert result["success"] is True
-        assert result["checklist_item_id"] == 10
-        assert result["is_done"] is True
-        mock_redmine.engine.request.assert_called_once_with(
-            "put",
-            "http://localhost:3000/checklists/10.json",
-            headers={"Content-Type": "application/json"},
-            data=json.dumps({"checklist": {"is_done": True}}),
-        )
-
-    @pytest.mark.asyncio
-    @patch("redmine_mcp_server.redmine_handler.REDMINE_URL", "http://localhost:3000")
-    @patch("redmine_mcp_server.redmine_handler.redmine")
-    async def test_marks_undone(self, mock_redmine):
-        mock_redmine.engine.request.return_value = True
-
-        with patch.dict(os.environ, {"REDMINE_CHECKLISTS_ENABLED": "true"}):
-            result = await mark_checklist_done(checklist_item_id=10, is_done=False)
-
-        assert result["success"] is True
-        assert result["is_done"] is False
-        mock_redmine.engine.request.assert_called_once_with(
-            "put",
-            "http://localhost:3000/checklists/10.json",
-            headers={"Content-Type": "application/json"},
-            data=json.dumps({"checklist": {"is_done": False}}),
-        )
-
-    @pytest.mark.asyncio
-    async def test_blocked_in_read_only_mode(self):
-        with patch.dict(
-            os.environ,
-            {
-                "REDMINE_MCP_READ_ONLY": "true",
-                "REDMINE_CHECKLISTS_ENABLED": "true",
-            },
-        ):
-            result = await mark_checklist_done(checklist_item_id=10)
-
-        assert "error" in result
-        assert "read-only" in result["error"].lower()
-
-    @pytest.mark.asyncio
-    async def test_returns_error_when_disabled(self):
-        with patch.dict(os.environ, {"REDMINE_CHECKLISTS_ENABLED": "false"}):
-            result = await mark_checklist_done(checklist_item_id=10)
-
-        assert "error" in result
-        assert "REDMINE_CHECKLISTS_ENABLED" in result["error"]
-
-    @pytest.mark.asyncio
-    async def test_rejects_invalid_id(self):
-        with patch.dict(os.environ, {"REDMINE_CHECKLISTS_ENABLED": "true"}):
-            result = await mark_checklist_done(checklist_item_id=0)
-
-        assert "error" in result
-        assert "positive integer" in result["error"]
-
-    @pytest.mark.asyncio
-    async def test_rejects_boolean_id(self):
-        with patch.dict(os.environ, {"REDMINE_CHECKLISTS_ENABLED": "true"}):
-            result = await mark_checklist_done(checklist_item_id=True)
-
-        assert "error" in result
-        assert "positive integer" in result["error"]
-
-    @pytest.mark.asyncio
-    async def test_rejects_non_bool_is_done(self):
-        with patch.dict(os.environ, {"REDMINE_CHECKLISTS_ENABLED": "true"}):
-            result = await mark_checklist_done(checklist_item_id=10, is_done=1)
-
-        assert "error" in result
-        assert "boolean" in result["error"]
-
-    @pytest.mark.asyncio
-    @patch("redmine_mcp_server.redmine_handler.REDMINE_URL", "http://localhost:3000")
-    @patch("redmine_mcp_server.redmine_handler.redmine")
-    async def test_handles_api_error(self, mock_redmine):
-        mock_redmine.engine.request.side_effect = Exception("not found")
-
-        with patch.dict(os.environ, {"REDMINE_CHECKLISTS_ENABLED": "true"}):
-            result = await mark_checklist_done(checklist_item_id=999)
-
-        assert "error" in result
+        assert "is_done" in result["updated_fields"]

--- a/tests/test_crm_support.py
+++ b/tests/test_crm_support.py
@@ -11,13 +11,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
 from redmine_mcp_server.redmine_handler import (  # noqa: E402
     _is_crm_enabled,
-    list_contacts,
-    get_contact,
-    edit_contact,
-    create_contact,
-    delete_contact,
-    assign_contact_to_project,
-    remove_contact_from_project,
+    manage_contact,
 )
 
 
@@ -74,7 +68,9 @@ class TestListContacts:
             "contacts": [_make_contact(1), _make_contact(2, "Bob")]
         }
         with patch.dict(os.environ, {"REDMINE_CRM_ENABLED": "true"}):
-            result = await list_contacts()
+            result = await manage_contact(
+                action="list",
+            )
 
         assert isinstance(result, list)
         assert len(result) == 2
@@ -90,7 +86,8 @@ class TestListContacts:
     async def test_filters_passed_to_api(self, mock_redmine):
         mock_redmine.engine.request.return_value = {"contacts": []}
         with patch.dict(os.environ, {"REDMINE_CRM_ENABLED": "true"}):
-            await list_contacts(
+            await manage_contact(
+                action="list",
                 project_id="proj",
                 search="alice",
                 tags="lead",
@@ -109,19 +106,21 @@ class TestListContacts:
     @pytest.mark.asyncio
     async def test_disabled(self):
         with patch.dict(os.environ, {"REDMINE_CRM_ENABLED": "false"}):
-            result = await list_contacts()
+            result = await manage_contact(
+                action="list",
+            )
         assert "REDMINE_CRM_ENABLED" in result["error"]
 
     @pytest.mark.asyncio
     async def test_invalid_limit(self):
         with patch.dict(os.environ, {"REDMINE_CRM_ENABLED": "true"}):
-            result = await list_contacts(limit=-1)
+            result = await manage_contact(action="list", limit=-1)
         assert "error" in result
 
     @pytest.mark.asyncio
     async def test_invalid_assigned_to_id(self):
         with patch.dict(os.environ, {"REDMINE_CRM_ENABLED": "true"}):
-            result = await list_contacts(assigned_to_id=0)
+            result = await manage_contact(action="list", assigned_to_id=0)
         assert "error" in result
 
     @pytest.mark.asyncio
@@ -131,7 +130,7 @@ class TestListContacts:
         """Redmine caps `limit` at 100 server-side; values above are clamped."""
         mock_redmine.engine.request.return_value = {"contacts": []}
         with patch.dict(os.environ, {"REDMINE_CRM_ENABLED": "true"}):
-            await list_contacts(limit=500)
+            await manage_contact(action="list", limit=500)
 
         call_kwargs = mock_redmine.engine.request.call_args.kwargs
         assert call_kwargs["params"]["limit"] == 100
@@ -145,7 +144,7 @@ class TestListContacts:
         many = [_make_contact(i) for i in range(200)]
         mock_redmine.engine.request.return_value = {"contacts": many}
         with patch.dict(os.environ, {"REDMINE_CRM_ENABLED": "true"}):
-            result = await list_contacts(limit=25)
+            result = await manage_contact(action="list", limit=25)
 
         assert isinstance(result, list)
         assert len(result) == 25
@@ -153,14 +152,14 @@ class TestListContacts:
     @pytest.mark.asyncio
     async def test_rejects_empty_project_id(self):
         with patch.dict(os.environ, {"REDMINE_CRM_ENABLED": "true"}):
-            result = await list_contacts(project_id="")
+            result = await manage_contact(action="list", project_id="")
         assert "error" in result
         assert "project_id" in result["error"]
 
     @pytest.mark.asyncio
     async def test_rejects_project_id_with_slash(self):
         with patch.dict(os.environ, {"REDMINE_CRM_ENABLED": "true"}):
-            result = await list_contacts(project_id="foo/../bar")
+            result = await manage_contact(action="list", project_id="foo/../bar")
         assert "error" in result
         assert "project_id" in result["error"]
 
@@ -177,7 +176,7 @@ class TestGetContact:
     async def test_get_success(self, mock_redmine):
         mock_redmine.engine.request.return_value = {"contact": _make_contact(42)}
         with patch.dict(os.environ, {"REDMINE_CRM_ENABLED": "true"}):
-            result = await get_contact(contact_id=42)
+            result = await manage_contact(action="get", contact_id=42)
         assert result["id"] == 42
         assert result["address"]["city"] == "Boston"
 
@@ -187,20 +186,20 @@ class TestGetContact:
     async def test_includes_passed(self, mock_redmine):
         mock_redmine.engine.request.return_value = {"contact": _make_contact(1)}
         with patch.dict(os.environ, {"REDMINE_CRM_ENABLED": "true"}):
-            await get_contact(contact_id=1, include="notes,deals")
+            await manage_contact(action="get", contact_id=1, include="notes,deals")
         params = mock_redmine.engine.request.call_args.kwargs["params"]
         assert params["include"] == "notes,deals"
 
     @pytest.mark.asyncio
     async def test_disabled(self):
         with patch.dict(os.environ, {"REDMINE_CRM_ENABLED": "false"}):
-            result = await get_contact(contact_id=1)
+            result = await manage_contact(action="get", contact_id=1)
         assert "error" in result
 
     @pytest.mark.asyncio
     async def test_invalid_id(self):
         with patch.dict(os.environ, {"REDMINE_CRM_ENABLED": "true"}):
-            result = await get_contact(contact_id=-1)
+            result = await manage_contact(action="get", contact_id=-1)
         assert "error" in result
 
     @pytest.mark.asyncio
@@ -209,7 +208,7 @@ class TestGetContact:
     async def test_not_found(self, mock_redmine):
         mock_redmine.engine.request.return_value = {}
         with patch.dict(os.environ, {"REDMINE_CRM_ENABLED": "true"}):
-            result = await get_contact(contact_id=999)
+            result = await manage_contact(action="get", contact_id=999)
         assert "error" in result
         assert "not found" in result["error"]
 
@@ -226,7 +225,8 @@ class TestEditContact:
     async def test_edit_success(self, mock_redmine):
         mock_redmine.engine.request.return_value = True
         with patch.dict(os.environ, {"REDMINE_CRM_ENABLED": "true"}):
-            result = await edit_contact(
+            result = await manage_contact(
+                action="update",
                 contact_id=1,
                 fields={"first_name": "Carol", "email": "c@x.com"},
             )
@@ -239,7 +239,8 @@ class TestEditContact:
     async def test_filters_unknown_fields(self, mock_redmine):
         mock_redmine.engine.request.return_value = True
         with patch.dict(os.environ, {"REDMINE_CRM_ENABLED": "true"}):
-            result = await edit_contact(
+            result = await manage_contact(
+                action="update",
                 contact_id=1,
                 fields={"first_name": "X", "evil": "bad"},
             )
@@ -253,19 +254,25 @@ class TestEditContact:
             os.environ,
             {"REDMINE_MCP_READ_ONLY": "true", "REDMINE_CRM_ENABLED": "true"},
         ):
-            result = await edit_contact(contact_id=1, fields={"email": "x"})
+            result = await manage_contact(
+                action="update", contact_id=1, fields={"email": "x"}
+            )
         assert "read-only" in result["error"].lower()
 
     @pytest.mark.asyncio
     async def test_disabled(self):
         with patch.dict(os.environ, {"REDMINE_CRM_ENABLED": "false"}):
-            result = await edit_contact(contact_id=1, fields={"first_name": "X"})
+            result = await manage_contact(
+                action="update", contact_id=1, fields={"first_name": "X"}
+            )
         assert "REDMINE_CRM_ENABLED" in result["error"]
 
     @pytest.mark.asyncio
     async def test_no_writable_fields(self):
         with patch.dict(os.environ, {"REDMINE_CRM_ENABLED": "true"}):
-            result = await edit_contact(contact_id=1, fields={"unknown": "x"})
+            result = await manage_contact(
+                action="update", contact_id=1, fields={"unknown": "x"}
+            )
         assert "writable fields" in result["error"]
 
 
@@ -281,7 +288,8 @@ class TestCreateContact:
     async def test_create_success(self, mock_redmine):
         mock_redmine.engine.request.return_value = {"contact": _make_contact(99)}
         with patch.dict(os.environ, {"REDMINE_CRM_ENABLED": "true"}):
-            result = await create_contact(
+            result = await manage_contact(
+                action="create",
                 project_id="proj",
                 first_name="Alice",
                 last_name="Smith",
@@ -300,7 +308,8 @@ class TestCreateContact:
     async def test_extra_fields_via_fields_param(self, mock_redmine):
         mock_redmine.engine.request.return_value = {"contact": _make_contact(1)}
         with patch.dict(os.environ, {"REDMINE_CRM_ENABLED": "true"}):
-            await create_contact(
+            await manage_contact(
+                action="create",
                 project_id="p",
                 first_name="A",
                 fields={"job_title": "CTO", "tag_list": "vip", "rogue": "x"},
@@ -316,32 +325,40 @@ class TestCreateContact:
             os.environ,
             {"REDMINE_MCP_READ_ONLY": "true", "REDMINE_CRM_ENABLED": "true"},
         ):
-            result = await create_contact(project_id="p", first_name="A")
+            result = await manage_contact(
+                action="create", project_id="p", first_name="A"
+            )
         assert "read-only" in result["error"].lower()
 
     @pytest.mark.asyncio
     async def test_disabled(self):
         with patch.dict(os.environ, {"REDMINE_CRM_ENABLED": "false"}):
-            result = await create_contact(project_id="p", first_name="A")
+            result = await manage_contact(
+                action="create", project_id="p", first_name="A"
+            )
         assert "error" in result
 
     @pytest.mark.asyncio
     async def test_empty_first_name(self):
         with patch.dict(os.environ, {"REDMINE_CRM_ENABLED": "true"}):
-            result = await create_contact(project_id="p", first_name="")
+            result = await manage_contact(
+                action="create", project_id="p", first_name=""
+            )
         assert "error" in result
 
     @pytest.mark.asyncio
     async def test_invalid_visibility(self):
         with patch.dict(os.environ, {"REDMINE_CRM_ENABLED": "true"}):
-            result = await create_contact(project_id="p", first_name="A", visibility=9)
+            result = await manage_contact(
+                action="create", project_id="p", first_name="A", visibility=9
+            )
         assert "error" in result
 
     @pytest.mark.asyncio
     async def test_invalid_is_company_type(self):
         with patch.dict(os.environ, {"REDMINE_CRM_ENABLED": "true"}):
-            result = await create_contact(
-                project_id="p", first_name="A", is_company="yes"
+            result = await manage_contact(
+                action="create", project_id="p", first_name="A", is_company="yes"
             )
         assert "error" in result
 
@@ -358,7 +375,7 @@ class TestDeleteContact:
     async def test_delete_success(self, mock_redmine):
         mock_redmine.engine.request.return_value = True
         with patch.dict(os.environ, {"REDMINE_CRM_ENABLED": "true"}):
-            result = await delete_contact(contact_id=42)
+            result = await manage_contact(action="delete", contact_id=42)
         assert result["success"] is True
         assert result["contact_id"] == 42
         mock_redmine.engine.request.assert_called_once_with(
@@ -371,19 +388,19 @@ class TestDeleteContact:
             os.environ,
             {"REDMINE_MCP_READ_ONLY": "true", "REDMINE_CRM_ENABLED": "true"},
         ):
-            result = await delete_contact(contact_id=1)
+            result = await manage_contact(action="delete", contact_id=1)
         assert "read-only" in result["error"].lower()
 
     @pytest.mark.asyncio
     async def test_disabled(self):
         with patch.dict(os.environ, {"REDMINE_CRM_ENABLED": "false"}):
-            result = await delete_contact(contact_id=1)
+            result = await manage_contact(action="delete", contact_id=1)
         assert "error" in result
 
     @pytest.mark.asyncio
     async def test_invalid_id(self):
         with patch.dict(os.environ, {"REDMINE_CRM_ENABLED": "true"}):
-            result = await delete_contact(contact_id=-1)
+            result = await manage_contact(action="delete", contact_id=-1)
         assert "error" in result
 
 
@@ -399,8 +416,8 @@ class TestAssignContactToProject:
     async def test_assign_success(self, mock_redmine):
         mock_redmine.engine.request.return_value = True
         with patch.dict(os.environ, {"REDMINE_CRM_ENABLED": "true"}):
-            result = await assign_contact_to_project(
-                contact_id=42, project_id="newproj"
+            result = await manage_contact(
+                action="assign_to_project", contact_id=42, project_id="newproj"
             )
         assert result["success"] is True
         body = json.loads(mock_redmine.engine.request.call_args.kwargs["data"])
@@ -412,19 +429,25 @@ class TestAssignContactToProject:
             os.environ,
             {"REDMINE_MCP_READ_ONLY": "true", "REDMINE_CRM_ENABLED": "true"},
         ):
-            result = await assign_contact_to_project(contact_id=1, project_id="p")
+            result = await manage_contact(
+                action="assign_to_project", contact_id=1, project_id="p"
+            )
         assert "read-only" in result["error"].lower()
 
     @pytest.mark.asyncio
     async def test_disabled(self):
         with patch.dict(os.environ, {"REDMINE_CRM_ENABLED": "false"}):
-            result = await assign_contact_to_project(contact_id=1, project_id="p")
+            result = await manage_contact(
+                action="assign_to_project", contact_id=1, project_id="p"
+            )
         assert "error" in result
 
     @pytest.mark.asyncio
     async def test_rejects_empty_project_id(self):
         with patch.dict(os.environ, {"REDMINE_CRM_ENABLED": "true"}):
-            result = await assign_contact_to_project(contact_id=1, project_id="")
+            result = await manage_contact(
+                action="assign_to_project", contact_id=1, project_id=""
+            )
         assert "error" in result
         assert "project_id" in result["error"]
 
@@ -436,8 +459,8 @@ class TestRemoveContactFromProject:
     async def test_remove_success(self, mock_redmine):
         mock_redmine.engine.request.return_value = True
         with patch.dict(os.environ, {"REDMINE_CRM_ENABLED": "true"}):
-            result = await remove_contact_from_project(
-                contact_id=42, project_id="oldproj"
+            result = await manage_contact(
+                action="remove_from_project", contact_id=42, project_id="oldproj"
             )
         assert result["success"] is True
         mock_redmine.engine.request.assert_called_once_with(
@@ -451,24 +474,32 @@ class TestRemoveContactFromProject:
             os.environ,
             {"REDMINE_MCP_READ_ONLY": "true", "REDMINE_CRM_ENABLED": "true"},
         ):
-            result = await remove_contact_from_project(contact_id=1, project_id="p")
+            result = await manage_contact(
+                action="remove_from_project", contact_id=1, project_id="p"
+            )
         assert "read-only" in result["error"].lower()
 
     @pytest.mark.asyncio
     async def test_disabled(self):
         with patch.dict(os.environ, {"REDMINE_CRM_ENABLED": "false"}):
-            result = await remove_contact_from_project(contact_id=1, project_id="p")
+            result = await manage_contact(
+                action="remove_from_project", contact_id=1, project_id="p"
+            )
         assert "error" in result
 
     @pytest.mark.asyncio
     async def test_invalid_id(self):
         with patch.dict(os.environ, {"REDMINE_CRM_ENABLED": "true"}):
-            result = await remove_contact_from_project(contact_id=-1, project_id="p")
+            result = await manage_contact(
+                action="remove_from_project", contact_id=-1, project_id="p"
+            )
         assert "error" in result
 
     @pytest.mark.asyncio
     async def test_rejects_empty_project_id(self):
         with patch.dict(os.environ, {"REDMINE_CRM_ENABLED": "true"}):
-            result = await remove_contact_from_project(contact_id=1, project_id="")
+            result = await manage_contact(
+                action="remove_from_project", contact_id=1, project_id=""
+            )
         assert "error" in result
         assert "project_id" in result["error"]

--- a/tests/test_crm_support.py
+++ b/tests/test_crm_support.py
@@ -59,7 +59,7 @@ class TestIsCrmEnabled:
 # ---------------------------------------------------------------------------
 
 
-class TestListContacts:
+class TestManageContactList:
     @pytest.mark.asyncio
     @patch("redmine_mcp_server.redmine_handler.REDMINE_URL", "http://localhost:3000")
     @patch("redmine_mcp_server.redmine_handler.redmine")
@@ -169,7 +169,7 @@ class TestListContacts:
 # ---------------------------------------------------------------------------
 
 
-class TestGetContact:
+class TestManageContactGet:
     @pytest.mark.asyncio
     @patch("redmine_mcp_server.redmine_handler.REDMINE_URL", "http://localhost:3000")
     @patch("redmine_mcp_server.redmine_handler.redmine")
@@ -218,7 +218,7 @@ class TestGetContact:
 # ---------------------------------------------------------------------------
 
 
-class TestEditContact:
+class TestManageContactUpdate:
     @pytest.mark.asyncio
     @patch("redmine_mcp_server.redmine_handler.REDMINE_URL", "http://localhost:3000")
     @patch("redmine_mcp_server.redmine_handler.redmine")
@@ -281,7 +281,7 @@ class TestEditContact:
 # ---------------------------------------------------------------------------
 
 
-class TestCreateContact:
+class TestManageContactCreate:
     @pytest.mark.asyncio
     @patch("redmine_mcp_server.redmine_handler.REDMINE_URL", "http://localhost:3000")
     @patch("redmine_mcp_server.redmine_handler.redmine")
@@ -368,7 +368,7 @@ class TestCreateContact:
 # ---------------------------------------------------------------------------
 
 
-class TestDeleteContact:
+class TestManageContactDelete:
     @pytest.mark.asyncio
     @patch("redmine_mcp_server.redmine_handler.REDMINE_URL", "http://localhost:3000")
     @patch("redmine_mcp_server.redmine_handler.redmine")
@@ -409,7 +409,7 @@ class TestDeleteContact:
 # ---------------------------------------------------------------------------
 
 
-class TestAssignContactToProject:
+class TestManageContactAssignToProject:
     @pytest.mark.asyncio
     @patch("redmine_mcp_server.redmine_handler.REDMINE_URL", "http://localhost:3000")
     @patch("redmine_mcp_server.redmine_handler.redmine")
@@ -452,7 +452,7 @@ class TestAssignContactToProject:
         assert "project_id" in result["error"]
 
 
-class TestRemoveContactFromProject:
+class TestManageContactRemoveFromProject:
     @pytest.mark.asyncio
     @patch("redmine_mcp_server.redmine_handler.REDMINE_URL", "http://localhost:3000")
     @patch("redmine_mcp_server.redmine_handler.redmine")

--- a/tests/test_global_search.py
+++ b/tests/test_global_search.py
@@ -350,10 +350,10 @@ class TestGetRedmineWikiPage:
     @patch("redmine_mcp_server.redmine_handler.redmine", None)
     async def test_wiki_page_no_client(self):
         """Test error when Redmine client is not initialized."""
-        from redmine_mcp_server.redmine_handler import get_redmine_wiki_page
+        from redmine_mcp_server.redmine_handler import manage_redmine_wiki_page
 
-        result = await get_redmine_wiki_page(
-            project_id="my-project", wiki_page_title="Installation"
+        result = await manage_redmine_wiki_page(
+            action="get", project_id="my-project", wiki_page_title="Installation"
         )
 
         assert "error" in result
@@ -364,12 +364,12 @@ class TestGetRedmineWikiPage:
     @patch("redmine_mcp_server.redmine_handler._ensure_cleanup_started")
     async def test_wiki_page_success(self, mock_cleanup, mock_redmine, mock_wiki_page):
         """Test successful wiki page retrieval."""
-        from redmine_mcp_server.redmine_handler import get_redmine_wiki_page
+        from redmine_mcp_server.redmine_handler import manage_redmine_wiki_page
 
         mock_redmine.wiki_page.get.return_value = mock_wiki_page
 
-        result = await get_redmine_wiki_page(
-            project_id="my-project", wiki_page_title="Installation Guide"
+        result = await manage_redmine_wiki_page(
+            action="get", project_id="my-project", wiki_page_title="Installation Guide"
         )
 
         assert result["title"] == "Installation Guide"
@@ -385,12 +385,12 @@ class TestGetRedmineWikiPage:
     @patch("redmine_mcp_server.redmine_handler._ensure_cleanup_started")
     async def test_wiki_page_not_found(self, mock_cleanup, mock_redmine):
         """Test handling of non-existent wiki page."""
-        from redmine_mcp_server.redmine_handler import get_redmine_wiki_page
+        from redmine_mcp_server.redmine_handler import manage_redmine_wiki_page
 
         mock_redmine.wiki_page.get.side_effect = ResourceNotFoundError()
 
-        result = await get_redmine_wiki_page(
-            project_id="my-project", wiki_page_title="NonExistent"
+        result = await manage_redmine_wiki_page(
+            action="get", project_id="my-project", wiki_page_title="NonExistent"
         )
 
         assert "error" in result
@@ -405,13 +405,16 @@ class TestGetRedmineWikiPage:
         self, mock_cleanup, mock_redmine, mock_wiki_page
     ):
         """Test retrieving specific wiki page version."""
-        from redmine_mcp_server.redmine_handler import get_redmine_wiki_page
+        from redmine_mcp_server.redmine_handler import manage_redmine_wiki_page
 
         mock_wiki_page.version = 3
         mock_redmine.wiki_page.get.return_value = mock_wiki_page
 
-        result = await get_redmine_wiki_page(
-            project_id="my-project", wiki_page_title="Installation", version=3
+        result = await manage_redmine_wiki_page(
+            action="get",
+            project_id="my-project",
+            wiki_page_title="Installation",
+            version=3,
         )
 
         # Verify version parameter passed
@@ -427,7 +430,7 @@ class TestGetRedmineWikiPage:
         self, mock_cleanup, mock_redmine, mock_wiki_page
     ):
         """Test wiki page with attachments."""
-        from redmine_mcp_server.redmine_handler import get_redmine_wiki_page
+        from redmine_mcp_server.redmine_handler import manage_redmine_wiki_page
 
         mock_attachment = Mock()
         mock_attachment.id = 456
@@ -440,7 +443,8 @@ class TestGetRedmineWikiPage:
         mock_wiki_page.attachments = [mock_attachment]
         mock_redmine.wiki_page.get.return_value = mock_wiki_page
 
-        result = await get_redmine_wiki_page(
+        result = await manage_redmine_wiki_page(
+            action="get",
             project_id="my-project",
             wiki_page_title="Installation",
             include_attachments=True,
@@ -458,12 +462,13 @@ class TestGetRedmineWikiPage:
         self, mock_cleanup, mock_redmine, mock_wiki_page
     ):
         """Test excluding attachments from response."""
-        from redmine_mcp_server.redmine_handler import get_redmine_wiki_page
+        from redmine_mcp_server.redmine_handler import manage_redmine_wiki_page
 
         mock_wiki_page.attachments = [Mock(id=1)]
         mock_redmine.wiki_page.get.return_value = mock_wiki_page
 
-        result = await get_redmine_wiki_page(
+        result = await manage_redmine_wiki_page(
+            action="get",
             project_id="my-project",
             wiki_page_title="Installation",
             include_attachments=False,
@@ -476,7 +481,7 @@ class TestGetRedmineWikiPage:
     @patch("redmine_mcp_server.redmine_handler._ensure_cleanup_started")
     async def test_wiki_page_missing_attributes(self, mock_cleanup, mock_redmine):
         """Test handling of wiki page with missing optional attributes."""
-        from redmine_mcp_server.redmine_handler import get_redmine_wiki_page
+        from redmine_mcp_server.redmine_handler import manage_redmine_wiki_page
 
         mock_page = Mock(spec=["title", "text", "version"])
         mock_page.title = "Simple Page"
@@ -485,8 +490,8 @@ class TestGetRedmineWikiPage:
 
         mock_redmine.wiki_page.get.return_value = mock_page
 
-        result = await get_redmine_wiki_page(
-            project_id=1, wiki_page_title="Simple Page"
+        result = await manage_redmine_wiki_page(
+            action="get", project_id=1, wiki_page_title="Simple Page"
         )
 
         assert result["title"] == "Simple Page"
@@ -501,11 +506,13 @@ class TestGetRedmineWikiPage:
         self, mock_cleanup, mock_redmine, mock_wiki_page
     ):
         """Test wiki page retrieval with integer project ID."""
-        from redmine_mcp_server.redmine_handler import get_redmine_wiki_page
+        from redmine_mcp_server.redmine_handler import manage_redmine_wiki_page
 
         mock_redmine.wiki_page.get.return_value = mock_wiki_page
 
-        await get_redmine_wiki_page(project_id=123, wiki_page_title="Test")
+        await manage_redmine_wiki_page(
+            action="get", project_id=123, wiki_page_title="Test"
+        )
 
         mock_redmine.wiki_page.get.assert_called_once_with("Test", project_id=123)
 
@@ -514,12 +521,12 @@ class TestGetRedmineWikiPage:
     @patch("redmine_mcp_server.redmine_handler._ensure_cleanup_started")
     async def test_wiki_page_general_exception(self, mock_cleanup, mock_redmine):
         """Test handling of general exceptions."""
-        from redmine_mcp_server.redmine_handler import get_redmine_wiki_page
+        from redmine_mcp_server.redmine_handler import manage_redmine_wiki_page
 
         mock_redmine.wiki_page.get.side_effect = Exception("Network error")
 
-        result = await get_redmine_wiki_page(
-            project_id="my-project", wiki_page_title="Test"
+        result = await manage_redmine_wiki_page(
+            action="get", project_id="my-project", wiki_page_title="Test"
         )
 
         assert "error" in result
@@ -548,7 +555,7 @@ class TestGlobalSearchIntegration:
         """Test wiki page retrieval by first discovering a wiki page via search."""
         from redmine_mcp_server.redmine_handler import (
             search_entire_redmine,
-            get_redmine_wiki_page,
+            manage_redmine_wiki_page,
             _get_redmine_client,
         )
 
@@ -587,8 +594,8 @@ class TestGlobalSearchIntegration:
         project_id = projects[0].identifier
 
         # Retrieve the wiki page
-        result = await get_redmine_wiki_page(
-            project_id=project_id, wiki_page_title=wiki_title
+        result = await manage_redmine_wiki_page(
+            action="get", project_id=project_id, wiki_page_title=wiki_title
         )
 
         # Should return valid structure with content

--- a/tests/test_global_search.py
+++ b/tests/test_global_search.py
@@ -323,7 +323,7 @@ class TestSearchEntireRedmine:
         assert "unknown" not in result["results_by_type"]
 
 
-class TestGetRedmineWikiPage:
+class TestManageRedmineWikiPageGet:
     """Tests for get_redmine_wiki_page MCP tool."""
 
     @pytest.fixture

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1315,8 +1315,8 @@ class TestTimeEntriesIntegration:
             pytest.skip("Redmine client not initialized")
 
         from redmine_mcp_server.redmine_handler import (
-            create_time_entry,
             list_time_entries,
+            manage_time_entry,
         )
 
         # Ensure at least one time entry exists
@@ -1325,7 +1325,8 @@ class TestTimeEntriesIntegration:
         activity_id = _get_activity_id(redmine)
         assert activity_id is not None, "No time entry activities configured"
 
-        created = await create_time_entry(
+        created = await manage_time_entry(
+            action="create",
             hours=0.1,
             project_id=projects[0].id,
             activity_id=activity_id,
@@ -1394,10 +1395,7 @@ class TestTimeEntriesIntegration:
         if redmine is None:
             pytest.skip("Redmine client not initialized")
 
-        from redmine_mcp_server.redmine_handler import (
-            create_time_entry,
-            update_time_entry,
-        )
+        from redmine_mcp_server.redmine_handler import manage_time_entry
 
         # Pick the first available project
         projects = list(redmine.project.all())
@@ -1411,7 +1409,8 @@ class TestTimeEntriesIntegration:
         time_entry_id = None
         try:
             # 1. Create a time entry
-            create_result = await create_time_entry(
+            create_result = await manage_time_entry(
+                action="create",
                 hours=0.25,
                 project_id=project_id,
                 activity_id=activity_id,
@@ -1433,7 +1432,8 @@ class TestTimeEntriesIntegration:
             time_entry_id = create_result["id"]
 
             # 2. Update the time entry
-            update_result = await update_time_entry(
+            update_result = await manage_time_entry(
+                action="update",
                 time_entry_id=time_entry_id,
                 hours=0.5,
                 comments="Integration test time entry (updated)",
@@ -1464,15 +1464,15 @@ class TestTimeEntriesIntegration:
         if redmine is None:
             pytest.skip("Redmine client not initialized")
 
-        from redmine_mcp_server.redmine_handler import create_time_entry
+        from redmine_mcp_server.redmine_handler import manage_time_entry
 
         # Missing both project_id and issue_id
-        result = await create_time_entry(hours=1.0)
+        result = await manage_time_entry(action="create", hours=1.0)
         assert "error" in result
         assert "project_id or issue_id" in result["error"]
 
         # Negative hours
-        result = await create_time_entry(hours=-1.0, project_id=1)
+        result = await manage_time_entry(action="create", hours=-1.0, project_id=1)
         assert "error" in result
         assert "positive" in result["error"]
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -440,12 +440,7 @@ class TestRedmineIntegration:
         if redmine is None:
             pytest.skip("Redmine client not initialized")
 
-        from redmine_mcp_server.redmine_handler import (
-            create_redmine_wiki_page,
-            update_redmine_wiki_page,
-            delete_redmine_wiki_page,
-            get_redmine_wiki_page,
-        )
+        from redmine_mcp_server.redmine_handler import manage_redmine_wiki_page
 
         # Pick the first available project
         projects = list(redmine.project.all())
@@ -457,7 +452,8 @@ class TestRedmineIntegration:
 
         try:
             # 1. Create a new wiki page
-            create_result = await create_redmine_wiki_page(
+            create_result = await manage_redmine_wiki_page(
+                action="create",
                 project_id=project_id,
                 wiki_page_title=wiki_title,
                 text="# Integration Test\n\nCreated by integration tests.",
@@ -479,7 +475,8 @@ class TestRedmineIntegration:
             assert create_result["version"] == 1
 
             # 2. Verify the page was created by reading it
-            read_result = await get_redmine_wiki_page(
+            read_result = await manage_redmine_wiki_page(
+                action="get",
                 project_id=project_id,
                 wiki_page_title=wiki_title,
             )
@@ -487,7 +484,8 @@ class TestRedmineIntegration:
             assert read_result["title"] == wiki_title
 
             # 3. Update the wiki page
-            update_result = await update_redmine_wiki_page(
+            update_result = await manage_redmine_wiki_page(
+                action="update",
                 project_id=project_id,
                 wiki_page_title=wiki_title,
                 text="# Integration Test Updated\n\nUpdated by integration tests.",
@@ -502,7 +500,8 @@ class TestRedmineIntegration:
             assert update_result["version"] >= 2  # Version should increment
 
             # 4. Delete the wiki page
-            delete_result = await delete_redmine_wiki_page(
+            delete_result = await manage_redmine_wiki_page(
+                action="delete",
                 project_id=project_id,
                 wiki_page_title=wiki_title,
             )
@@ -514,7 +513,8 @@ class TestRedmineIntegration:
             assert delete_result["title"] == wiki_title
 
             # 5. Verify the page was deleted
-            verify_result = await get_redmine_wiki_page(
+            verify_result = await manage_redmine_wiki_page(
+                action="get",
                 project_id=project_id,
                 wiki_page_title=wiki_title,
             )
@@ -526,7 +526,8 @@ class TestRedmineIntegration:
         finally:
             # Clean up: attempt to delete the wiki page if it still exists
             try:
-                await delete_redmine_wiki_page(
+                await manage_redmine_wiki_page(
+                    action="delete",
                     project_id=project_id,
                     wiki_page_title=wiki_title,
                 )
@@ -542,7 +543,7 @@ class TestRedmineIntegration:
         if redmine is None:
             pytest.skip("Redmine client not initialized")
 
-        from redmine_mcp_server.redmine_handler import delete_redmine_wiki_page
+        from redmine_mcp_server.redmine_handler import manage_redmine_wiki_page
 
         # Pick the first available project
         projects = list(redmine.project.all())
@@ -555,7 +556,8 @@ class TestRedmineIntegration:
         # Test delete on non-existent page - should return error
         # Note: Redmine's wiki update API has upsert behavior (creates if not exists),
         # so we only test delete for "not found" errors
-        delete_result = await delete_redmine_wiki_page(
+        delete_result = await manage_redmine_wiki_page(
+            action="delete",
             project_id=project_id,
             wiki_page_title=nonexistent_title,
         )

--- a/tests/test_issue_tracking_tools.py
+++ b/tests/test_issue_tracking_tools.py
@@ -2,10 +2,10 @@
 
 Covers:
     - copy_issue
-    - list_issue_relations / create_issue_relation / delete_issue_relation
+    - manage_issue_relation (action=list|create|delete)
     - list_subtasks
     - edit_note / get_private_notes / set_note_private
-    - add_watcher / remove_watcher
+    - manage_issue_watcher (action=add|remove)
     - manage_issue_category (action=list|create|update|delete)
 
 Follows the project's mocking convention: patch the module-level
@@ -25,16 +25,13 @@ from redmine_mcp_server.redmine_handler import (  # noqa: E402
     _issue_category_to_dict,
     _issue_relation_to_dict,
     _journal_to_dict,
-    add_watcher,
     copy_issue,
-    create_issue_relation,
-    delete_issue_relation,
     edit_note,
     get_private_notes,
-    list_issue_relations,
     list_subtasks,
     manage_issue_category,
-    remove_watcher,
+    manage_issue_relation,
+    manage_issue_watcher,
     set_note_private,
 )
 
@@ -253,7 +250,16 @@ class TestCopyIssue:
 # ---------------------------------------------------------------------------
 
 
-class TestListIssueRelations:
+class TestManageIssueRelation:
+
+    @pytest.mark.asyncio
+    async def test_invalid_action(self):
+        result = await manage_issue_relation(action="get")
+        assert "error" in result
+        assert "Invalid action" in result["error"]
+
+    # --- list ---
+
     @pytest.mark.asyncio
     @patch("redmine_mcp_server.redmine_handler.redmine")
     async def test_list_returns_relations(self, mock_redmine):
@@ -265,7 +271,7 @@ class TestListIssueRelations:
         rel.delay = None
         mock_redmine.issue_relation.filter.return_value = [rel]
 
-        result = await list_issue_relations(issue_id=1)
+        result = await manage_issue_relation(action="list", issue_id=1)
 
         assert len(result) == 1
         assert result[0]["id"] == 5
@@ -276,7 +282,7 @@ class TestListIssueRelations:
     @patch("redmine_mcp_server.redmine_handler.redmine")
     async def test_list_empty(self, mock_redmine):
         mock_redmine.issue_relation.filter.return_value = []
-        result = await list_issue_relations(issue_id=1)
+        result = await manage_issue_relation(action="list", issue_id=1)
         assert result == []
 
     @pytest.mark.asyncio
@@ -285,15 +291,30 @@ class TestListIssueRelations:
         from redminelib.exceptions import ForbiddenError
 
         mock_redmine.issue_relation.filter.side_effect = ForbiddenError()
-        result = await list_issue_relations(issue_id=1)
+        result = await manage_issue_relation(action="list", issue_id=1)
         assert isinstance(result, dict)
         assert "error" in result
 
+    @pytest.mark.asyncio
+    async def test_list_missing_issue_id(self):
+        result = await manage_issue_relation(action="list")
+        assert "error" in result
+        assert "issue_id" in result["error"]
 
-class TestCreateIssueRelation:
+    @pytest.mark.asyncio
+    async def test_list_allowed_in_read_only(self, monkeypatch):
+        monkeypatch.setenv("REDMINE_MCP_READ_ONLY", "true")
+        with patch("redmine_mcp_server.redmine_handler.redmine") as mock_redmine:
+            mock_redmine.issue_relation.filter.return_value = []
+            result = await manage_issue_relation(action="list", issue_id=1)
+            assert isinstance(result, list)
+
+    # --- create ---
+
     @pytest.mark.asyncio
     @patch("redmine_mcp_server.redmine_handler.redmine")
-    async def test_create_basic(self, mock_redmine):
+    @patch("redmine_mcp_server.redmine_handler._ensure_cleanup_started")
+    async def test_create_basic(self, mock_cleanup, mock_redmine):
         rel = Mock()
         rel.id = 99
         rel.issue_id = 1
@@ -302,7 +323,7 @@ class TestCreateIssueRelation:
         rel.delay = None
         mock_redmine.issue_relation.create.return_value = rel
 
-        result = await create_issue_relation(issue_id=1, issue_to_id=2)
+        result = await manage_issue_relation(action="create", issue_id=1, issue_to_id=2)
 
         assert result["id"] == 99
         mock_redmine.issue_relation.create.assert_called_once_with(
@@ -311,7 +332,8 @@ class TestCreateIssueRelation:
 
     @pytest.mark.asyncio
     @patch("redmine_mcp_server.redmine_handler.redmine")
-    async def test_create_with_delay_for_precedes(self, mock_redmine):
+    @patch("redmine_mcp_server.redmine_handler._ensure_cleanup_started")
+    async def test_create_with_delay_for_precedes(self, mock_cleanup, mock_redmine):
         rel = Mock()
         rel.id = 100
         rel.issue_id = 1
@@ -320,7 +342,8 @@ class TestCreateIssueRelation:
         rel.delay = 5
         mock_redmine.issue_relation.create.return_value = rel
 
-        result = await create_issue_relation(
+        result = await manage_issue_relation(
+            action="create",
             issue_id=1,
             issue_to_id=2,
             relation_type="precedes",
@@ -333,43 +356,63 @@ class TestCreateIssueRelation:
         )
 
     @pytest.mark.asyncio
-    async def test_invalid_relation_type(self):
-        result = await create_issue_relation(
-            issue_id=1, issue_to_id=2, relation_type="bogus"
+    async def test_create_invalid_relation_type(self):
+        result = await manage_issue_relation(
+            action="create", issue_id=1, issue_to_id=2, relation_type="bogus"
         )
         assert "error" in result
         assert "Invalid relation_type" in result["error"]
 
     @pytest.mark.asyncio
-    async def test_read_only_mode(self, monkeypatch):
+    async def test_create_missing_issue_id(self):
+        result = await manage_issue_relation(action="create", issue_to_id=2)
+        assert "error" in result
+        assert "issue_id" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_create_missing_issue_to_id(self):
+        result = await manage_issue_relation(action="create", issue_id=1)
+        assert "error" in result
+        assert "issue_to_id" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_create_read_only_mode(self, monkeypatch):
         monkeypatch.setenv("REDMINE_MCP_READ_ONLY", "true")
-        result = await create_issue_relation(issue_id=1, issue_to_id=2)
+        result = await manage_issue_relation(action="create", issue_id=1, issue_to_id=2)
         assert "error" in result
         assert "read-only" in result["error"].lower()
 
+    # --- delete ---
 
-class TestDeleteIssueRelation:
     @pytest.mark.asyncio
     @patch("redmine_mcp_server.redmine_handler.redmine")
-    async def test_delete_success(self, mock_redmine):
+    @patch("redmine_mcp_server.redmine_handler._ensure_cleanup_started")
+    async def test_delete_success(self, mock_cleanup, mock_redmine):
         mock_redmine.issue_relation.delete.return_value = True
-        result = await delete_issue_relation(relation_id=42)
+        result = await manage_issue_relation(action="delete", relation_id=42)
         assert result == {"success": True, "deleted_relation_id": 42}
         mock_redmine.issue_relation.delete.assert_called_once_with(42)
 
     @pytest.mark.asyncio
-    async def test_read_only_mode(self, monkeypatch):
+    async def test_delete_missing_relation_id(self):
+        result = await manage_issue_relation(action="delete")
+        assert "error" in result
+        assert "relation_id" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_delete_read_only_mode(self, monkeypatch):
         monkeypatch.setenv("REDMINE_MCP_READ_ONLY", "true")
-        result = await delete_issue_relation(relation_id=42)
+        result = await manage_issue_relation(action="delete", relation_id=42)
         assert "error" in result
 
     @pytest.mark.asyncio
     @patch("redmine_mcp_server.redmine_handler.redmine")
-    async def test_delete_not_found(self, mock_redmine):
+    @patch("redmine_mcp_server.redmine_handler._ensure_cleanup_started")
+    async def test_delete_not_found(self, mock_cleanup, mock_redmine):
         from redminelib.exceptions import ResourceNotFoundError
 
         mock_redmine.issue_relation.delete.side_effect = ResourceNotFoundError()
-        result = await delete_issue_relation(relation_id=999)
+        result = await manage_issue_relation(action="delete", relation_id=999)
         assert "error" in result
 
 
@@ -416,14 +459,21 @@ class TestListSubtasks:
 # ---------------------------------------------------------------------------
 
 
-class TestWatchers:
+class TestManageIssueWatcher:
+    @pytest.mark.asyncio
+    async def test_invalid_action(self):
+        result = await manage_issue_watcher(action="list", issue_id=1, user_id=5)
+        assert "error" in result
+        assert "Invalid action" in result["error"]
+
     @pytest.mark.asyncio
     @patch("redmine_mcp_server.redmine_handler.redmine")
-    async def test_add_watcher(self, mock_redmine):
+    @patch("redmine_mcp_server.redmine_handler._ensure_cleanup_started")
+    async def test_add_watcher(self, mock_cleanup, mock_redmine):
         issue_mock = Mock()
         mock_redmine.issue.get.return_value = issue_mock
 
-        result = await add_watcher(issue_id=1, user_id=5)
+        result = await manage_issue_watcher(action="add", issue_id=1, user_id=5)
 
         assert result["success"] is True
         assert result["issue_id"] == 1
@@ -433,34 +483,48 @@ class TestWatchers:
 
     @pytest.mark.asyncio
     @patch("redmine_mcp_server.redmine_handler.redmine")
-    async def test_remove_watcher(self, mock_redmine):
+    @patch("redmine_mcp_server.redmine_handler._ensure_cleanup_started")
+    async def test_remove_watcher(self, mock_cleanup, mock_redmine):
         issue_mock = Mock()
         mock_redmine.issue.get.return_value = issue_mock
 
-        result = await remove_watcher(issue_id=1, user_id=5)
+        result = await manage_issue_watcher(action="remove", issue_id=1, user_id=5)
 
         assert result["success"] is True
         issue_mock.watcher.remove.assert_called_once_with(5)
 
     @pytest.mark.asyncio
+    async def test_add_invalid_issue_id(self):
+        result = await manage_issue_watcher(action="add", issue_id=0, user_id=5)
+        assert "error" in result
+
+    @pytest.mark.asyncio
+    async def test_add_invalid_user_id(self):
+        result = await manage_issue_watcher(action="add", issue_id=10, user_id=-1)
+        assert "error" in result
+
+    @pytest.mark.asyncio
     async def test_add_watcher_read_only(self, monkeypatch):
         monkeypatch.setenv("REDMINE_MCP_READ_ONLY", "true")
-        result = await add_watcher(issue_id=1, user_id=5)
+        result = await manage_issue_watcher(action="add", issue_id=1, user_id=5)
         assert "error" in result
+        assert "read-only" in result["error"].lower()
 
     @pytest.mark.asyncio
     async def test_remove_watcher_read_only(self, monkeypatch):
         monkeypatch.setenv("REDMINE_MCP_READ_ONLY", "true")
-        result = await remove_watcher(issue_id=1, user_id=5)
+        result = await manage_issue_watcher(action="remove", issue_id=1, user_id=5)
         assert "error" in result
+        assert "read-only" in result["error"].lower()
 
     @pytest.mark.asyncio
     @patch("redmine_mcp_server.redmine_handler.redmine")
-    async def test_add_watcher_issue_not_found(self, mock_redmine):
+    @patch("redmine_mcp_server.redmine_handler._ensure_cleanup_started")
+    async def test_add_watcher_issue_not_found(self, mock_cleanup, mock_redmine):
         from redminelib.exceptions import ResourceNotFoundError
 
         mock_redmine.issue.get.side_effect = ResourceNotFoundError()
-        result = await add_watcher(issue_id=999, user_id=5)
+        result = await manage_issue_watcher(action="add", issue_id=999, user_id=5)
         assert "error" in result
 
 

--- a/tests/test_issue_tracking_tools.py
+++ b/tests/test_issue_tracking_tools.py
@@ -4,7 +4,7 @@ Covers:
     - copy_issue
     - manage_issue_relation (action=list|create|delete)
     - list_subtasks
-    - edit_note / get_private_notes / set_note_private
+    - manage_issue_note (action=edit|set_private) / get_private_notes
     - manage_issue_watcher (action=add|remove)
     - manage_issue_category (action=list|create|update|delete)
 
@@ -26,13 +26,12 @@ from redmine_mcp_server.redmine_handler import (  # noqa: E402
     _issue_relation_to_dict,
     _journal_to_dict,
     copy_issue,
-    edit_note,
     get_private_notes,
     list_subtasks,
     manage_issue_category,
+    manage_issue_note,
     manage_issue_relation,
     manage_issue_watcher,
-    set_note_private,
 )
 
 
@@ -533,13 +532,21 @@ class TestManageIssueWatcher:
 # ---------------------------------------------------------------------------
 
 
-class TestEditNote:
+class TestManageIssueNoteEdit:
+    @pytest.mark.asyncio
+    async def test_invalid_action(self):
+        result = await manage_issue_note(action="get", journal_id=1, notes="x")
+        assert "error" in result
+        assert "Invalid action" in result["error"]
+
     @pytest.mark.asyncio
     @patch("redmine_mcp_server.redmine_handler.redmine")
     async def test_edit_note_basic(self, mock_redmine):
         mock_redmine.issue_journal.update.return_value = True
 
-        result = await edit_note(journal_id=10, notes="Updated text")
+        result = await manage_issue_note(
+            action="edit", journal_id=10, notes="Updated text"
+        )
 
         assert result["success"] is True
         assert result["journal_id"] == 10
@@ -552,17 +559,31 @@ class TestEditNote:
     async def test_edit_note_with_private_flag(self, mock_redmine):
         mock_redmine.issue_journal.update.return_value = True
 
-        await edit_note(journal_id=10, notes="Secret", private_notes=True)
+        await manage_issue_note(
+            action="edit", journal_id=10, notes="Secret", private_notes=True
+        )
 
         mock_redmine.issue_journal.update.assert_called_once_with(
             10, notes="Secret", private_notes=True
         )
 
     @pytest.mark.asyncio
+    @patch("redmine_mcp_server.redmine_handler.redmine")
+    async def test_edit_note_clear_with_empty_string(self, mock_redmine):
+        result = await manage_issue_note(action="edit", journal_id=10, notes="")
+        assert result["success"] is True
+
+    @pytest.mark.asyncio
+    async def test_edit_note_missing_notes(self):
+        result = await manage_issue_note(action="edit", journal_id=10)
+        assert "error" in result
+
+    @pytest.mark.asyncio
     async def test_edit_note_read_only(self, monkeypatch):
         monkeypatch.setenv("REDMINE_MCP_READ_ONLY", "true")
-        result = await edit_note(journal_id=10, notes="x")
+        result = await manage_issue_note(action="edit", journal_id=10, notes="x")
         assert "error" in result
+        assert "read-only" in result["error"].lower()
 
 
 class TestGetPrivateNotes:
@@ -621,13 +642,15 @@ class TestGetPrivateNotes:
         assert result == []
 
 
-class TestSetNotePrivate:
+class TestManageIssueNoteSetPrivate:
     @pytest.mark.asyncio
     @patch("redmine_mcp_server.redmine_handler.redmine")
     async def test_toggle_private_true(self, mock_redmine):
         mock_redmine.issue_journal.update.return_value = True
 
-        result = await set_note_private(journal_id=10, is_private=True)
+        result = await manage_issue_note(
+            action="set_private", journal_id=10, is_private=True
+        )
 
         assert result["success"] is True
         assert result["private_notes"] is True
@@ -639,16 +662,24 @@ class TestSetNotePrivate:
     @patch("redmine_mcp_server.redmine_handler.redmine")
     async def test_toggle_private_false(self, mock_redmine):
         mock_redmine.issue_journal.update.return_value = True
-        await set_note_private(journal_id=10, is_private=False)
+        await manage_issue_note(action="set_private", journal_id=10, is_private=False)
         mock_redmine.issue_journal.update.assert_called_once_with(
             10, private_notes=False
         )
 
     @pytest.mark.asyncio
+    async def test_set_private_missing_is_private(self):
+        result = await manage_issue_note(action="set_private", journal_id=10)
+        assert "error" in result
+
+    @pytest.mark.asyncio
     async def test_read_only_mode(self, monkeypatch):
         monkeypatch.setenv("REDMINE_MCP_READ_ONLY", "true")
-        result = await set_note_private(journal_id=10, is_private=True)
+        result = await manage_issue_note(
+            action="set_private", journal_id=10, is_private=True
+        )
         assert "error" in result
+        assert "read-only" in result["error"].lower()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_issue_tracking_tools.py
+++ b/tests/test_issue_tracking_tools.py
@@ -6,8 +6,7 @@ Covers:
     - list_subtasks
     - edit_note / get_private_notes / set_note_private
     - add_watcher / remove_watcher
-    - list_issue_categories / create_issue_category /
-      update_issue_category / delete_issue_category
+    - manage_issue_category (action=list|create|update|delete)
 
 Follows the project's mocking convention: patch the module-level
 ``redmine_mcp_server.redmine_handler.redmine`` attribute so that
@@ -28,18 +27,15 @@ from redmine_mcp_server.redmine_handler import (  # noqa: E402
     _journal_to_dict,
     add_watcher,
     copy_issue,
-    create_issue_category,
     create_issue_relation,
-    delete_issue_category,
     delete_issue_relation,
     edit_note,
     get_private_notes,
-    list_issue_categories,
     list_issue_relations,
     list_subtasks,
+    manage_issue_category,
     remove_watcher,
     set_note_private,
-    update_issue_category,
 )
 
 
@@ -596,7 +592,16 @@ class TestSetNotePrivate:
 # ---------------------------------------------------------------------------
 
 
-class TestListIssueCategories:
+class TestManageIssueCategory:
+
+    @pytest.mark.asyncio
+    async def test_invalid_action(self):
+        result = await manage_issue_category(action="get")
+        assert "error" in result
+        assert "Invalid action" in result["error"]
+
+    # --- list ---
+
     @pytest.mark.asyncio
     @patch("redmine_mcp_server.redmine_handler.redmine")
     async def test_list_categories(self, mock_redmine):
@@ -607,7 +612,7 @@ class TestListIssueCategories:
         cat.assigned_to = None
         mock_redmine.issue_category.filter.return_value = [cat]
 
-        result = await list_issue_categories(project_id=10)
+        result = await manage_issue_category(action="list", project_id=10)
 
         assert len(result) == 1
         assert "Bugs" in result[0]["name"]
@@ -617,17 +622,32 @@ class TestListIssueCategories:
     @patch("redmine_mcp_server.redmine_handler.redmine")
     async def test_list_by_identifier(self, mock_redmine):
         mock_redmine.issue_category.filter.return_value = []
-        result = await list_issue_categories(project_id="my-project")
+        result = await manage_issue_category(action="list", project_id="my-project")
         assert result == []
         mock_redmine.issue_category.filter.assert_called_once_with(
             project_id="my-project"
         )
 
+    @pytest.mark.asyncio
+    async def test_list_missing_project_id(self):
+        result = await manage_issue_category(action="list")
+        assert "error" in result
+        assert "project_id" in result["error"]
 
-class TestCreateIssueCategory:
+    @pytest.mark.asyncio
+    async def test_list_allowed_in_read_only(self, monkeypatch):
+        monkeypatch.setenv("REDMINE_MCP_READ_ONLY", "true")
+        with patch("redmine_mcp_server.redmine_handler.redmine") as mock_redmine:
+            mock_redmine.issue_category.filter.return_value = []
+            result = await manage_issue_category(action="list", project_id=10)
+            assert isinstance(result, list)
+
+    # --- create ---
+
     @pytest.mark.asyncio
     @patch("redmine_mcp_server.redmine_handler.redmine")
-    async def test_create_basic(self, mock_redmine):
+    @patch("redmine_mcp_server.redmine_handler._ensure_cleanup_started")
+    async def test_create_basic(self, mock_cleanup, mock_redmine):
         cat = Mock()
         cat.id = 7
         cat.name = "New Cat"
@@ -635,7 +655,9 @@ class TestCreateIssueCategory:
         cat.assigned_to = None
         mock_redmine.issue_category.create.return_value = cat
 
-        result = await create_issue_category(project_id=10, name="New Cat")
+        result = await manage_issue_category(
+            action="create", project_id=10, name="New Cat"
+        )
 
         assert result["id"] == 7
         mock_redmine.issue_category.create.assert_called_once_with(
@@ -644,7 +666,8 @@ class TestCreateIssueCategory:
 
     @pytest.mark.asyncio
     @patch("redmine_mcp_server.redmine_handler.redmine")
-    async def test_create_with_assignee(self, mock_redmine):
+    @patch("redmine_mcp_server.redmine_handler._ensure_cleanup_started")
+    async def test_create_with_assignee(self, mock_cleanup, mock_redmine):
         cat = Mock()
         cat.id = 8
         cat.name = "Support"
@@ -652,8 +675,8 @@ class TestCreateIssueCategory:
         cat.assigned_to = _mock_with_name(3, "Bob")
         mock_redmine.issue_category.create.return_value = cat
 
-        result = await create_issue_category(
-            project_id=10, name="Support", assigned_to_id=3
+        result = await manage_issue_category(
+            action="create", project_id=10, name="Support", assigned_to_id=3
         )
 
         assert result["assigned_to"]["id"] == 3
@@ -663,21 +686,31 @@ class TestCreateIssueCategory:
         )
 
     @pytest.mark.asyncio
+    async def test_create_missing_project_id(self):
+        result = await manage_issue_category(action="create", name="X")
+        assert "error" in result
+        assert "project_id" in result["error"]
+
+    @pytest.mark.asyncio
     async def test_create_empty_name(self):
-        result = await create_issue_category(project_id=10, name="   ")
+        result = await manage_issue_category(action="create", project_id=10, name="   ")
         assert "error" in result
 
     @pytest.mark.asyncio
-    async def test_read_only_mode(self, monkeypatch):
+    async def test_create_read_only_mode(self, monkeypatch):
         monkeypatch.setenv("REDMINE_MCP_READ_ONLY", "true")
-        result = await create_issue_category(project_id=10, name="Test")
+        result = await manage_issue_category(
+            action="create", project_id=10, name="Test"
+        )
         assert "error" in result
+        assert "read-only" in result["error"].lower()
 
+    # --- update ---
 
-class TestUpdateIssueCategory:
     @pytest.mark.asyncio
     @patch("redmine_mcp_server.redmine_handler.redmine")
-    async def test_update_name(self, mock_redmine):
+    @patch("redmine_mcp_server.redmine_handler._ensure_cleanup_started")
+    async def test_update_name(self, mock_cleanup, mock_redmine):
         updated = Mock()
         updated.id = 1
         updated.name = "Renamed"
@@ -685,14 +718,17 @@ class TestUpdateIssueCategory:
         updated.assigned_to = None
         mock_redmine.issue_category.get.return_value = updated
 
-        result = await update_issue_category(category_id=1, name="Renamed")
+        result = await manage_issue_category(
+            action="update", category_id=1, name="Renamed"
+        )
 
         assert "Renamed" in result["name"]
         mock_redmine.issue_category.update.assert_called_once_with(1, name="Renamed")
 
     @pytest.mark.asyncio
     @patch("redmine_mcp_server.redmine_handler.redmine")
-    async def test_update_assignee(self, mock_redmine):
+    @patch("redmine_mcp_server.redmine_handler._ensure_cleanup_started")
+    async def test_update_assignee(self, mock_cleanup, mock_redmine):
         updated = Mock()
         updated.id = 1
         updated.name = "Cat"
@@ -700,59 +736,80 @@ class TestUpdateIssueCategory:
         updated.assigned_to = _mock_with_name(9, "Carol")
         mock_redmine.issue_category.get.return_value = updated
 
-        result = await update_issue_category(category_id=1, assigned_to_id=9)
+        result = await manage_issue_category(
+            action="update", category_id=1, assigned_to_id=9
+        )
 
         assert result["assigned_to"]["id"] == 9
         assert "Carol" in result["assigned_to"]["name"]
         mock_redmine.issue_category.update.assert_called_once_with(1, assigned_to_id=9)
 
     @pytest.mark.asyncio
+    async def test_update_missing_category_id(self):
+        result = await manage_issue_category(action="update", name="X")
+        assert "error" in result
+        assert "category_id" in result["error"]
+
+    @pytest.mark.asyncio
     async def test_update_no_fields(self):
-        result = await update_issue_category(category_id=1)
+        result = await manage_issue_category(action="update", category_id=1)
         assert "error" in result
         assert "No fields" in result["error"]
 
     @pytest.mark.asyncio
     async def test_update_empty_name(self):
-        result = await update_issue_category(category_id=1, name="   ")
+        result = await manage_issue_category(action="update", category_id=1, name="   ")
         assert "error" in result
 
     @pytest.mark.asyncio
-    async def test_read_only_mode(self, monkeypatch):
+    async def test_update_read_only_mode(self, monkeypatch):
         monkeypatch.setenv("REDMINE_MCP_READ_ONLY", "true")
-        result = await update_issue_category(category_id=1, name="x")
+        result = await manage_issue_category(action="update", category_id=1, name="x")
         assert "error" in result
+        assert "read-only" in result["error"].lower()
 
+    # --- delete ---
 
-class TestDeleteIssueCategory:
     @pytest.mark.asyncio
     @patch("redmine_mcp_server.redmine_handler.redmine")
-    async def test_delete_basic(self, mock_redmine):
+    @patch("redmine_mcp_server.redmine_handler._ensure_cleanup_started")
+    async def test_delete_basic(self, mock_cleanup, mock_redmine):
         mock_redmine.issue_category.delete.return_value = True
-        result = await delete_issue_category(category_id=5)
+        result = await manage_issue_category(action="delete", category_id=5)
         assert result["success"] is True
         assert result["deleted_category_id"] == 5
         mock_redmine.issue_category.delete.assert_called_once_with(5)
 
     @pytest.mark.asyncio
     @patch("redmine_mcp_server.redmine_handler.redmine")
-    async def test_delete_with_reassign(self, mock_redmine):
+    @patch("redmine_mcp_server.redmine_handler._ensure_cleanup_started")
+    async def test_delete_with_reassign(self, mock_cleanup, mock_redmine):
         mock_redmine.issue_category.delete.return_value = True
-        result = await delete_issue_category(category_id=5, reassign_to_id=7)
+        result = await manage_issue_category(
+            action="delete", category_id=5, reassign_to_id=7
+        )
         assert result["reassigned_to_id"] == 7
         mock_redmine.issue_category.delete.assert_called_once_with(5, reassign_to_id=7)
 
     @pytest.mark.asyncio
-    async def test_read_only_mode(self, monkeypatch):
-        monkeypatch.setenv("REDMINE_MCP_READ_ONLY", "true")
-        result = await delete_issue_category(category_id=5)
+    async def test_delete_missing_category_id(self):
+        result = await manage_issue_category(action="delete")
         assert "error" in result
+        assert "category_id" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_delete_read_only_mode(self, monkeypatch):
+        monkeypatch.setenv("REDMINE_MCP_READ_ONLY", "true")
+        result = await manage_issue_category(action="delete", category_id=5)
+        assert "error" in result
+        assert "read-only" in result["error"].lower()
 
     @pytest.mark.asyncio
     @patch("redmine_mcp_server.redmine_handler.redmine")
-    async def test_delete_not_found(self, mock_redmine):
+    @patch("redmine_mcp_server.redmine_handler._ensure_cleanup_started")
+    async def test_delete_not_found(self, mock_cleanup, mock_redmine):
         from redminelib.exceptions import ResourceNotFoundError
 
         mock_redmine.issue_category.delete.side_effect = ResourceNotFoundError()
-        result = await delete_issue_category(category_id=999)
+        result = await manage_issue_category(action="delete", category_id=999)
         assert "error" in result

--- a/tests/test_products_support.py
+++ b/tests/test_products_support.py
@@ -11,10 +11,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
 from redmine_mcp_server.redmine_handler import (  # noqa: E402
     _is_products_enabled,
-    list_products,
-    get_product,
-    add_product,
-    edit_product,
+    manage_product,
 )
 
 
@@ -65,7 +62,9 @@ class TestListProducts:
             "products": [_make_product(1), _make_product(2, "Gadget")]
         }
         with patch.dict(os.environ, {"REDMINE_PRODUCTS_ENABLED": "true"}):
-            result = await list_products()
+            result = await manage_product(
+                action="list",
+            )
 
         assert isinstance(result, list)
         assert len(result) == 2
@@ -82,7 +81,7 @@ class TestListProducts:
     async def test_list_by_project(self, mock_redmine):
         mock_redmine.engine.request.return_value = {"products": []}
         with patch.dict(os.environ, {"REDMINE_PRODUCTS_ENABLED": "true"}):
-            await list_products(project_id="catalog")
+            await manage_product(action="list", project_id="catalog")
 
         mock_redmine.engine.request.assert_called_once_with(
             "get",
@@ -93,14 +92,16 @@ class TestListProducts:
     @pytest.mark.asyncio
     async def test_disabled(self):
         with patch.dict(os.environ, {"REDMINE_PRODUCTS_ENABLED": "false"}):
-            result = await list_products()
+            result = await manage_product(
+                action="list",
+            )
         assert "error" in result
         assert "REDMINE_PRODUCTS_ENABLED" in result["error"]
 
     @pytest.mark.asyncio
     async def test_invalid_limit(self):
         with patch.dict(os.environ, {"REDMINE_PRODUCTS_ENABLED": "true"}):
-            result = await list_products(limit=0)
+            result = await manage_product(action="list", limit=0)
         assert "error" in result
 
     @pytest.mark.asyncio
@@ -109,7 +110,9 @@ class TestListProducts:
     async def test_handles_api_error(self, mock_redmine):
         mock_redmine.engine.request.side_effect = Exception("boom")
         with patch.dict(os.environ, {"REDMINE_PRODUCTS_ENABLED": "true"}):
-            result = await list_products()
+            result = await manage_product(
+                action="list",
+            )
         assert "error" in result
 
     @pytest.mark.asyncio
@@ -119,7 +122,7 @@ class TestListProducts:
         """Redmine caps `limit` at 100 server-side; values above are clamped."""
         mock_redmine.engine.request.return_value = {"products": []}
         with patch.dict(os.environ, {"REDMINE_PRODUCTS_ENABLED": "true"}):
-            await list_products(limit=500)
+            await manage_product(action="list", limit=500)
 
         call_kwargs = mock_redmine.engine.request.call_args.kwargs
         assert call_kwargs["params"]["limit"] == 100
@@ -133,7 +136,7 @@ class TestListProducts:
         many = [_make_product(i) for i in range(200)]
         mock_redmine.engine.request.return_value = {"products": many}
         with patch.dict(os.environ, {"REDMINE_PRODUCTS_ENABLED": "true"}):
-            result = await list_products(limit=50)
+            result = await manage_product(action="list", limit=50)
 
         assert isinstance(result, list)
         assert len(result) == 50
@@ -141,28 +144,28 @@ class TestListProducts:
     @pytest.mark.asyncio
     async def test_rejects_empty_project_id(self):
         with patch.dict(os.environ, {"REDMINE_PRODUCTS_ENABLED": "true"}):
-            result = await list_products(project_id="")
+            result = await manage_product(action="list", project_id="")
         assert "error" in result
         assert "project_id" in result["error"]
 
     @pytest.mark.asyncio
     async def test_rejects_project_id_with_slash(self):
         with patch.dict(os.environ, {"REDMINE_PRODUCTS_ENABLED": "true"}):
-            result = await list_products(project_id="foo/../bar")
+            result = await manage_product(action="list", project_id="foo/../bar")
         assert "error" in result
         assert "project_id" in result["error"]
 
     @pytest.mark.asyncio
     async def test_rejects_project_id_with_query_chars(self):
         with patch.dict(os.environ, {"REDMINE_PRODUCTS_ENABLED": "true"}):
-            result = await list_products(project_id="foo?x=1")
+            result = await manage_product(action="list", project_id="foo?x=1")
         assert "error" in result
         assert "project_id" in result["error"]
 
     @pytest.mark.asyncio
     async def test_rejects_project_id_with_uppercase(self):
         with patch.dict(os.environ, {"REDMINE_PRODUCTS_ENABLED": "true"}):
-            result = await list_products(project_id="MyProject")
+            result = await manage_product(action="list", project_id="MyProject")
         assert "error" in result
         assert "project_id" in result["error"]
 
@@ -172,7 +175,7 @@ class TestListProducts:
     async def test_accepts_valid_string_project_id(self, mock_redmine):
         mock_redmine.engine.request.return_value = {"products": []}
         with patch.dict(os.environ, {"REDMINE_PRODUCTS_ENABLED": "true"}):
-            result = await list_products(project_id="my-project_42")
+            result = await manage_product(action="list", project_id="my-project_42")
         assert isinstance(result, list)
 
     @pytest.mark.asyncio
@@ -181,7 +184,7 @@ class TestListProducts:
     async def test_accepts_integer_project_id(self, mock_redmine):
         mock_redmine.engine.request.return_value = {"products": []}
         with patch.dict(os.environ, {"REDMINE_PRODUCTS_ENABLED": "true"}):
-            result = await list_products(project_id=42)
+            result = await manage_product(action="list", project_id=42)
         assert isinstance(result, list)
 
 
@@ -197,20 +200,20 @@ class TestGetProduct:
     async def test_get_success(self, mock_redmine):
         mock_redmine.engine.request.return_value = {"product": _make_product(42)}
         with patch.dict(os.environ, {"REDMINE_PRODUCTS_ENABLED": "true"}):
-            result = await get_product(product_id=42)
+            result = await manage_product(action="get", product_id=42)
         assert result["id"] == 42
         assert "Widget" in result["name"]
 
     @pytest.mark.asyncio
     async def test_disabled(self):
         with patch.dict(os.environ, {"REDMINE_PRODUCTS_ENABLED": "false"}):
-            result = await get_product(product_id=1)
+            result = await manage_product(action="get", product_id=1)
         assert "error" in result
 
     @pytest.mark.asyncio
     async def test_invalid_id(self):
         with patch.dict(os.environ, {"REDMINE_PRODUCTS_ENABLED": "true"}):
-            result = await get_product(product_id=-5)
+            result = await manage_product(action="get", product_id=-5)
         assert "error" in result
 
     @pytest.mark.asyncio
@@ -219,7 +222,7 @@ class TestGetProduct:
     async def test_not_found(self, mock_redmine):
         mock_redmine.engine.request.return_value = {}
         with patch.dict(os.environ, {"REDMINE_PRODUCTS_ENABLED": "true"}):
-            result = await get_product(product_id=999)
+            result = await manage_product(action="get", product_id=999)
         assert "error" in result
         assert "not found" in result["error"]
 
@@ -236,7 +239,7 @@ class TestAddProduct:
     async def test_add_success(self, mock_redmine):
         mock_redmine.engine.request.return_value = {"product": _make_product(1)}
         with patch.dict(os.environ, {"REDMINE_PRODUCTS_ENABLED": "true"}):
-            result = await add_product(name="Widget", price=9.99)
+            result = await manage_product(action="create", name="Widget", price=9.99)
 
         assert result["id"] == 1
         # Verify POST body shape
@@ -255,45 +258,47 @@ class TestAddProduct:
                 "REDMINE_PRODUCTS_ENABLED": "true",
             },
         ):
-            result = await add_product(name="X")
+            result = await manage_product(action="create", name="X")
         assert "read-only" in result["error"].lower()
 
     @pytest.mark.asyncio
     async def test_disabled(self):
         with patch.dict(os.environ, {"REDMINE_PRODUCTS_ENABLED": "false"}):
-            result = await add_product(name="X")
+            result = await manage_product(action="create", name="X")
         assert "REDMINE_PRODUCTS_ENABLED" in result["error"]
 
     @pytest.mark.asyncio
     async def test_empty_name(self):
         with patch.dict(os.environ, {"REDMINE_PRODUCTS_ENABLED": "true"}):
-            result = await add_product(name="")
+            result = await manage_product(action="create", name="")
         assert "error" in result
 
     @pytest.mark.asyncio
     async def test_invalid_status_id(self):
         with patch.dict(os.environ, {"REDMINE_PRODUCTS_ENABLED": "true"}):
-            result = await add_product(name="X", status_id=-1)
+            result = await manage_product(action="create", name="X", status_id=-1)
         assert "error" in result
 
     @pytest.mark.asyncio
     async def test_rejects_unknown_status_id(self):
         with patch.dict(os.environ, {"REDMINE_PRODUCTS_ENABLED": "true"}):
-            result = await add_product(name="Widget", status_id=999)
+            result = await manage_product(action="create", name="Widget", status_id=999)
         assert "error" in result
         assert "status_id" in result["error"]
 
     @pytest.mark.asyncio
     async def test_rejects_zero_status_id(self):
         with patch.dict(os.environ, {"REDMINE_PRODUCTS_ENABLED": "true"}):
-            result = await add_product(name="Widget", status_id=0)
+            result = await manage_product(action="create", name="Widget", status_id=0)
         assert "error" in result
         assert "status_id" in result["error"]
 
     @pytest.mark.asyncio
     async def test_rejects_bool_status_id(self):
         with patch.dict(os.environ, {"REDMINE_PRODUCTS_ENABLED": "true"}):
-            result = await add_product(name="Widget", status_id=True)
+            result = await manage_product(
+                action="create", name="Widget", status_id=True
+            )
         assert "error" in result
         assert "status_id" in result["error"]
 
@@ -310,8 +315,8 @@ class TestEditProduct:
     async def test_edit_success(self, mock_redmine):
         mock_redmine.engine.request.return_value = True
         with patch.dict(os.environ, {"REDMINE_PRODUCTS_ENABLED": "true"}):
-            result = await edit_product(
-                product_id=1, fields={"name": "New", "price": 19.99}
+            result = await manage_product(
+                action="update", product_id=1, fields={"name": "New", "price": 19.99}
             )
 
         assert result["success"] is True
@@ -323,7 +328,8 @@ class TestEditProduct:
     async def test_filters_unknown_fields(self, mock_redmine):
         mock_redmine.engine.request.return_value = True
         with patch.dict(os.environ, {"REDMINE_PRODUCTS_ENABLED": "true"}):
-            result = await edit_product(
+            result = await manage_product(
+                action="update",
                 product_id=1,
                 fields={"name": "New", "evil_field": "bad", "rogue": "x"},
             )
@@ -339,14 +345,16 @@ class TestEditProduct:
             os.environ,
             {"REDMINE_MCP_READ_ONLY": "true", "REDMINE_PRODUCTS_ENABLED": "true"},
         ):
-            result = await edit_product(product_id=1, fields={"name": "X"})
+            result = await manage_product(
+                action="update", product_id=1, fields={"name": "X"}
+            )
         assert "read-only" in result["error"].lower()
 
     @pytest.mark.asyncio
     async def test_no_writable_fields(self):
         with patch.dict(os.environ, {"REDMINE_PRODUCTS_ENABLED": "true"}):
-            result = await edit_product(
-                product_id=1, fields={"unknown": "x", "rogue": "y"}
+            result = await manage_product(
+                action="update", product_id=1, fields={"unknown": "x", "rogue": "y"}
             )
         assert "error" in result
         assert "writable fields" in result["error"]
@@ -354,5 +362,7 @@ class TestEditProduct:
     @pytest.mark.asyncio
     async def test_invalid_id(self):
         with patch.dict(os.environ, {"REDMINE_PRODUCTS_ENABLED": "true"}):
-            result = await edit_product(product_id=-1, fields={"name": "X"})
+            result = await manage_product(
+                action="update", product_id=-1, fields={"name": "X"}
+            )
         assert "error" in result

--- a/tests/test_products_support.py
+++ b/tests/test_products_support.py
@@ -53,7 +53,7 @@ class TestIsProductsEnabled:
 # ---------------------------------------------------------------------------
 
 
-class TestListProducts:
+class TestManageProductList:
     @pytest.mark.asyncio
     @patch("redmine_mcp_server.redmine_handler.REDMINE_URL", "http://localhost:3000")
     @patch("redmine_mcp_server.redmine_handler.redmine")
@@ -193,7 +193,7 @@ class TestListProducts:
 # ---------------------------------------------------------------------------
 
 
-class TestGetProduct:
+class TestManageProductGet:
     @pytest.mark.asyncio
     @patch("redmine_mcp_server.redmine_handler.REDMINE_URL", "http://localhost:3000")
     @patch("redmine_mcp_server.redmine_handler.redmine")
@@ -232,7 +232,7 @@ class TestGetProduct:
 # ---------------------------------------------------------------------------
 
 
-class TestAddProduct:
+class TestManageProductCreate:
     @pytest.mark.asyncio
     @patch("redmine_mcp_server.redmine_handler.REDMINE_URL", "http://localhost:3000")
     @patch("redmine_mcp_server.redmine_handler.redmine")
@@ -308,7 +308,7 @@ class TestAddProduct:
 # ---------------------------------------------------------------------------
 
 
-class TestEditProduct:
+class TestManageProductUpdate:
     @pytest.mark.asyncio
     @patch("redmine_mcp_server.redmine_handler.REDMINE_URL", "http://localhost:3000")
     @patch("redmine_mcp_server.redmine_handler.redmine")

--- a/tests/test_project_tools.py
+++ b/tests/test_project_tools.py
@@ -2,7 +2,8 @@
 
 Covers:
     - get_project_modules
-    - add_project_member / update_project_member / remove_project_member
+    - manage_project_member (action=add|update|remove)
+    - list_redmine_roles
 """
 
 import os
@@ -14,11 +15,9 @@ from unittest.mock import Mock, patch
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
 from redmine_mcp_server.redmine_handler import (  # noqa: E402
-    add_project_member,
     get_project_modules,
     list_redmine_roles,
-    remove_project_member,
-    update_project_member,
+    manage_project_member,
 )
 
 
@@ -154,22 +153,30 @@ class TestGetProjectModules:
 
 
 # ---------------------------------------------------------------------------
-# add_project_member
+# manage_project_member
 # ---------------------------------------------------------------------------
 
 
-class TestAddProjectMember:
+class TestManageProjectMember:
+
+    @pytest.mark.asyncio
+    async def test_invalid_action(self):
+        result = await manage_project_member(action="create")
+        assert "error" in result
+        assert "Invalid action" in result["error"]
+
+    # --- add ---
+
     @pytest.mark.asyncio
     @patch("redmine_mcp_server.redmine_handler.redmine")
-    async def test_add_user(self, mock_redmine):
+    @patch("redmine_mcp_server.redmine_handler._ensure_cleanup_started")
+    async def test_add_user_success(self, mock_cleanup, mock_redmine):
         mock_redmine.project_membership.create.return_value = _mock_membership(
             membership_id=100, user_id=5, user_name="Alice", role_ids=[3]
         )
-
-        result = await add_project_member(
-            project_id="my-project", role_ids=[3], user_id=5
+        result = await manage_project_member(
+            action="add", project_id="my-project", user_id=5, role_ids=[3]
         )
-
         assert result["id"] == 100
         assert result["user"]["id"] == 5
         assert "Alice" in result["user"]["name"]
@@ -179,7 +186,8 @@ class TestAddProjectMember:
 
     @pytest.mark.asyncio
     @patch("redmine_mcp_server.redmine_handler.redmine")
-    async def test_add_group(self, mock_redmine):
+    @patch("redmine_mcp_server.redmine_handler._ensure_cleanup_started")
+    async def test_add_group_routes_via_user_id_field(self, mock_cleanup, mock_redmine):
         """Redmine's membership API uses user_id for both users and groups
         (principal ID namespace is shared). The tool forwards group_id via
         the user_id field."""
@@ -191,84 +199,106 @@ class TestAddProjectMember:
         m.roles = [_mock_with_name(3, "Developer")]
         mock_redmine.project_membership.create.return_value = m
 
-        result = await add_project_member(project_id=10, role_ids=[3], group_id=20)
-
+        result = await manage_project_member(
+            action="add", project_id=10, group_id=20, role_ids=[3]
+        )
         assert result["group"]["id"] == 20
         assert "Dev Team" in result["group"]["name"]
         assert result["user"] is None
-        # Verify group_id was forwarded as user_id (Redmine API convention)
         mock_redmine.project_membership.create.assert_called_once_with(
             project_id=10, user_id=20, role_ids=[3]
         )
 
     @pytest.mark.asyncio
-    async def test_missing_user_and_group(self):
-        result = await add_project_member(project_id=10, role_ids=[3])
+    async def test_add_missing_project_id(self):
+        result = await manage_project_member(action="add", user_id=5, role_ids=[3])
+        assert "error" in result
+        assert "project_id" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_add_missing_user_and_group(self):
+        result = await manage_project_member(action="add", project_id=10, role_ids=[3])
         assert "error" in result
         assert "user_id or group_id" in result["error"]
 
     @pytest.mark.asyncio
-    async def test_both_user_and_group(self):
-        result = await add_project_member(
-            project_id=10, role_ids=[3], user_id=5, group_id=20
+    async def test_add_both_user_and_group_rejected(self):
+        result = await manage_project_member(
+            action="add", project_id=10, user_id=5, group_id=20, role_ids=[3]
         )
         assert "error" in result
         assert "Exactly one" in result["error"]
 
     @pytest.mark.asyncio
-    async def test_empty_role_ids(self):
-        result = await add_project_member(project_id=10, role_ids=[], user_id=5)
+    async def test_add_empty_role_ids(self):
+        result = await manage_project_member(
+            action="add", project_id=10, user_id=5, role_ids=[]
+        )
         assert "error" in result
         assert "role_id" in result["error"]
 
     @pytest.mark.asyncio
-    async def test_non_integer_role_ids(self):
-        result = await add_project_member(project_id=10, role_ids=["admin"], user_id=5)
+    async def test_add_non_integer_role_ids(self):
+        result = await manage_project_member(
+            action="add", project_id=10, user_id=5, role_ids=["admin"]
+        )
         assert "error" in result
         assert "integers" in result["error"]
 
     @pytest.mark.asyncio
-    async def test_read_only_mode(self, monkeypatch):
+    async def test_add_boolean_role_id_rejected(self):
+        result = await manage_project_member(
+            action="add", project_id=10, user_id=5, role_ids=[True]
+        )
+        assert "error" in result
+
+    @pytest.mark.asyncio
+    async def test_add_read_only_mode(self, monkeypatch):
         monkeypatch.setenv("REDMINE_MCP_READ_ONLY", "true")
-        result = await add_project_member(project_id=10, role_ids=[3], user_id=5)
+        result = await manage_project_member(
+            action="add", project_id=10, user_id=5, role_ids=[3]
+        )
         assert "error" in result
         assert "read-only" in result["error"].lower()
 
     @pytest.mark.asyncio
     @patch("redmine_mcp_server.redmine_handler.redmine")
-    async def test_project_not_found(self, mock_redmine):
+    @patch("redmine_mcp_server.redmine_handler._ensure_cleanup_started")
+    async def test_add_project_not_found(self, mock_cleanup, mock_redmine):
         from redminelib.exceptions import ResourceNotFoundError
 
         mock_redmine.project_membership.create.side_effect = ResourceNotFoundError()
-        result = await add_project_member(project_id=9999, role_ids=[3], user_id=5)
+        result = await manage_project_member(
+            action="add", project_id=9999, user_id=5, role_ids=[3]
+        )
         assert "error" in result
 
     @pytest.mark.asyncio
     @patch("redmine_mcp_server.redmine_handler.redmine")
-    async def test_forbidden(self, mock_redmine):
+    @patch("redmine_mcp_server.redmine_handler._ensure_cleanup_started")
+    async def test_add_forbidden(self, mock_cleanup, mock_redmine):
         from redminelib.exceptions import ForbiddenError
 
         mock_redmine.project_membership.create.side_effect = ForbiddenError()
-        result = await add_project_member(project_id=10, role_ids=[3], user_id=5)
+        result = await manage_project_member(
+            action="add", project_id=10, user_id=5, role_ids=[3]
+        )
         assert "error" in result
         assert "Access denied" in result["error"]
 
+    # --- update ---
 
-# ---------------------------------------------------------------------------
-# update_project_member
-# ---------------------------------------------------------------------------
-
-
-class TestUpdateProjectMember:
     @pytest.mark.asyncio
     @patch("redmine_mcp_server.redmine_handler.redmine")
-    async def test_update_roles(self, mock_redmine):
+    @patch("redmine_mcp_server.redmine_handler._ensure_cleanup_started")
+    async def test_update_success(self, mock_cleanup, mock_redmine):
         mock_redmine.project_membership.update.return_value = True
         updated = _mock_membership(membership_id=42, role_ids=[3, 4])
         mock_redmine.project_membership.get.return_value = updated
 
-        result = await update_project_member(membership_id=42, role_ids=[3, 4])
-
+        result = await manage_project_member(
+            action="update", membership_id=42, role_ids=[3, 4]
+        )
         assert result["id"] == 42
         assert len(result["roles"]) == 2
         mock_redmine.project_membership.update.assert_called_once_with(
@@ -277,74 +307,92 @@ class TestUpdateProjectMember:
         mock_redmine.project_membership.get.assert_called_once_with(42)
 
     @pytest.mark.asyncio
-    async def test_empty_role_ids(self):
-        result = await update_project_member(membership_id=42, role_ids=[])
+    async def test_update_missing_membership_id(self):
+        result = await manage_project_member(action="update", role_ids=[3])
+        assert "error" in result
+        assert "membership_id" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_update_empty_role_ids(self):
+        result = await manage_project_member(
+            action="update", membership_id=42, role_ids=[]
+        )
         assert "error" in result
 
     @pytest.mark.asyncio
-    async def test_non_integer_role_ids(self):
-        result = await update_project_member(membership_id=42, role_ids=["admin"])
+    async def test_update_non_integer_role_ids(self):
+        result = await manage_project_member(
+            action="update", membership_id=42, role_ids=["admin"]
+        )
         assert "error" in result
 
     @pytest.mark.asyncio
-    async def test_read_only_mode(self, monkeypatch):
+    async def test_update_read_only_mode(self, monkeypatch):
         monkeypatch.setenv("REDMINE_MCP_READ_ONLY", "true")
-        result = await update_project_member(membership_id=42, role_ids=[3])
+        result = await manage_project_member(
+            action="update", membership_id=42, role_ids=[3]
+        )
         assert "error" in result
         assert "read-only" in result["error"].lower()
 
     @pytest.mark.asyncio
     @patch("redmine_mcp_server.redmine_handler.redmine")
-    async def test_membership_not_found(self, mock_redmine):
+    @patch("redmine_mcp_server.redmine_handler._ensure_cleanup_started")
+    async def test_update_membership_not_found(self, mock_cleanup, mock_redmine):
         from redminelib.exceptions import ResourceNotFoundError
 
         mock_redmine.project_membership.update.side_effect = ResourceNotFoundError()
-        result = await update_project_member(membership_id=9999, role_ids=[3])
+        result = await manage_project_member(
+            action="update", membership_id=9999, role_ids=[3]
+        )
         assert "error" in result
 
+    # --- remove ---
 
-# ---------------------------------------------------------------------------
-# remove_project_member
-# ---------------------------------------------------------------------------
-
-
-class TestRemoveProjectMember:
     @pytest.mark.asyncio
     @patch("redmine_mcp_server.redmine_handler.redmine")
-    async def test_remove_success(self, mock_redmine):
+    @patch("redmine_mcp_server.redmine_handler._ensure_cleanup_started")
+    async def test_remove_success(self, mock_cleanup, mock_redmine):
         mock_redmine.project_membership.delete.return_value = True
 
-        result = await remove_project_member(membership_id=42)
-
+        result = await manage_project_member(action="remove", membership_id=42)
         assert result == {"success": True, "deleted_membership_id": 42}
         mock_redmine.project_membership.delete.assert_called_once_with(42)
 
     @pytest.mark.asyncio
-    async def test_read_only_mode(self, monkeypatch):
+    async def test_remove_missing_membership_id(self):
+        result = await manage_project_member(action="remove")
+        assert "error" in result
+        assert "membership_id" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_remove_read_only_mode(self, monkeypatch):
         monkeypatch.setenv("REDMINE_MCP_READ_ONLY", "true")
-        result = await remove_project_member(membership_id=42)
+        result = await manage_project_member(action="remove", membership_id=42)
         assert "error" in result
         assert "read-only" in result["error"].lower()
 
     @pytest.mark.asyncio
     @patch("redmine_mcp_server.redmine_handler.redmine")
-    async def test_membership_not_found(self, mock_redmine):
+    @patch("redmine_mcp_server.redmine_handler._ensure_cleanup_started")
+    async def test_remove_membership_not_found(self, mock_cleanup, mock_redmine):
         from redminelib.exceptions import ResourceNotFoundError
 
         mock_redmine.project_membership.delete.side_effect = ResourceNotFoundError()
-        result = await remove_project_member(membership_id=9999)
+        result = await manage_project_member(action="remove", membership_id=9999)
         assert "error" in result
 
     @pytest.mark.asyncio
     @patch("redmine_mcp_server.redmine_handler.redmine")
-    async def test_inherited_membership_error(self, mock_redmine):
+    @patch("redmine_mcp_server.redmine_handler._ensure_cleanup_started")
+    async def test_remove_inherited_membership_error(self, mock_cleanup, mock_redmine):
         """Redmine returns 422 for inherited memberships that cannot be removed."""
         from redminelib.exceptions import ValidationError
 
         mock_redmine.project_membership.delete.side_effect = ValidationError(
             "Cannot remove inherited membership"
         )
-        result = await remove_project_member(membership_id=42)
+        result = await manage_project_member(action="remove", membership_id=42)
         assert "error" in result
 
 
@@ -422,20 +470,28 @@ class TestRoleIdErrorHints:
 
     @pytest.mark.asyncio
     async def test_add_member_empty_role_ids_hints_list_roles(self):
-        result = await add_project_member(project_id=10, role_ids=[], user_id=5)
+        result = await manage_project_member(
+            action="add", project_id=10, user_id=5, role_ids=[]
+        )
         assert "list_redmine_roles" in result["error"]
 
     @pytest.mark.asyncio
     async def test_add_member_invalid_role_ids_hints_list_roles(self):
-        result = await add_project_member(project_id=10, role_ids=["admin"], user_id=5)
+        result = await manage_project_member(
+            action="add", project_id=10, user_id=5, role_ids=["admin"]
+        )
         assert "list_redmine_roles" in result["error"]
 
     @pytest.mark.asyncio
     async def test_update_member_empty_role_ids_hints_list_roles(self):
-        result = await update_project_member(membership_id=42, role_ids=[])
+        result = await manage_project_member(
+            action="update", membership_id=42, role_ids=[]
+        )
         assert "list_redmine_roles" in result["error"]
 
     @pytest.mark.asyncio
     async def test_update_member_invalid_role_ids_hints_list_roles(self):
-        result = await update_project_member(membership_id=42, role_ids=["admin"])
+        result = await manage_project_member(
+            action="update", membership_id=42, role_ids=["admin"]
+        )
         assert "list_redmine_roles" in result["error"]

--- a/tests/test_read_only_mode.py
+++ b/tests/test_read_only_mode.py
@@ -17,9 +17,7 @@ from redmine_mcp_server.redmine_handler import (  # noqa: E402
     _is_read_only_mode,
     create_redmine_issue,
     update_redmine_issue,
-    create_redmine_wiki_page,
-    update_redmine_wiki_page,
-    delete_redmine_wiki_page,
+    manage_redmine_wiki_page,
     get_redmine_issue,
     list_redmine_projects,
     list_redmine_issues,
@@ -73,7 +71,9 @@ class TestWriteToolsBlockedInReadOnly:
     @patch("redmine_mcp_server.redmine_handler._ensure_cleanup_started")
     @patch("redmine_mcp_server.redmine_handler.redmine")
     async def test_create_wiki_blocked(self, mock_redmine, mock_cleanup):
-        result = await create_redmine_wiki_page("proj", "Page", "text")
+        result = await manage_redmine_wiki_page(
+            action="create", project_id="proj", wiki_page_title="Page", text="x"
+        )
         assert "read-only" in result["error"].lower()
         mock_redmine.wiki_page.create.assert_not_called()
 
@@ -82,7 +82,9 @@ class TestWriteToolsBlockedInReadOnly:
     @patch("redmine_mcp_server.redmine_handler._ensure_cleanup_started")
     @patch("redmine_mcp_server.redmine_handler.redmine")
     async def test_update_wiki_blocked(self, mock_redmine, mock_cleanup):
-        result = await update_redmine_wiki_page("proj", "Page", "text")
+        result = await manage_redmine_wiki_page(
+            action="update", project_id="proj", wiki_page_title="Page", text="x"
+        )
         assert "read-only" in result["error"].lower()
         mock_redmine.wiki_page.update.assert_not_called()
 
@@ -91,9 +93,22 @@ class TestWriteToolsBlockedInReadOnly:
     @patch("redmine_mcp_server.redmine_handler._ensure_cleanup_started")
     @patch("redmine_mcp_server.redmine_handler.redmine")
     async def test_delete_wiki_blocked(self, mock_redmine, mock_cleanup):
-        result = await delete_redmine_wiki_page("proj", "Page")
+        result = await manage_redmine_wiki_page(
+            action="delete", project_id="proj", wiki_page_title="Page"
+        )
         assert "read-only" in result["error"].lower()
         mock_redmine.wiki_page.delete.assert_not_called()
+
+    @pytest.mark.asyncio
+    @patch.dict(os.environ, {"REDMINE_MCP_READ_ONLY": "true"})
+    @patch("redmine_mcp_server.redmine_handler._ensure_cleanup_started")
+    @patch("redmine_mcp_server.redmine_handler.redmine")
+    async def test_rename_wiki_blocked(self, mock_redmine, mock_cleanup):
+        result = await manage_redmine_wiki_page(
+            action="rename", project_id="p", wiki_page_title="A", new_title="B"
+        )
+        assert "read-only" in result["error"].lower()
+        mock_redmine.wiki_page.update.assert_not_called()
 
 
 class TestReadToolsWorkInReadOnly:

--- a/tests/test_security_hardening.py
+++ b/tests/test_security_hardening.py
@@ -800,16 +800,16 @@ class TestRoleIdsRejectBoolean:
 class TestWatcherUserIdValidation:
     @pytest.mark.asyncio
     async def test_add_watcher_rejects_bool_user_id(self):
-        from redmine_mcp_server.redmine_handler import add_watcher
+        from redmine_mcp_server.redmine_handler import manage_issue_watcher
 
-        result = await add_watcher(issue_id=1, user_id=True)
+        result = await manage_issue_watcher(action="add", issue_id=1, user_id=True)
         assert "error" in result
 
     @pytest.mark.asyncio
     async def test_remove_watcher_rejects_bool_user_id(self):
-        from redmine_mcp_server.redmine_handler import remove_watcher
+        from redmine_mcp_server.redmine_handler import manage_issue_watcher
 
-        result = await remove_watcher(issue_id=1, user_id=True)
+        result = await manage_issue_watcher(action="remove", issue_id=1, user_id=True)
         assert "error" in result
 
 

--- a/tests/test_security_hardening.py
+++ b/tests/test_security_hardening.py
@@ -816,9 +816,11 @@ class TestWatcherUserIdValidation:
 class TestLogTimeForUserRejectsBool:
     @pytest.mark.asyncio
     async def test_user_id_bool_rejected(self):
-        from redmine_mcp_server.redmine_handler import log_time_for_user
+        from redmine_mcp_server.redmine_handler import manage_time_entry
 
-        result = await log_time_for_user(user_id=True, hours=1.0, issue_id=123)
+        result = await manage_time_entry(
+            action="create", user_id=True, hours=1.0, issue_id=123
+        )
         assert "error" in result
         assert "positive integer" in result["error"]
 

--- a/tests/test_security_hardening.py
+++ b/tests/test_security_hardening.py
@@ -755,37 +755,45 @@ class TestIsPositiveInt:
 
 
 class TestRoleIdsRejectBoolean:
-    """add_project_member must reject role_ids=[True] — without the fix
+    """manage_project_member must reject role_ids=[True] — without the fix
     it would silently assign role 1 (often an elevated role)."""
 
     @pytest.mark.asyncio
     async def test_role_ids_with_true_rejected(self):
-        from redmine_mcp_server.redmine_handler import add_project_member
+        from redmine_mcp_server.redmine_handler import manage_project_member
 
-        result = await add_project_member(project_id=10, role_ids=[True], user_id=5)
+        result = await manage_project_member(
+            action="add", project_id=10, role_ids=[True], user_id=5
+        )
         assert "error" in result
         assert "positive integers" in result["error"]
 
     @pytest.mark.asyncio
     async def test_role_ids_with_false_rejected(self):
-        from redmine_mcp_server.redmine_handler import add_project_member
+        from redmine_mcp_server.redmine_handler import manage_project_member
 
-        result = await add_project_member(project_id=10, role_ids=[False], user_id=5)
+        result = await manage_project_member(
+            action="add", project_id=10, role_ids=[False], user_id=5
+        )
         assert "error" in result
 
     @pytest.mark.asyncio
     async def test_role_ids_with_zero_rejected(self):
         """role_id=0 doesn't exist and shouldn't be forwarded."""
-        from redmine_mcp_server.redmine_handler import add_project_member
+        from redmine_mcp_server.redmine_handler import manage_project_member
 
-        result = await add_project_member(project_id=10, role_ids=[0, 3], user_id=5)
+        result = await manage_project_member(
+            action="add", project_id=10, role_ids=[0, 3], user_id=5
+        )
         assert "error" in result
 
     @pytest.mark.asyncio
     async def test_user_id_bool_rejected(self):
-        from redmine_mcp_server.redmine_handler import add_project_member
+        from redmine_mcp_server.redmine_handler import manage_project_member
 
-        result = await add_project_member(project_id=10, role_ids=[3], user_id=True)
+        result = await manage_project_member(
+            action="add", project_id=10, role_ids=[3], user_id=True
+        )
         assert "error" in result
 
 

--- a/tests/test_time_entries.py
+++ b/tests/test_time_entries.py
@@ -265,7 +265,7 @@ class TestListTimeEntries:
         assert len(result) == 0
 
 
-class TestCreateTimeEntry:
+class TestManageTimeEntryCreate:
     """Test cases for create_time_entry tool."""
 
     @pytest.fixture
@@ -416,7 +416,7 @@ class TestCreateTimeEntry:
         assert call_kwargs["hours"] == 0.25
 
 
-class TestUpdateTimeEntry:
+class TestManageTimeEntryUpdate:
     """Test cases for update_time_entry tool."""
 
     @pytest.fixture

--- a/tests/test_time_entries.py
+++ b/tests/test_time_entries.py
@@ -1,7 +1,7 @@
 """
 Test cases for time entry tools.
 
-Tests for list_time_entries, create_time_entry, and update_time_entry tools.
+Tests for list_time_entries and manage_time_entry (action=create|update).
 """
 
 import pytest
@@ -10,8 +10,7 @@ from datetime import datetime
 
 from redmine_mcp_server.redmine_handler import (
     list_time_entries,
-    create_time_entry,
-    update_time_entry,
+    manage_time_entry,
     _time_entry_to_dict,
 )
 
@@ -296,7 +295,9 @@ class TestCreateTimeEntry:
         mock_entry = self.create_mock_time_entry(1, 2.5, issue_id=123)
         mock_redmine.time_entry.create.return_value = mock_entry
 
-        result = await create_time_entry(hours=2.5, issue_id=123, comments="Bug fix")
+        result = await manage_time_entry(
+            action="create", hours=2.5, issue_id=123, comments="Bug fix"
+        )
 
         assert result["id"] == 1
         assert result["hours"] == 2.5
@@ -311,8 +312,8 @@ class TestCreateTimeEntry:
         mock_entry = self.create_mock_time_entry(1, 1.0)
         mock_redmine.time_entry.create.return_value = mock_entry
 
-        result = await create_time_entry(
-            hours=1.0, project_id=10, comments="Project meeting"
+        result = await manage_time_entry(
+            action="create", hours=1.0, project_id=10, comments="Project meeting"
         )
 
         assert result["id"] == 1
@@ -325,7 +326,9 @@ class TestCreateTimeEntry:
         mock_entry = self.create_mock_time_entry(1, 1.0)
         mock_redmine.time_entry.create.return_value = mock_entry
 
-        await create_time_entry(hours=1.0, project_id="my-project", comments="Work")
+        await manage_time_entry(
+            action="create", hours=1.0, project_id="my-project", comments="Work"
+        )
 
         call_kwargs = mock_redmine.time_entry.create.call_args[1]
         assert call_kwargs["project_id"] == "my-project"
@@ -336,7 +339,7 @@ class TestCreateTimeEntry:
         mock_entry = self.create_mock_time_entry(1, 2.0)
         mock_redmine.time_entry.create.return_value = mock_entry
 
-        await create_time_entry(hours=2.0, issue_id=123, activity_id=9)
+        await manage_time_entry(action="create", hours=2.0, issue_id=123, activity_id=9)
 
         call_kwargs = mock_redmine.time_entry.create.call_args[1]
         assert call_kwargs["activity_id"] == 9
@@ -347,7 +350,9 @@ class TestCreateTimeEntry:
         mock_entry = self.create_mock_time_entry(1, 2.0)
         mock_redmine.time_entry.create.return_value = mock_entry
 
-        await create_time_entry(hours=2.0, issue_id=123, spent_on="2024-03-15")
+        await manage_time_entry(
+            action="create", hours=2.0, issue_id=123, spent_on="2024-03-15"
+        )
 
         call_kwargs = mock_redmine.time_entry.create.call_args[1]
         assert call_kwargs["spent_on"] == "2024-03-15"
@@ -355,7 +360,7 @@ class TestCreateTimeEntry:
     @pytest.mark.asyncio
     async def test_create_time_entry_missing_project_and_issue(self, mock_redmine):
         """Test error when neither project_id nor issue_id provided."""
-        result = await create_time_entry(hours=2.0)
+        result = await manage_time_entry(action="create", hours=2.0)
 
         assert "error" in result
         assert "project_id or issue_id" in result["error"]
@@ -363,7 +368,7 @@ class TestCreateTimeEntry:
     @pytest.mark.asyncio
     async def test_create_time_entry_zero_hours(self, mock_redmine):
         """Test error when hours is zero."""
-        result = await create_time_entry(hours=0, issue_id=123)
+        result = await manage_time_entry(action="create", hours=0, issue_id=123)
 
         assert "error" in result
         assert "positive" in result["error"]
@@ -371,7 +376,7 @@ class TestCreateTimeEntry:
     @pytest.mark.asyncio
     async def test_create_time_entry_negative_hours(self, mock_redmine):
         """Test error when hours is negative."""
-        result = await create_time_entry(hours=-1.0, issue_id=123)
+        result = await manage_time_entry(action="create", hours=-1.0, issue_id=123)
 
         assert "error" in result
         assert "positive" in result["error"]
@@ -383,7 +388,7 @@ class TestCreateTimeEntry:
             "redmine_mcp_server.redmine_handler._get_redmine_client",
             side_effect=RuntimeError("No Redmine authentication available"),
         ):
-            result = await create_time_entry(hours=2.0, issue_id=123)
+            result = await manage_time_entry(action="create", hours=2.0, issue_id=123)
 
         assert "error" in result
 
@@ -394,7 +399,7 @@ class TestCreateTimeEntry:
 
         mock_redmine.time_entry.create.side_effect = ResourceNotFoundError()
 
-        result = await create_time_entry(hours=2.0, issue_id=9999)
+        result = await manage_time_entry(action="create", hours=2.0, issue_id=9999)
 
         assert "error" in result
 
@@ -404,7 +409,7 @@ class TestCreateTimeEntry:
         mock_entry = self.create_mock_time_entry(1, 0.25)
         mock_redmine.time_entry.create.return_value = mock_entry
 
-        result = await create_time_entry(hours=0.25, issue_id=123)
+        result = await manage_time_entry(action="create", hours=0.25, issue_id=123)
 
         assert result["id"] == 1
         call_kwargs = mock_redmine.time_entry.create.call_args[1]
@@ -441,7 +446,7 @@ class TestUpdateTimeEntry:
         mock_entry = self.create_mock_time_entry(1, 3.0)
         mock_redmine.time_entry.get.return_value = mock_entry
 
-        result = await update_time_entry(time_entry_id=1, hours=3.0)
+        result = await manage_time_entry(action="update", time_entry_id=1, hours=3.0)
 
         assert result["id"] == 1
         assert result["hours"] == 3.0
@@ -455,7 +460,9 @@ class TestUpdateTimeEntry:
         mock_entry = self.create_mock_time_entry(1, 2.0)
         mock_redmine.time_entry.get.return_value = mock_entry
 
-        await update_time_entry(time_entry_id=1, comments="New description")
+        await manage_time_entry(
+            action="update", time_entry_id=1, comments="New description"
+        )
 
         call_kwargs = mock_redmine.time_entry.update.call_args[1]
         assert call_kwargs["comments"] == "New description"
@@ -466,7 +473,7 @@ class TestUpdateTimeEntry:
         mock_entry = self.create_mock_time_entry(1, 2.0)
         mock_redmine.time_entry.get.return_value = mock_entry
 
-        await update_time_entry(time_entry_id=1, activity_id=10)
+        await manage_time_entry(action="update", time_entry_id=1, activity_id=10)
 
         call_kwargs = mock_redmine.time_entry.update.call_args[1]
         assert call_kwargs["activity_id"] == 10
@@ -477,7 +484,7 @@ class TestUpdateTimeEntry:
         mock_entry = self.create_mock_time_entry(1, 2.0)
         mock_redmine.time_entry.get.return_value = mock_entry
 
-        await update_time_entry(time_entry_id=1, spent_on="2024-03-20")
+        await manage_time_entry(action="update", time_entry_id=1, spent_on="2024-03-20")
 
         call_kwargs = mock_redmine.time_entry.update.call_args[1]
         assert call_kwargs["spent_on"] == "2024-03-20"
@@ -488,7 +495,8 @@ class TestUpdateTimeEntry:
         mock_entry = self.create_mock_time_entry(1, 4.0)
         mock_redmine.time_entry.get.return_value = mock_entry
 
-        await update_time_entry(
+        await manage_time_entry(
+            action="update",
             time_entry_id=1,
             hours=4.0,
             comments="Extended work",
@@ -503,7 +511,7 @@ class TestUpdateTimeEntry:
     @pytest.mark.asyncio
     async def test_update_time_entry_no_fields(self, mock_redmine):
         """Test error when no fields provided for update."""
-        result = await update_time_entry(time_entry_id=1)
+        result = await manage_time_entry(action="update", time_entry_id=1)
 
         assert "error" in result
         assert "No fields" in result["error"]
@@ -511,7 +519,7 @@ class TestUpdateTimeEntry:
     @pytest.mark.asyncio
     async def test_update_time_entry_zero_hours(self, mock_redmine):
         """Test error when hours set to zero."""
-        result = await update_time_entry(time_entry_id=1, hours=0)
+        result = await manage_time_entry(action="update", time_entry_id=1, hours=0)
 
         assert "error" in result
         assert "positive" in result["error"]
@@ -519,7 +527,7 @@ class TestUpdateTimeEntry:
     @pytest.mark.asyncio
     async def test_update_time_entry_negative_hours(self, mock_redmine):
         """Test error when hours set to negative."""
-        result = await update_time_entry(time_entry_id=1, hours=-1.0)
+        result = await manage_time_entry(action="update", time_entry_id=1, hours=-1.0)
 
         assert "error" in result
         assert "positive" in result["error"]
@@ -531,7 +539,7 @@ class TestUpdateTimeEntry:
 
         mock_redmine.time_entry.update.side_effect = ResourceNotFoundError()
 
-        result = await update_time_entry(time_entry_id=9999, hours=2.0)
+        result = await manage_time_entry(action="update", time_entry_id=9999, hours=2.0)
 
         assert "error" in result
 
@@ -542,7 +550,9 @@ class TestUpdateTimeEntry:
             "redmine_mcp_server.redmine_handler._get_redmine_client",
             side_effect=RuntimeError("No Redmine authentication available"),
         ):
-            result = await update_time_entry(time_entry_id=1, hours=2.0)
+            result = await manage_time_entry(
+                action="update", time_entry_id=1, hours=2.0
+            )
 
         assert "error" in result
 
@@ -553,7 +563,7 @@ class TestUpdateTimeEntry:
 
         mock_redmine.time_entry.update.side_effect = ForbiddenError()
 
-        result = await update_time_entry(time_entry_id=1, hours=2.0)
+        result = await manage_time_entry(action="update", time_entry_id=1, hours=2.0)
 
         assert "error" in result
         assert "Access denied" in result["error"]

--- a/tests/test_time_tracking_tools.py
+++ b/tests/test_time_tracking_tools.py
@@ -1,7 +1,7 @@
 """Unit tests for Stage D time tracking tools.
 
 Covers:
-    - log_time_for_user
+    - manage_time_entry(action="create", user_id=...) (replaces log_time_for_user)
     - import_time_entries
 """
 
@@ -15,7 +15,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
 from redmine_mcp_server.redmine_handler import (  # noqa: E402
     import_time_entries,
-    log_time_for_user,
+    manage_time_entry,
 )
 
 
@@ -62,7 +62,8 @@ class TestLogTimeForUser:
             entry_id=100, hours=2.5, user_id=7, user_name="Bob"
         )
 
-        result = await log_time_for_user(
+        result = await manage_time_entry(
+            action="create",
             user_id=7,
             hours=2.5,
             issue_id=123,
@@ -81,7 +82,8 @@ class TestLogTimeForUser:
             entry_id=101, hours=1.0, user_id=7
         )
 
-        result = await log_time_for_user(
+        result = await manage_time_entry(
+            action="create",
             user_id=7,
             hours=1.0,
             project_id="web",
@@ -100,25 +102,31 @@ class TestLogTimeForUser:
 
     @pytest.mark.asyncio
     async def test_missing_project_and_issue(self):
-        result = await log_time_for_user(user_id=7, hours=1.0)
+        result = await manage_time_entry(action="create", user_id=7, hours=1.0)
         assert "error" in result
         assert "project_id or issue_id" in result["error"]
 
     @pytest.mark.asyncio
     async def test_negative_hours(self):
-        result = await log_time_for_user(user_id=7, hours=-1.0, issue_id=123)
+        result = await manage_time_entry(
+            action="create", user_id=7, hours=-1.0, issue_id=123
+        )
         assert "error" in result
         assert "positive" in result["error"].lower()
 
     @pytest.mark.asyncio
     async def test_zero_hours(self):
-        result = await log_time_for_user(user_id=7, hours=0, issue_id=123)
+        result = await manage_time_entry(
+            action="create", user_id=7, hours=0, issue_id=123
+        )
         assert "error" in result
 
     @pytest.mark.asyncio
     async def test_read_only_mode(self, monkeypatch):
         monkeypatch.setenv("REDMINE_MCP_READ_ONLY", "true")
-        result = await log_time_for_user(user_id=7, hours=1.0, issue_id=123)
+        result = await manage_time_entry(
+            action="create", user_id=7, hours=1.0, issue_id=123
+        )
         assert "error" in result
         assert "read-only" in result["error"].lower()
 
@@ -129,7 +137,9 @@ class TestLogTimeForUser:
         from redminelib.exceptions import ForbiddenError
 
         mock_redmine.time_entry.create.side_effect = ForbiddenError()
-        result = await log_time_for_user(user_id=7, hours=1.0, issue_id=123)
+        result = await manage_time_entry(
+            action="create", user_id=7, hours=1.0, issue_id=123
+        )
         assert "error" in result
         assert "Access denied" in result["error"]
 
@@ -140,7 +150,9 @@ class TestLogTimeForUser:
         from redminelib.exceptions import ValidationError
 
         mock_redmine.time_entry.create.side_effect = ValidationError("User is invalid")
-        result = await log_time_for_user(user_id=999, hours=1.0, issue_id=123)
+        result = await manage_time_entry(
+            action="create", user_id=999, hours=1.0, issue_id=123
+        )
         assert "error" in result
 
     @pytest.mark.asyncio
@@ -149,7 +161,9 @@ class TestLogTimeForUser:
         from redminelib.exceptions import ResourceNotFoundError
 
         mock_redmine.time_entry.create.side_effect = ResourceNotFoundError()
-        result = await log_time_for_user(user_id=7, hours=1.0, issue_id=9999)
+        result = await manage_time_entry(
+            action="create", user_id=7, hours=1.0, issue_id=9999
+        )
         assert "error" in result
 
 

--- a/tests/test_time_tracking_tools.py
+++ b/tests/test_time_tracking_tools.py
@@ -54,7 +54,7 @@ def _mock_time_entry(
 # ---------------------------------------------------------------------------
 
 
-class TestLogTimeForUser:
+class TestManageTimeEntryForUser:
     @pytest.mark.asyncio
     @patch("redmine_mcp_server.redmine_handler.redmine")
     async def test_log_time_on_issue(self, mock_redmine):

--- a/tests/test_wiki_editing.py
+++ b/tests/test_wiki_editing.py
@@ -39,9 +39,10 @@ class TestCreateRedmineWikiPage:
     @patch("redmine_mcp_server.redmine_handler.redmine", None)
     async def test_create_wiki_page_no_client(self):
         """Test error when Redmine client is not initialized."""
-        from redmine_mcp_server.redmine_handler import create_redmine_wiki_page
+        from redmine_mcp_server.redmine_handler import manage_redmine_wiki_page
 
-        result = await create_redmine_wiki_page(
+        result = await manage_redmine_wiki_page(
+            action="create",
             project_id="my-project",
             wiki_page_title="New Page",
             text="# New Page\n\nContent here.",
@@ -57,11 +58,12 @@ class TestCreateRedmineWikiPage:
         self, mock_cleanup, mock_redmine, mock_wiki_page
     ):
         """Test successful wiki page creation."""
-        from redmine_mcp_server.redmine_handler import create_redmine_wiki_page
+        from redmine_mcp_server.redmine_handler import manage_redmine_wiki_page
 
         mock_redmine.wiki_page.create.return_value = mock_wiki_page
 
-        result = await create_redmine_wiki_page(
+        result = await manage_redmine_wiki_page(
+            action="create",
             project_id="my-project",
             wiki_page_title="New Page",
             text="# New Page\n\nContent here.",
@@ -80,11 +82,12 @@ class TestCreateRedmineWikiPage:
         self, mock_cleanup, mock_redmine, mock_wiki_page
     ):
         """Test wiki page creation with comments."""
-        from redmine_mcp_server.redmine_handler import create_redmine_wiki_page
+        from redmine_mcp_server.redmine_handler import manage_redmine_wiki_page
 
         mock_redmine.wiki_page.create.return_value = mock_wiki_page
 
-        result = await create_redmine_wiki_page(
+        result = await manage_redmine_wiki_page(
+            action="create",
             project_id="my-project",
             wiki_page_title="New Page",
             text="# New Page\n\nContent here.",
@@ -99,11 +102,12 @@ class TestCreateRedmineWikiPage:
     @patch("redmine_mcp_server.redmine_handler._ensure_cleanup_started")
     async def test_create_wiki_page_forbidden(self, mock_cleanup, mock_redmine):
         """Test handling of permission denied error."""
-        from redmine_mcp_server.redmine_handler import create_redmine_wiki_page
+        from redmine_mcp_server.redmine_handler import manage_redmine_wiki_page
 
         mock_redmine.wiki_page.create.side_effect = ForbiddenError()
 
-        result = await create_redmine_wiki_page(
+        result = await manage_redmine_wiki_page(
+            action="create",
             project_id="my-project",
             wiki_page_title="New Page",
             text="Content",
@@ -120,13 +124,14 @@ class TestCreateRedmineWikiPage:
     @patch("redmine_mcp_server.redmine_handler._ensure_cleanup_started")
     async def test_create_wiki_page_validation_error(self, mock_cleanup, mock_redmine):
         """Test handling of validation error."""
-        from redmine_mcp_server.redmine_handler import create_redmine_wiki_page
+        from redmine_mcp_server.redmine_handler import manage_redmine_wiki_page
 
         mock_redmine.wiki_page.create.side_effect = ValidationError(
             "Title can't be blank"
         )
 
-        result = await create_redmine_wiki_page(
+        result = await manage_redmine_wiki_page(
+            action="create",
             project_id="my-project",
             wiki_page_title="",
             text="Content",
@@ -139,11 +144,12 @@ class TestCreateRedmineWikiPage:
     @patch("redmine_mcp_server.redmine_handler._ensure_cleanup_started")
     async def test_create_wiki_page_general_exception(self, mock_cleanup, mock_redmine):
         """Test handling of general exception."""
-        from redmine_mcp_server.redmine_handler import create_redmine_wiki_page
+        from redmine_mcp_server.redmine_handler import manage_redmine_wiki_page
 
         mock_redmine.wiki_page.create.side_effect = Exception("Unexpected error")
 
-        result = await create_redmine_wiki_page(
+        result = await manage_redmine_wiki_page(
+            action="create",
             project_id="my-project",
             wiki_page_title="New Page",
             text="Content",
@@ -179,9 +185,10 @@ class TestUpdateRedmineWikiPage:
     @patch("redmine_mcp_server.redmine_handler.redmine", None)
     async def test_update_wiki_page_no_client(self):
         """Test error when Redmine client is not initialized."""
-        from redmine_mcp_server.redmine_handler import update_redmine_wiki_page
+        from redmine_mcp_server.redmine_handler import manage_redmine_wiki_page
 
-        result = await update_redmine_wiki_page(
+        result = await manage_redmine_wiki_page(
+            action="update",
             project_id="my-project",
             wiki_page_title="Existing Page",
             text="Updated content",
@@ -197,12 +204,13 @@ class TestUpdateRedmineWikiPage:
         self, mock_cleanup, mock_redmine, mock_wiki_page
     ):
         """Test successful wiki page update."""
-        from redmine_mcp_server.redmine_handler import update_redmine_wiki_page
+        from redmine_mcp_server.redmine_handler import manage_redmine_wiki_page
 
         mock_redmine.wiki_page.update.return_value = True
         mock_redmine.wiki_page.get.return_value = mock_wiki_page
 
-        result = await update_redmine_wiki_page(
+        result = await manage_redmine_wiki_page(
+            action="update",
             project_id="my-project",
             wiki_page_title="Existing Page",
             text="# Updated Content\n\nNew content here.",
@@ -219,12 +227,13 @@ class TestUpdateRedmineWikiPage:
         self, mock_cleanup, mock_redmine, mock_wiki_page
     ):
         """Test wiki page update with comments."""
-        from redmine_mcp_server.redmine_handler import update_redmine_wiki_page
+        from redmine_mcp_server.redmine_handler import manage_redmine_wiki_page
 
         mock_redmine.wiki_page.update.return_value = True
         mock_redmine.wiki_page.get.return_value = mock_wiki_page
 
-        result = await update_redmine_wiki_page(
+        result = await manage_redmine_wiki_page(
+            action="update",
             project_id="my-project",
             wiki_page_title="Existing Page",
             text="Updated content",
@@ -238,11 +247,12 @@ class TestUpdateRedmineWikiPage:
     @patch("redmine_mcp_server.redmine_handler._ensure_cleanup_started")
     async def test_update_wiki_page_not_found(self, mock_cleanup, mock_redmine):
         """Test handling of non-existent wiki page."""
-        from redmine_mcp_server.redmine_handler import update_redmine_wiki_page
+        from redmine_mcp_server.redmine_handler import manage_redmine_wiki_page
 
         mock_redmine.wiki_page.update.side_effect = ResourceNotFoundError()
 
-        result = await update_redmine_wiki_page(
+        result = await manage_redmine_wiki_page(
+            action="update",
             project_id="my-project",
             wiki_page_title="NonExistent",
             text="Content",
@@ -256,11 +266,12 @@ class TestUpdateRedmineWikiPage:
     @patch("redmine_mcp_server.redmine_handler._ensure_cleanup_started")
     async def test_update_wiki_page_forbidden(self, mock_cleanup, mock_redmine):
         """Test handling of permission denied error."""
-        from redmine_mcp_server.redmine_handler import update_redmine_wiki_page
+        from redmine_mcp_server.redmine_handler import manage_redmine_wiki_page
 
         mock_redmine.wiki_page.update.side_effect = ForbiddenError()
 
-        result = await update_redmine_wiki_page(
+        result = await manage_redmine_wiki_page(
+            action="update",
             project_id="my-project",
             wiki_page_title="Existing Page",
             text="Content",
@@ -277,11 +288,12 @@ class TestUpdateRedmineWikiPage:
     @patch("redmine_mcp_server.redmine_handler._ensure_cleanup_started")
     async def test_update_wiki_page_general_exception(self, mock_cleanup, mock_redmine):
         """Test handling of general exception."""
-        from redmine_mcp_server.redmine_handler import update_redmine_wiki_page
+        from redmine_mcp_server.redmine_handler import manage_redmine_wiki_page
 
         mock_redmine.wiki_page.update.side_effect = Exception("Unexpected error")
 
-        result = await update_redmine_wiki_page(
+        result = await manage_redmine_wiki_page(
+            action="update",
             project_id="my-project",
             wiki_page_title="Existing Page",
             text="Content",
@@ -297,9 +309,10 @@ class TestDeleteRedmineWikiPage:
     @patch("redmine_mcp_server.redmine_handler.redmine", None)
     async def test_delete_wiki_page_no_client(self):
         """Test error when Redmine client is not initialized."""
-        from redmine_mcp_server.redmine_handler import delete_redmine_wiki_page
+        from redmine_mcp_server.redmine_handler import manage_redmine_wiki_page
 
-        result = await delete_redmine_wiki_page(
+        result = await manage_redmine_wiki_page(
+            action="delete",
             project_id="my-project",
             wiki_page_title="Page To Delete",
         )
@@ -312,11 +325,12 @@ class TestDeleteRedmineWikiPage:
     @patch("redmine_mcp_server.redmine_handler._ensure_cleanup_started")
     async def test_delete_wiki_page_success(self, mock_cleanup, mock_redmine):
         """Test successful wiki page deletion."""
-        from redmine_mcp_server.redmine_handler import delete_redmine_wiki_page
+        from redmine_mcp_server.redmine_handler import manage_redmine_wiki_page
 
         mock_redmine.wiki_page.delete.return_value = True
 
-        result = await delete_redmine_wiki_page(
+        result = await manage_redmine_wiki_page(
+            action="delete",
             project_id="my-project",
             wiki_page_title="Page To Delete",
         )
@@ -330,11 +344,12 @@ class TestDeleteRedmineWikiPage:
     @patch("redmine_mcp_server.redmine_handler._ensure_cleanup_started")
     async def test_delete_wiki_page_not_found(self, mock_cleanup, mock_redmine):
         """Test handling of non-existent wiki page."""
-        from redmine_mcp_server.redmine_handler import delete_redmine_wiki_page
+        from redmine_mcp_server.redmine_handler import manage_redmine_wiki_page
 
         mock_redmine.wiki_page.delete.side_effect = ResourceNotFoundError()
 
-        result = await delete_redmine_wiki_page(
+        result = await manage_redmine_wiki_page(
+            action="delete",
             project_id="my-project",
             wiki_page_title="NonExistent",
         )
@@ -347,11 +362,12 @@ class TestDeleteRedmineWikiPage:
     @patch("redmine_mcp_server.redmine_handler._ensure_cleanup_started")
     async def test_delete_wiki_page_forbidden(self, mock_cleanup, mock_redmine):
         """Test handling of permission denied error."""
-        from redmine_mcp_server.redmine_handler import delete_redmine_wiki_page
+        from redmine_mcp_server.redmine_handler import manage_redmine_wiki_page
 
         mock_redmine.wiki_page.delete.side_effect = ForbiddenError()
 
-        result = await delete_redmine_wiki_page(
+        result = await manage_redmine_wiki_page(
+            action="delete",
             project_id="my-project",
             wiki_page_title="Protected Page",
         )
@@ -367,11 +383,12 @@ class TestDeleteRedmineWikiPage:
     @patch("redmine_mcp_server.redmine_handler._ensure_cleanup_started")
     async def test_delete_wiki_page_general_exception(self, mock_cleanup, mock_redmine):
         """Test handling of general exception."""
-        from redmine_mcp_server.redmine_handler import delete_redmine_wiki_page
+        from redmine_mcp_server.redmine_handler import manage_redmine_wiki_page
 
         mock_redmine.wiki_page.delete.side_effect = Exception("Unexpected error")
 
-        result = await delete_redmine_wiki_page(
+        result = await manage_redmine_wiki_page(
+            action="delete",
             project_id="my-project",
             wiki_page_title="Some Page",
         )

--- a/tests/test_wiki_editing.py
+++ b/tests/test_wiki_editing.py
@@ -12,7 +12,7 @@ from redminelib.exceptions import (
 )
 
 
-class TestCreateRedmineWikiPage:
+class TestManageRedmineWikiPageCreate:
     """Tests for create_redmine_wiki_page MCP tool."""
 
     @pytest.fixture
@@ -158,7 +158,7 @@ class TestCreateRedmineWikiPage:
         assert "error" in result
 
 
-class TestUpdateRedmineWikiPage:
+class TestManageRedmineWikiPageUpdate:
     """Tests for update_redmine_wiki_page MCP tool."""
 
     @pytest.fixture
@@ -302,7 +302,7 @@ class TestUpdateRedmineWikiPage:
         assert "error" in result
 
 
-class TestDeleteRedmineWikiPage:
+class TestManageRedmineWikiPageDelete:
     """Tests for delete_redmine_wiki_page MCP tool."""
 
     @pytest.mark.asyncio

--- a/tests/test_wiki_management.py
+++ b/tests/test_wiki_management.py
@@ -39,7 +39,7 @@ def _make_wiki_page(
 # ---------------------------------------------------------------------------
 
 
-class TestListWikiPages:
+class TestManageRedmineWikiPageList:
     @pytest.mark.asyncio
     @patch("redmine_mcp_server.redmine_handler.redmine")
     async def test_returns_list_of_pages(self, mock_redmine):
@@ -83,7 +83,7 @@ class TestListWikiPages:
 # ---------------------------------------------------------------------------
 
 
-class TestRenameWikiPage:
+class TestManageRedmineWikiPageRename:
     @pytest.mark.asyncio
     @patch("redmine_mcp_server.redmine_handler.redmine")
     async def test_rename_success(self, mock_redmine):

--- a/tests/test_wiki_management.py
+++ b/tests/test_wiki_management.py
@@ -9,8 +9,7 @@ import pytest
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
 from redmine_mcp_server.redmine_handler import (  # noqa: E402
-    list_wiki_pages,
-    rename_wiki_page,
+    manage_redmine_wiki_page,
 )
 
 
@@ -49,7 +48,7 @@ class TestListWikiPages:
             _make_wiki_page("Setup", version=1, parent_title="Home"),
         ]
 
-        result = await list_wiki_pages(project_id="my-project")
+        result = await manage_redmine_wiki_page(action="list", project_id="my-project")
 
         assert isinstance(result, list)
         assert len(result) == 2
@@ -64,7 +63,7 @@ class TestListWikiPages:
     async def test_empty_project(self, mock_redmine):
         mock_redmine.wiki_page.filter.return_value = []
 
-        result = await list_wiki_pages(project_id="empty")
+        result = await manage_redmine_wiki_page(action="list", project_id="empty")
 
         assert result == []
 
@@ -73,7 +72,7 @@ class TestListWikiPages:
     async def test_returns_error_dict_on_exception(self, mock_redmine):
         mock_redmine.wiki_page.filter.side_effect = Exception("boom")
 
-        result = await list_wiki_pages(project_id="x")
+        result = await manage_redmine_wiki_page(action="list", project_id="x")
 
         assert isinstance(result, dict)
         assert "error" in result
@@ -92,8 +91,8 @@ class TestRenameWikiPage:
         renamed = _make_wiki_page("New", text="Body")
         mock_redmine.wiki_page.get.side_effect = [existing, renamed]
 
-        result = await rename_wiki_page(
-            project_id="proj", old_title="Old", new_title="New"
+        result = await manage_redmine_wiki_page(
+            action="rename", project_id="proj", wiki_page_title="Old", new_title="New"
         )
 
         assert "error" not in result
@@ -114,9 +113,10 @@ class TestRenameWikiPage:
         renamed = _make_wiki_page("New", text="Body")
         mock_redmine.wiki_page.get.side_effect = [existing, renamed]
 
-        await rename_wiki_page(
+        await manage_redmine_wiki_page(
+            action="rename",
             project_id="proj",
-            old_title="Old",
+            wiki_page_title="Old",
             new_title="New",
             redirect_existing_links=False,
         )
@@ -135,8 +135,8 @@ class TestRenameWikiPage:
             Exception("404"),
         ]
 
-        result = await rename_wiki_page(
-            project_id="proj", old_title="Old", new_title="New"
+        result = await manage_redmine_wiki_page(
+            action="rename", project_id="proj", wiki_page_title="Old", new_title="New"
         )
 
         assert "error" in result
@@ -145,8 +145,8 @@ class TestRenameWikiPage:
     @pytest.mark.asyncio
     async def test_blocked_in_read_only_mode(self):
         with patch.dict(os.environ, {"REDMINE_MCP_READ_ONLY": "true"}):
-            result = await rename_wiki_page(
-                project_id="p", old_title="A", new_title="B"
+            result = await manage_redmine_wiki_page(
+                action="rename", project_id="p", wiki_page_title="A", new_title="B"
             )
 
         assert "error" in result
@@ -154,21 +154,27 @@ class TestRenameWikiPage:
 
     @pytest.mark.asyncio
     async def test_rejects_empty_old_title(self):
-        result = await rename_wiki_page(project_id="p", old_title="", new_title="B")
+        result = await manage_redmine_wiki_page(
+            action="rename", project_id="p", wiki_page_title="", new_title="B"
+        )
 
         assert "error" in result
-        assert "old_title" in result["error"]
+        assert "wiki_page_title" in result["error"]
 
     @pytest.mark.asyncio
     async def test_rejects_empty_new_title(self):
-        result = await rename_wiki_page(project_id="p", old_title="A", new_title="")
+        result = await manage_redmine_wiki_page(
+            action="rename", project_id="p", wiki_page_title="A", new_title=""
+        )
 
         assert "error" in result
         assert "new_title" in result["error"]
 
     @pytest.mark.asyncio
     async def test_rejects_unchanged_title(self):
-        result = await rename_wiki_page(project_id="p", old_title="A", new_title="A")
+        result = await manage_redmine_wiki_page(
+            action="rename", project_id="p", wiki_page_title="A", new_title="A"
+        )
 
         assert "error" in result
         assert "differ" in result["error"]
@@ -180,8 +186,8 @@ class TestRenameWikiPage:
 
         mock_redmine.wiki_page.get.side_effect = ResourceNotFoundError()
 
-        result = await rename_wiki_page(
-            project_id="p", old_title="Missing", new_title="New"
+        result = await manage_redmine_wiki_page(
+            action="rename", project_id="p", wiki_page_title="Missing", new_title="New"
         )
 
         assert "error" in result


### PR DESCRIPTION
This pull request implements a major consolidation of the MCP toolset, reducing the total number of tools from 69 to 43 by combining many CRUD-style tools into new `manage_X` tools with an `action` parameter. No functionality is lost; instead, the interface is streamlined and more consistent. Documentation, environment variable descriptions, and the roadmap are updated to reflect these changes, and the deprecated tools are removed from code and docs.

**Tool Consolidation and Interface Changes**
* 35 CRUD-style tools are consolidated into 9 `manage_X` tools (e.g., `manage_project_member`, `manage_issue_category`, `manage_issue_relation`, etc.), reducing the tool count from 69 to 43 and standardizing the action pattern for create/read/update/delete operations. (`CHANGELOG.md` [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR10-R25) `README.md` [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L19-R19) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L440-R442) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L451-L482) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L493-R484) [[6]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L509-R504) `.env.example` [[7]](diffhunk://#diff-a3046da0d15a27e89f2afe639b25748a7ad4d9290af3e7b1b6c1a5533c8f0a8cL57-R69)
* Obsolete tools such as `mark_checklist_done`, `add_project_member`, `edit_note`, and others are removed from the documentation and codebase in favor of their `manage_X` equivalents. (`README.md` [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L451-L482) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L493-R484) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L509-R504) `tests/test_checklist_support.py` [[4]](diffhunk://#diff-ee6dde2d339c638331fc1bbc22ad3380ef8f4bf085da9284bc38f036a20c63dcL18)
* The documentation and environment variable descriptions are updated to reflect the new tool names, usage patterns, and plugin gating. (`README.md` [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L120-R122) `.env.example` [[2]](diffhunk://#diff-a3046da0d15a27e89f2afe639b25748a7ad4d9290af3e7b1b6c1a5533c8f0a8cL57-R69)

**Read-Only Mode Adjustments**
* Read-only mode now blocks all write actions of `manage_X` tools, not just the original create/update/delete endpoints. Documentation is updated to clarify which actions are allowed or blocked. (`README.md` [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L19-R19) `docs/troubleshooting.md` [[2]](diffhunk://#diff-373ebedf1806538a48b09135d964fe714cd54bd8c385e2ef97383324b759e82dL709-R710)

**Project Roadmap and Migration**
* The roadmap is updated to mark tool consolidation as implemented and document the migration steps, including test reorganization and doc updates. (`roadmap.md` [[1]](diffhunk://#diff-51abe96bc493857fdfba599c6b70e3a6c09200cf29e130d15b599fef538e32dfL66-R68) [[2]](diffhunk://#diff-51abe96bc493857fdfba599c6b70e3a6c09200cf29e130d15b599fef538e32dfL85-R88)

These changes provide a more maintainable, discoverable, and uniform interface for MCP tool consumers, with improved documentation and migration guidance.