### PR TITLE
feat: add manage_document tool for DMSF document management (REDMINE_DMSF_ENABLED)

### DIFF
--- a/.env.docker.example
+++ b/.env.docker.example
@@ -35,6 +35,9 @@ ATTACHMENT_EXPIRES_MINUTES=60
 # RedmineUP CRM (Contacts) plugin support (optional)
 # REDMINE_CRM_ENABLED=false
 
+# DMSF (Document Management) plugin support (optional)
+# REDMINE_DMSF_ENABLED=false
+
 # Required custom field autofill (optional)
 # Retries once on relevant create/update validation errors (blank/invalid custom fields)
 # REDMINE_AUTOFILL_REQUIRED_CUSTOM_FIELDS=false

--- a/.env.example
+++ b/.env.example
@@ -70,6 +70,15 @@ ATTACHMENT_EXPIRES_MINUTES=60
 # Requires the RedmineUP CRM plugin installed on your Redmine instance.
 # REDMINE_CRM_ENABLED=false
 
+# DMSF (Document Management) plugin support (optional)
+# Set to true to enable the manage_document tool
+# (action=list/get/create/update). Requires the `redmine_dmsf` plugin
+# (GPL v2, https://github.com/danmunn/redmine_dmsf) installed on your
+# Redmine server. DMSF replaces Redmine's built-in (web-UI-only)
+# Documents module; existing native documents must be migrated with
+# `rake redmine:dmsf_convert_documents` on the server.
+# REDMINE_DMSF_ENABLED=false
+
 # Required custom field autofill (optional)
 # Retries once on relevant create/update validation errors (blank/invalid custom fields)
 # REDMINE_AUTOFILL_REQUIRED_CUSTOM_FIELDS=false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- **`manage_document`** (gated by `REDMINE_DMSF_ENABLED=true`): single MCP tool covering DMSF (Document Management System for Files) plugin operations via an `action` parameter. Requires the `redmine_dmsf` plugin (GPL v2) on the Redmine server.
+  - `action="list"`: list documents in a project (or a specific DMSF folder via `folder_id`); supports `limit` (capped at Redmine's server-side 100/request)
+  - `action="get"`: fetch a single document's metadata by `document_id`
+  - `action="create"`: upload a new document — two-step under the hood (`POST /uploads.json` to get a token, then `POST /projects/{id}/dmsf/commit_files.json` with metadata). Accepts `content_base64` (raw bytes as base64), `filename`, `title`, `description`, `comment`, `folder_id`, `version`, `custom_fields`. Decoded payload capped at 50 MiB.
+  - `action="update"`: update metadata fields (`title`, `description`, `comment`, `custom_fields`) by creating a **new revision** — DMSF is versioned and does not support in-place mutation. DMSF filenames are immutable; to replace file content, `create` a new revision with the same filename.
+  - User-controlled fields (`filename`, `title`, `description`, `name`, plus nested `author.name`) wrapped in `<insecure-content>` boundary tags
+  - Write actions respect `REDMINE_MCP_READ_ONLY` and require `_is_valid_project_id` / `_is_positive_int` validation on path parameters
+  - Whitelist filtering on `update` rejects unknown / immutable keys (e.g., `filename`) with a clear error pointing at the create-new-revision workaround
+  - 31 new unit tests covering feature-flag gating, all four actions, read-only mode, validation paths, base64 decoding errors, size-cap rejection, response shape variants (`{dmsf: [...]}` vs bare list)
+- `REDMINE_DMSF_ENABLED` environment variable (default `false`) documented in `.env.example`, `.env.docker.example`, and README
+- `_is_dmsf_enabled()` helper in `_env.py`
+
 ### Changed
 - Renamed `.env.docker` (previously tracked-but-gitignored placeholder, which trapped local edits as ongoing "modified" status and risked accidental commit of real credentials) to `.env.docker.example`, matching the `.env.example` convention. Users now copy `.env.docker.example` to `.env.docker`, which stays untracked. `deploy.sh` and the README quick-start were updated to copy from the new template name.
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ A Model Context Protocol (MCP) server that integrates with Redmine project manag
 
 ## Features
 
-- **43 MCP Tools**: Issues, projects, time tracking, wiki, Gantt, file operations, membership management, products, contacts (CRM), and more
+- **44 MCP Tools**: Issues, projects, time tracking, wiki, Gantt, file operations, membership management, products, contacts (CRM), DMSF documents, and more
 - **Flexible Authentication**: API key, username/password, or OAuth2 per-user tokens
 - **Prompt Injection Protection**: User-controlled content wrapped in boundary tags for safe LLM consumption
 - **Read-Only Mode**: Restrict to read-only operations via `REDMINE_MCP_READ_ONLY` environment variable
@@ -120,6 +120,7 @@ The server runs on `http://localhost:8000` with the MCP endpoint at `/mcp`, heal
 | `REDMINE_CHECKLISTS_ENABLED` | No | `false` | Enable RedmineUP Checklists plugin support: `get_checklist`, `update_checklist_item` (requires Checklists Pro plugin) |
 | `REDMINE_PRODUCTS_ENABLED` | No | `false` | Enable RedmineUP Products plugin support: `manage_product` (action=list/get/create/update) |
 | `REDMINE_CRM_ENABLED` | No | `false` | Enable RedmineUP CRM plugin support: `manage_contact` (action=list/get/create/update/delete/assign_to_project/remove_from_project) |
+| `REDMINE_DMSF_ENABLED` | No | `false` | Enable DMSF document-management plugin support: `manage_document` (action=list/get/create/update). Requires `redmine_dmsf` plugin on the Redmine server. |
 | `REDMINE_AUTOFILL_REQUIRED_CUSTOM_FIELDS` | No | `false` | Enable one retry for issue creation by filling missing required custom fields |
 | `REDMINE_REQUIRED_CUSTOM_FIELD_DEFAULTS` | No | `{}` | JSON object mapping required custom field names to fallback values used when creating issues |
 | `REDMINE_ALLOW_PRIVATE_FETCH_URLS` | No | `false` | **Warning:** disables all SSRF protection for attachment fetching. Never set to `true` in production. |
@@ -437,7 +438,7 @@ curl http://localhost:8000/health
 
 ## Available Tools
 
-This MCP server provides 43 tools for interacting with Redmine. For detailed documentation, see [Tool Reference](./docs/tool-reference.md).
+This MCP server provides 44 tools for interacting with Redmine. For detailed documentation, see [Tool Reference](./docs/tool-reference.md).
 
 - **Project Management** (9 tools)
   - [`list_redmine_projects`](docs/tool-reference.md#list_redmine_projects) - List all accessible projects
@@ -502,6 +503,9 @@ This MCP server provides 43 tools for interacting with Redmine. For detailed doc
 
 - **Contacts (CRM)** (1 tool, requires `REDMINE_CRM_ENABLED=true` + RedmineUP CRM plugin)
   - [`manage_contact`](docs/tool-reference.md#manage_contact) - List, get, create, update, delete, or assign/remove project association for contacts
+
+- **Documents (DMSF)** (1 tool, requires `REDMINE_DMSF_ENABLED=true` + `redmine_dmsf` plugin)
+  - [`manage_document`](docs/tool-reference.md#manage_document) - List, get, create (upload), or update (new revision) DMSF documents
 
 
 ## Docker Deployment

--- a/docs/tool-reference.md
+++ b/docs/tool-reference.md
@@ -1953,3 +1953,83 @@ manage_contact(action="remove_from_project", contact_id=42, project_id="support"
 **Notes:**
 - `list` and `get` are allowed in read-only mode; `create`, `update`, `delete`, `assign_to_project`, and `remove_from_project` are blocked when `REDMINE_MCP_READ_ONLY=true`.
 - **PII handling:** contact `email`, `phone`, `address`, `birthday`, `website` are returned as-is to the caller; the module never logs them. Error messages reference only `contact_id`. User-controlled display fields (`first_name`, `last_name`, `middle_name`, `company`, `job_title`, `background`, `assigned_to.name`) are wrapped in `<insecure-content>` boundary tags so downstream LLMs treat them as untrusted data.
+
+---
+
+## Documents (DMSF plugin)
+
+This section requires the **`redmine_dmsf`** plugin (GPL v2, open-source) installed on the Redmine server, and `REDMINE_DMSF_ENABLED=true`. DMSF *replaces* Redmine's built-in (web-UI-only) Documents module with a full document-management system that exposes a REST API.
+
+### `manage_document`
+
+Combined DMSF CRUD tool. **Action-dispatched** — pass `action="list"|"get"|"create"|"update"`.
+
+**Parameters (per action):**
+
+| Action | Required | Optional |
+|---|---|---|
+| `list` | `project_id` | `folder_id`, `limit` (1–100) |
+| `get` | `document_id` | – |
+| `create` | `project_id`, `filename`, `content_base64` | `title`, `description`, `comment`, `folder_id`, `version`, `custom_fields` |
+| `update` | `document_id`, `fields` | – |
+
+**Common parameter types:**
+
+- `project_id`: `int` or `string` (Redmine project identifier).
+- `folder_id`, `document_id`: positive `int`.
+- `filename`: `string` (becomes the **immutable** filename for all future revisions of the document).
+- `content_base64`: `string` (raw file bytes encoded as base64). Decoded payload is capped at **50 MiB**.
+- `fields` (for `update`): dict with any subset of the writable keys: `title`, `description`, `comment`, `custom_fields`. Unknown keys (including `filename`) are silently filtered out.
+
+**Returns:**
+
+- `list`: list of node dicts. Each node has `id`, `type` (`file` / `folder` / `file-link` / `folder-link`), `filename`, `title`, `name`, `description`, `version`, `size`, `content_type`, `folder_id`, `project_id`, `author` (`{id, name}`), `created_on`, `updated_on`.
+- `get`: a single node dict with the same shape.
+- `create`: the created document dict, or `{"success": True}` on a 204 / empty response.
+- `update`: `{"success": True, "document_id": N, "updated_fields": [...], "note": "DMSF created a new revision; previous revisions remain accessible via the document's revision history."}`.
+- Any failure: `{"error": "..."}`.
+
+**Examples:**
+
+```python
+# List documents in a project
+manage_document(action="list", project_id="docs", limit=50)
+
+# List documents inside a specific DMSF folder
+manage_document(action="list", project_id="docs", folder_id=12)
+
+# Get metadata for one document
+manage_document(action="get", document_id=42)
+
+# Upload a new document
+import base64
+content_b64 = base64.b64encode(open("spec.pdf", "rb").read()).decode()
+manage_document(
+    action="create",
+    project_id="docs",
+    filename="spec.pdf",
+    content_base64=content_b64,
+    title="Specification",
+    description="Initial draft",
+    comment="Created from CLI",
+)
+
+# Update metadata (creates a new revision — DMSF is versioned)
+manage_document(
+    action="update",
+    document_id=42,
+    fields={"title": "Specification v2", "description": "Updated draft"},
+)
+```
+
+**DMSF design notes (read these before reporting bugs):**
+
+- **Every update creates a new revision.** DMSF is a versioned document system — there is no in-place mutation. Previous revisions remain accessible via the document's revision history in the Redmine UI.
+- **Filenames are immutable.** To change the file content, call `action="create"` again with the same `filename`; DMSF will add the new content as a new revision under the existing document. To rename, you must recreate the document (and update any external references manually).
+- **DMSF replaces the built-in Documents module** rather than complementing it. If your Redmine instance has existing native documents, the server admin must run `rake redmine:dmsf_convert_documents` to migrate them before they're accessible here.
+- **HTTP endpoint paths used** (visible in raw error messages): `GET /projects/{id}/dmsf.json` (list), `GET /dmsf_files/{id}.json` (get), `POST /uploads.json` + `POST /projects/{id}/dmsf/commit_files.json` (create), `POST /dmsf_files/{id}/revision/create.json` (update).
+- If you see a 404 on these endpoints, the `redmine_dmsf` plugin is not installed (or is too old to expose the REST API); double-check the server with `bundle exec rake redmine:plugins:migrate RAILS_ENV=production` after installation.
+
+**Notes:**
+- `list` and `get` are allowed in read-only mode; `create` and `update` are blocked when `REDMINE_MCP_READ_ONLY=true`.
+- User-controlled fields (`filename`, `title`, `name`, `description`, plus nested `author.name`) are wrapped in `<insecure-content>` boundary tags.

--- a/docs/tool-reference.md
+++ b/docs/tool-reference.md
@@ -1970,15 +1970,16 @@ Combined DMSF CRUD tool. **Action-dispatched** — pass `action="list"|"get"|"cr
 |---|---|---|
 | `list` | `project_id` | `folder_id`, `limit` (1–100) |
 | `get` | `document_id` | – |
-| `create` | `project_id`, `filename`, `content_base64` | `title`, `description`, `comment`, `folder_id`, `custom_fields` |
+| `create` | `project_id`, `filename`, `content_base64` | `title`, `description`, `comment`, `folder_id`, `version`, `custom_fields` |
 | `update` | `document_id`, `fields` | – |
 
 **Common parameter types:**
 
 - `project_id`: `int` or `string` (Redmine project identifier).
 - `folder_id`, `document_id`: positive `int`.
-- `filename`: `string`. Used as the initial filename on `create`; can be changed later by passing `name` in `update`'s `fields` (DMSF renames the parent file when a revision's `name` differs).
+- `filename`: `string`. Used as the initial filename on `create`; can be changed later by passing `name` in `update`'s `fields` (DMSF renames the parent file when a revision's `name` differs). **Sent to DMSF as the `name` key** inside `attachments.uploaded_file` — the upload helper reads `committed_file[:name]`, not `[:filename]`.
 - `content_base64`: `string` (raw file bytes encoded as base64). Decoded payload is capped at **50 MiB**.
+- `version` (for `create`): semantic version string for the new revision, e.g. `"1.0"` or `"1.2.3"`. Accepts `"X"`, `"X.Y"`, or `"X.Y.Z"`; missing parts are padded with `"0"`. Each part must be a non-negative integer. DMSF stores `major_version` / `minor_version` / `patch_version` as separate integer columns; the tool splits on `.` before sending.
 - `custom_fields`: list of `{"id": N, "value": ...}` dicts. Sent to DMSF as `custom_field_values` (the API's internal key).
 - `fields` (for `update`): dict with any subset of the writable keys: `title`, `name` (rename), `description`, `comment`, `custom_fields`. Unknown keys are silently filtered out.
 
@@ -2002,17 +2003,18 @@ manage_document(action="list", project_id="docs", folder_id=12)
 # Get metadata for one document
 manage_document(action="get", document_id=42)
 
-# Upload a new document
+# Upload a new document with an explicit initial version
 import base64
 content_b64 = base64.b64encode(open("spec.pdf", "rb").read()).decode()
 manage_document(
     action="create",
     project_id="docs",
-    filename="spec.pdf",
+    filename="spec.pdf",       # sent to DMSF as `name` (the helper reads :name)
     content_base64=content_b64,
     title="Specification",
     description="Initial draft",
     comment="Created from CLI",
+    version="0.1",             # split into version_major / version_minor / version_patch
 )
 
 # Update metadata (creates a new revision — DMSF is versioned)
@@ -2037,7 +2039,7 @@ manage_document(
 - **Renaming.** Set `fields["name"]` on `update` to rename the document; DMSF propagates the new name to the parent file. The list-shape `filename` field cannot be used in `update` — only the canonical `name` key.
 - **Sparse `create` response.** The commit endpoint intentionally returns only `id` + `name` (plus a `total_count`). For full metadata, follow up with `action="get"` using the returned `id`.
 - **Two response shapes for the same document.** `list` returns flat nodes; `get` nests most metadata under `dmsf_file_revisions[]`. The serializer merges both into one stable representation.
-- **Version bumping not exposed.** DMSF's `create_revision` accepts `version_major` / `version_minor` / `version_patch` top-level ints; this tool does not surface those — DMSF auto-increments the patch version on each new revision. Use the Redmine web UI if you need explicit semantic version control.
+- **Version on `create`, not on `update`.** Pass a semantic `version` string (e.g. `"1.2.3"`) on `create` to set the initial revision's version. The tool splits the string into `version_major` / `version_minor` / `version_patch` and nests them inside `attachments.uploaded_file` (where DMSF's commit helper reads them). `update` does **not** expose version control — DMSF auto-increments the patch version when a new revision is created via `dmsf_files#create_revision`. Use the Redmine web UI if you need explicit semantic version control on existing documents. (Why the asymmetry? DMSF's two endpoints read the version fields from different places: `commit` reads them nested inside `uploaded_file`, while `create_revision` reads them from top-level `params`. The MCP tool covers the more common case — version-at-upload-time.)
 - **DMSF replaces the built-in Documents module** rather than complementing it. If your Redmine instance has existing native documents, the server admin must run `rake redmine:dmsf_convert_documents` to migrate them before they're accessible here.
 - **HTTP endpoint paths used** (visible in raw error messages):
   - `GET /projects/{id}/dmsf.json` — list

--- a/docs/tool-reference.md
+++ b/docs/tool-reference.md
@@ -1970,22 +1970,23 @@ Combined DMSF CRUD tool. **Action-dispatched** — pass `action="list"|"get"|"cr
 |---|---|---|
 | `list` | `project_id` | `folder_id`, `limit` (1–100) |
 | `get` | `document_id` | – |
-| `create` | `project_id`, `filename`, `content_base64` | `title`, `description`, `comment`, `folder_id`, `version`, `custom_fields` |
+| `create` | `project_id`, `filename`, `content_base64` | `title`, `description`, `comment`, `folder_id`, `custom_fields` |
 | `update` | `document_id`, `fields` | – |
 
 **Common parameter types:**
 
 - `project_id`: `int` or `string` (Redmine project identifier).
 - `folder_id`, `document_id`: positive `int`.
-- `filename`: `string` (becomes the **immutable** filename for all future revisions of the document).
+- `filename`: `string`. Used as the initial filename on `create`; can be changed later by passing `name` in `update`'s `fields` (DMSF renames the parent file when a revision's `name` differs).
 - `content_base64`: `string` (raw file bytes encoded as base64). Decoded payload is capped at **50 MiB**.
-- `fields` (for `update`): dict with any subset of the writable keys: `title`, `description`, `comment`, `custom_fields`. Unknown keys (including `filename`) are silently filtered out.
+- `custom_fields`: list of `{"id": N, "value": ...}` dicts. Sent to DMSF as `custom_field_values` (the API's internal key).
+- `fields` (for `update`): dict with any subset of the writable keys: `title`, `name` (rename), `description`, `comment`, `custom_fields`. Unknown keys are silently filtered out.
 
 **Returns:**
 
 - `list`: list of node dicts. Each node has `id`, `type` (`file` / `folder` / `file-link` / `folder-link`), `filename`, `title`, `name`, `description`, `version`, `size`, `content_type`, `folder_id`, `project_id`, `author` (`{id, name}`), `created_on`, `updated_on`.
-- `get`: a single node dict with the same shape.
-- `create`: the created document dict, or `{"success": True}` on a 204 / empty response.
+- `get`: a single node dict with the same shape. Most metadata (`description`, `size`, `version`, `mime_type`, `user_id`, timestamps) is pulled from the latest entry of `dmsf_file_revisions[]` — see the design notes below.
+- `create`: a **sparse** dict containing only `id` + `name` (plus a `note` pointing at `action="get"` for full metadata). DMSF's commit endpoint deliberately returns id + name only; call `get` if you need description/size/version/timestamps. Returns `{"success": True}` if the response is unexpectedly empty.
 - `update`: `{"success": True, "document_id": N, "updated_fields": [...], "note": "DMSF created a new revision; previous revisions remain accessible via the document's revision history."}`.
 - Any failure: `{"error": "..."}`.
 
@@ -2020,14 +2021,29 @@ manage_document(
     document_id=42,
     fields={"title": "Specification v2", "description": "Updated draft"},
 )
+
+# Rename a document (DMSF assigns the revision's `name` back to the parent file)
+manage_document(
+    action="update",
+    document_id=42,
+    fields={"name": "spec-v2.pdf"},
+)
 ```
 
-**DMSF design notes (read these before reporting bugs):**
+**DMSF design notes:**
 
 - **Every update creates a new revision.** DMSF is a versioned document system — there is no in-place mutation. Previous revisions remain accessible via the document's revision history in the Redmine UI.
-- **Filenames are immutable.** To change the file content, call `action="create"` again with the same `filename`; DMSF will add the new content as a new revision under the existing document. To rename, you must recreate the document (and update any external references manually).
+- **Required-field auto-population on `update`.** DMSF's revision-create controller crashes (`NoMethodError` on `nil.scrub`) if either `title` or `name` is missing. To make `update` ergonomic when the caller only wants to change `description`, the tool pre-fetches the current document via `GET /dmsf_files/{id}.json` and uses the existing `title`/`name` as defaults. The caller's overrides take precedence.
+- **Renaming.** Set `fields["name"]` on `update` to rename the document; DMSF propagates the new name to the parent file. The list-shape `filename` field cannot be used in `update` — only the canonical `name` key.
+- **Sparse `create` response.** The commit endpoint intentionally returns only `id` + `name` (plus a `total_count`). For full metadata, follow up with `action="get"` using the returned `id`.
+- **Two response shapes for the same document.** `list` returns flat nodes; `get` nests most metadata under `dmsf_file_revisions[]`. The serializer merges both into one stable representation.
+- **Version bumping not exposed.** DMSF's `create_revision` accepts `version_major` / `version_minor` / `version_patch` top-level ints; this tool does not surface those — DMSF auto-increments the patch version on each new revision. Use the Redmine web UI if you need explicit semantic version control.
 - **DMSF replaces the built-in Documents module** rather than complementing it. If your Redmine instance has existing native documents, the server admin must run `rake redmine:dmsf_convert_documents` to migrate them before they're accessible here.
-- **HTTP endpoint paths used** (visible in raw error messages): `GET /projects/{id}/dmsf.json` (list), `GET /dmsf_files/{id}.json` (get), `POST /uploads.json` + `POST /projects/{id}/dmsf/commit_files.json` (create), `POST /dmsf_files/{id}/revision/create.json` (update).
+- **HTTP endpoint paths used** (visible in raw error messages):
+  - `GET /projects/{id}/dmsf.json` — list
+  - `GET /dmsf_files/{id}.json` — get (legacy path is preserved for show)
+  - `POST /uploads.json` then `POST /projects/{id}/dmsf/commit.json` — create
+  - `POST /dmsf/files/{id}/revision/create.json` — update (note slash, not underscore: `dmsf/files`, not `dmsf_files`)
 - If you see a 404 on these endpoints, the `redmine_dmsf` plugin is not installed (or is too old to expose the REST API); double-check the server with `bundle exec rake redmine:plugins:migrate RAILS_ENV=production` after installation.
 
 **Notes:**

--- a/src/redmine_mcp_server/_env.py
+++ b/src/redmine_mcp_server/_env.py
@@ -33,6 +33,11 @@ def _is_crm_enabled() -> bool:
     return _is_true_env("REDMINE_CRM_ENABLED", "false")
 
 
+def _is_dmsf_enabled() -> bool:
+    """Check if DMSF (document management) plugin support is enabled."""
+    return _is_true_env("REDMINE_DMSF_ENABLED", "false")
+
+
 def _get_int_env(var_name: str, default: int) -> int:
     """Parse an integer environment variable, falling back to default."""
     try:

--- a/src/redmine_mcp_server/tools/__init__.py
+++ b/src/redmine_mcp_server/tools/__init__.py
@@ -1,10 +1,11 @@
 """MCP tool implementations, grouped by Redmine resource.
 
-Importing this package triggers ``@mcp.tool()`` registration for all 43 tools.
+Importing this package triggers ``@mcp.tool()`` registration for all tools.
 """
 
 from . import checklists  # noqa: F401  -- triggers @mcp.tool() registration
 from . import contacts  # noqa: F401  -- triggers @mcp.tool() registration
+from . import documents  # noqa: F401  -- triggers @mcp.tool() registration
 from . import enumeration  # noqa: F401  -- triggers @mcp.tool() registration
 from . import files  # noqa: F401  -- triggers @mcp.tool() registration
 from . import gantt  # noqa: F401  -- triggers @mcp.tool() registration

--- a/src/redmine_mcp_server/tools/documents.py
+++ b/src/redmine_mcp_server/tools/documents.py
@@ -65,36 +65,76 @@ _DMSF_UPLOAD_MAX_SIZE_BYTES = 50 * 1024 * 1024
 def _document_to_dict(node: Dict[str, Any]) -> Dict[str, Any]:
     """Serialize a DMSF API node (file / folder / link) into a stable dict.
 
+    DMSF returns two different shapes for the same logical document depending
+    on the endpoint:
+
+    - ``GET /projects/{id}/dmsf.json`` (list) returns flat nodes:
+      ``{"id", "type", "filename", "title", ...}``
+    - ``GET /dmsf_files/{id}.json`` (single) nests current metadata under the
+      latest entry of ``dmsf_file_revisions``: most fields (``description``,
+      ``size``, ``mime_type``, ``user_id``, ``created_at``, ``updated_at``)
+      live there, and the filename is exposed as ``name`` (not ``filename``).
+
+    This serializer merges both shapes into one stable representation, falling
+    back to the latest revision when a field is missing at the top level.
+
     User-controlled fields (``title``, ``name``, ``description``, ``filename``)
     are wrapped in ``<insecure-content>`` boundary tags because they may
     contain prompt-injection payloads.
     """
     if not isinstance(node, dict):
         return {}
-    raw_author = node.get("author")
-    author = raw_author if isinstance(raw_author, dict) else {}
+
+    # The latest revision is the highest-id entry; DMSF returns them in
+    # ascending order so the last element is the current one. Fall back to
+    # max-by-id when the order can't be assumed.
+    revisions = node.get("dmsf_file_revisions")
+    if isinstance(revisions, list) and revisions:
+        latest = revisions[-1]
+        if not isinstance(latest, dict):
+            latest = {}
+    else:
+        latest = {}
+
+    # Author can arrive as a nested dict (list endpoint) or as a bare user_id
+    # on the latest revision (single endpoint). Normalize to either a
+    # ``{"id", "name"}`` dict or ``None``.
+    raw_author = node.get("author") or latest.get("author")
+    if isinstance(raw_author, dict):
+        author: Optional[Dict[str, Any]] = {
+            "id": raw_author.get("id"),
+            "name": wrap_insecure_content(raw_author.get("name", "")),
+        }
+    elif latest.get("user_id") is not None:
+        author = {"id": latest.get("user_id"), "name": None}
+    else:
+        author = None
+
+    filename = node.get("filename") or node.get("name") or ""
+
     return {
         "id": node.get("id"),
         "type": node.get("type"),
-        "filename": wrap_insecure_content(node.get("filename", "")),
-        "title": wrap_insecure_content(node.get("title", "")),
+        "filename": wrap_insecure_content(filename),
+        "title": wrap_insecure_content(node.get("title") or latest.get("title") or ""),
         "name": wrap_insecure_content(node.get("name", "")),
-        "description": wrap_insecure_content(node.get("description", "")),
-        "version": node.get("version"),
-        "size": node.get("size"),
-        "content_type": node.get("content_type"),
+        "description": wrap_insecure_content(
+            node.get("description") or latest.get("description") or ""
+        ),
+        "version": node.get("version") or latest.get("version"),
+        "size": (
+            node.get("size") if node.get("size") is not None else latest.get("size")
+        ),
+        "content_type": node.get("content_type") or latest.get("mime_type"),
         "folder_id": node.get("folder_id"),
         "project_id": node.get("project_id"),
-        "author": (
-            {
-                "id": author.get("id"),
-                "name": wrap_insecure_content(author.get("name", "")),
-            }
-            if author
-            else None
+        "author": author,
+        "created_on": _safe_isoformat(
+            node.get("created_on") or latest.get("created_at")
         ),
-        "created_on": _safe_isoformat(node.get("created_on")),
-        "updated_on": _safe_isoformat(node.get("updated_on")),
+        "updated_on": _safe_isoformat(
+            node.get("updated_on") or latest.get("updated_at")
+        ),
     }
 
 

--- a/src/redmine_mcp_server/tools/documents.py
+++ b/src/redmine_mcp_server/tools/documents.py
@@ -98,6 +98,34 @@ def _document_to_dict(node: Dict[str, Any]) -> Dict[str, Any]:
     }
 
 
+def _extract_dmsf_single_doc(payload: Any) -> Dict[str, Any]:
+    """Pull a single DMSF document dict out of any of the response shapes.
+
+    Variants we tolerate:
+      - ``{"dmsf_file": {...}}``           -- most common single-resource shape
+      - ``{"document": {...}}``            -- older / alternate plugin builds
+      - ``{"dmsf": {"dmsf_file": {...}}}`` -- defensive: same outer wrapping
+        as the list endpoint, in case a plugin version applies it to
+        single resources too
+
+    Returns ``{}`` when no recognized shape is found, so callers can
+    distinguish missing/unparseable payloads from real data.
+    """
+    if not isinstance(payload, dict):
+        return {}
+    for key in ("dmsf_file", "document"):
+        node = payload.get(key)
+        if isinstance(node, dict):
+            return node
+    wrapper = payload.get("dmsf")
+    if isinstance(wrapper, dict):
+        for key in ("dmsf_file", "document"):
+            node = wrapper.get(key)
+            if isinstance(node, dict):
+                return node
+    return {}
+
+
 async def _list_documents_action(
     project_id: Optional[Union[str, int]] = None,
     folder_id: Optional[int] = None,
@@ -125,11 +153,22 @@ async def _list_documents_action(
         if folder_id is not None:
             params["folder_id"] = folder_id
         payload = client.engine.request("get", url, params=params)
-        # DMSF responses commonly wrap items under "dmsf" or return a list.
+        # DMSF's actual list response is:
+        #   {"dmsf": {"dmsf_nodes": [...], "total_count": N}}
+        # i.e. payload["dmsf"] is a *dict* (not a list). Earlier code
+        # assumed payload["dmsf"] was a list and silently emptied the
+        # result. Be defensive: also accept a bare list (older versions
+        # observed in the wild) and the legacy "nodes" key.
         if isinstance(payload, list):
             raw: List[Dict[str, Any]] = payload
         elif isinstance(payload, dict):
-            raw = payload.get("dmsf") or payload.get("nodes") or []
+            dmsf_wrapper = payload.get("dmsf")
+            if isinstance(dmsf_wrapper, dict):
+                raw = dmsf_wrapper.get("dmsf_nodes") or dmsf_wrapper.get("nodes") or []
+            elif isinstance(dmsf_wrapper, list):
+                raw = dmsf_wrapper
+            else:
+                raw = payload.get("nodes") or []
             if not isinstance(raw, list):
                 raw = []
         else:
@@ -155,11 +194,7 @@ async def _get_document_action(
         client = _get_redmine_client()
         url = f"{_client.REDMINE_URL}/dmsf_files/{document_id}.json"
         payload = client.engine.request("get", url)
-        doc = (
-            payload.get("dmsf_file") or payload.get("document") or {}
-            if isinstance(payload, dict)
-            else {}
-        )
+        doc = _extract_dmsf_single_doc(payload)
         if not doc:
             return {"error": f"Document {document_id} not found."}
         return _document_to_dict(doc)
@@ -257,11 +292,7 @@ async def _create_document_action(
             headers={"Content-Type": "application/json"},
             data=json.dumps({"dmsf_file": commit_body}),
         )
-        doc = (
-            payload.get("dmsf_file") or payload.get("document") or {}
-            if isinstance(payload, dict)
-            else {}
-        )
+        doc = _extract_dmsf_single_doc(payload)
         return _document_to_dict(doc) if doc else {"success": True}
     except Exception as e:
         return _handle_redmine_error(

--- a/src/redmine_mcp_server/tools/documents.py
+++ b/src/redmine_mcp_server/tools/documents.py
@@ -8,16 +8,36 @@ system that exposes a REST API.
 Endpoints used (DMSF plugin REST API):
 
 - ``GET  /projects/{id}/dmsf.json`` — list (folder via ``folder_id``)
-- ``GET  /dmsf_files/{id}.json`` — get metadata
+- ``GET  /dmsf_files/{id}.json`` — get metadata (legacy route preserved
+  for show)
 - ``POST /uploads.json`` — upload binary, returns token (core endpoint)
-- ``POST /projects/{id}/dmsf/commit_files.json`` — finalize upload
-- ``POST /dmsf_files/{id}/revision/create.json`` — update (new revision)
+- ``POST /projects/{id}/dmsf/commit.json`` — finalize upload as a DMSF
+  document (controller action ``dmsf_upload#commit``; reads
+  ``params[:attachments][:uploaded_file]`` and ``[:folder_id]``)
+- ``POST /dmsf/files/{id}/revision/create.json`` — update by creating a
+  new revision. Note the slash form (``dmsf/files``), not the legacy
+  underscore form (``dmsf_files``) which only exists for the show route.
 
 DMSF design notes:
 
 - Every update creates a **new revision**; there is no in-place mutation.
-- Filenames are **immutable**. To replace content, upload a new revision
-  with the same filename.
+- ``title`` and ``name`` are **required** by ``create_revision`` (the
+  controller calls ``.scrub.strip`` on both unconditionally). When the
+  caller omits either, ``_update_document_action`` pre-fetches the
+  current document and uses the existing values.
+- ``name`` is the document filename, and DMSF supports renaming via
+  revisions: when a revision's ``name`` differs from the parent file,
+  the controller assigns it back onto the file. (Earlier docs claiming
+  "filenames are immutable" were wrong.)
+- The caller's ``custom_fields`` parameter maps to DMSF's
+  ``custom_field_values`` key in both the commit and revision-create
+  request bodies.
+- DMSF's commit response is intentionally sparse:
+  ``{"dmsf_files": [{"id": N, "name": "..."}], "total_count": N}``.
+  Follow up with ``action="get"`` for full metadata.
+- Document version bumping (``version_major`` / ``version_minor`` /
+  ``version_patch``) is not exposed by this tool; DMSF auto-increments
+  the patch version on each new revision.
 - DMSF replaces the built-in Documents module rather than complementing it.
   Existing native documents are not accessible via DMSF until migrated
   with ``rake redmine:dmsf_convert_documents`` on the server.
@@ -51,8 +71,15 @@ _DMSF_DISABLED_ERROR = {
 
 # Fields the caller may update on an existing document via a new revision.
 # Unknown keys are silently filtered out before reaching the API.
+#
+# Note: ``name`` is included intentionally — DMSF supports renaming a
+# document by creating a new revision with a different ``name``
+# (``dmsf_files_controller#create_revision`` assigns it back to the
+# parent ``DmsfFile``). The caller's ``custom_fields`` key is mapped to
+# DMSF's ``custom_field_values`` in the request body.
 _DOCUMENT_WRITABLE_FIELDS = {
     "title",
+    "name",
     "description",
     "comment",
     "custom_fields",
@@ -274,7 +301,6 @@ async def _create_document_action(
     description: Optional[str] = None,
     comment: Optional[str] = None,
     folder_id: Optional[int] = None,
-    version: Optional[str] = None,
     custom_fields: Optional[List[Dict[str, Any]]] = None,
     **_: Any,
 ) -> Dict[str, Any]:
@@ -305,41 +331,72 @@ async def _create_document_action(
         # DMSF accepts the same token mechanism as core file uploads.
         token = client.upload(io.BytesIO(content_bytes), filename=filename)["token"]
 
-        # Step 2: commit the upload with metadata via the DMSF endpoint.
-        commit_url = (
-            f"{_client.REDMINE_URL}/projects/{project_id}/dmsf/commit_files.json"
-        )
-        commit_body: Dict[str, Any] = {
+        # Step 2: POST /projects/{id}/dmsf/commit.json (DMSF's REST commit
+        # action `dmsf_upload#commit`). The controller reads
+        # ``params[:attachments]``, picks the entries keyed ``uploaded_file``,
+        # and uses ``params[:attachments][:folder_id]`` for folder targeting.
+        # ``custom_field_values`` is the key the upload helper reads (NOT
+        # ``custom_fields``).
+        commit_url = f"{_client.REDMINE_URL}/projects/{project_id}/dmsf/commit.json"
+        uploaded_file: Dict[str, Any] = {
             "token": token,
             "filename": filename,
         }
         if title is not None:
-            commit_body["title"] = title
+            uploaded_file["title"] = title
         if description is not None:
-            commit_body["description"] = description
+            uploaded_file["description"] = description
         if comment is not None:
-            commit_body["comment"] = comment
-        if folder_id is not None:
-            commit_body["folder_id"] = folder_id
-        if version is not None:
-            commit_body["version"] = version
+            uploaded_file["comment"] = comment
         if custom_fields is not None:
-            commit_body["custom_fields"] = custom_fields
+            uploaded_file["custom_field_values"] = custom_fields
+
+        attachments_body: Dict[str, Any] = {"uploaded_file": uploaded_file}
+        if folder_id is not None:
+            attachments_body["folder_id"] = folder_id
 
         payload = client.engine.request(
             "post",
             commit_url,
             headers={"Content-Type": "application/json"},
-            data=json.dumps({"dmsf_file": commit_body}),
+            data=json.dumps({"attachments": attachments_body}),
         )
-        doc = _extract_dmsf_single_doc(payload)
-        return _document_to_dict(doc) if doc else {"success": True}
+
+        # DMSF's commit response is intentionally sparse: each entry is
+        # ``{"id": N, "name": "..."}`` (no description / size / mime /
+        # timestamps). Callers who need full metadata should follow up
+        # with action="get".
+        files = payload.get("dmsf_files", []) if isinstance(payload, dict) else []
+        if not files or not isinstance(files[0], dict):
+            return {"success": True}
+        created = _document_to_dict(files[0])
+        created["note"] = (
+            "DMSF's commit response only includes id + name. "
+            "Call action='get' with the returned id for full metadata "
+            "(description, size, version, timestamps, etc.)."
+        )
+        return created
     except Exception as e:
         return _handle_redmine_error(
             e,
             f"creating DMSF document '{filename}' in project {project_id}",
             {"resource_type": "document", "resource_id": filename},
         )
+
+
+def _fetch_current_dmsf_doc(document_id: int) -> Dict[str, Any]:
+    """Fetch the current document via the show endpoint and return the
+    raw (unwrapped) dict. Used by ``_update_document_action`` to obtain
+    the required ``title`` and ``name`` when the caller has not supplied
+    overrides (``dmsf_files_controller#create_revision`` calls
+    ``.scrub.strip`` on both unconditionally, so nil values crash the
+    server)."""
+    from .. import _client
+
+    client = _get_redmine_client()
+    url = f"{_client.REDMINE_URL}/dmsf_files/{document_id}.json"
+    payload = client.engine.request("get", url)
+    return _extract_dmsf_single_doc(payload)
 
 
 async def _update_document_action(
@@ -356,22 +413,43 @@ async def _update_document_action(
         return {
             "error": (
                 "No writable fields provided. Allowed fields: "
-                f"{sorted(_DOCUMENT_WRITABLE_FIELDS)}. "
-                "Note: DMSF filenames are immutable; to replace content, "
-                "create a new revision via the create action with the same "
-                "filename."
+                f"{sorted(_DOCUMENT_WRITABLE_FIELDS)}."
             )
         }
     from .. import _client
 
     try:
+        # `title` and `name` are required by DMSF's create_revision action
+        # (the controller does .scrub.strip on both unconditionally). When
+        # the caller omits either, pull the current value from the show
+        # endpoint so we don't 500 the server.
+        current = _fetch_current_dmsf_doc(document_id)
+        if not current:
+            return {"error": f"Document {document_id} not found."}
+
+        revision_body: Dict[str, Any] = {
+            "title": filtered.get("title", current.get("title") or ""),
+            "name": filtered.get("name", current.get("name") or ""),
+        }
+        if "description" in filtered:
+            revision_body["description"] = filtered["description"]
+        if "comment" in filtered:
+            revision_body["comment"] = filtered["comment"]
+        if "custom_fields" in filtered:
+            # DMSF reads this key, not "custom_fields", in both
+            # commit and create_revision paths.
+            revision_body["custom_field_values"] = filtered["custom_fields"]
+
         client = _get_redmine_client()
-        url = f"{_client.REDMINE_URL}/dmsf_files/{document_id}/revision/create.json"
+        # Canonical route is /dmsf/files/:id/revision/create (with slash);
+        # the underscore form /dmsf_files/:id/... only exists for GET-show
+        # legacy compatibility and 404s on this POST.
+        url = f"{_client.REDMINE_URL}/dmsf/files/{document_id}/revision/create.json"
         client.engine.request(
             "post",
             url,
             headers={"Content-Type": "application/json"},
-            data=json.dumps({"dmsf_file_revision": filtered}),
+            data=json.dumps({"dmsf_file_revision": revision_body}),
         )
         return {
             "success": True,
@@ -419,7 +497,6 @@ async def manage_document(
     title: Optional[str] = None,
     description: Optional[str] = None,
     comment: Optional[str] = None,
-    version: Optional[str] = None,
     custom_fields: Optional[List[Dict[str, Any]]] = None,
     fields: Optional[Dict[str, Any]] = None,
 ) -> Union[List[Dict[str, Any]], Dict[str, Any]]:
@@ -432,14 +509,17 @@ async def manage_document(
         * ``get``     — fetch a single document's metadata by ID.
         * ``create``  — upload a new document. Two-step under the hood:
                         ``POST /uploads.json`` → token, then
-                        ``POST /projects/{id}/dmsf/commit_files.json``.
-                        Accepts file content as ``content_base64``.
-                        Capped at 50 MiB decoded.
+                        ``POST /projects/{id}/dmsf/commit.json``. Accepts
+                        file content as ``content_base64`` (capped at
+                        50 MiB decoded). DMSF's commit response only
+                        includes ``id`` + ``name``; call ``get`` with the
+                        returned id for full metadata.
         * ``update``  — update document metadata. **Creates a new revision**
                         (DMSF is versioned; in-place mutation is not
-                        supported). DMSF filenames are immutable — to
-                        replace content, ``create`` a new revision with
-                        the same filename.
+                        supported). Supports renaming via the ``name``
+                        field in ``fields``. Required fields (``title``,
+                        ``name``) are auto-populated from the current
+                        document when not supplied.
 
     Args:
         action: One of ``list``, ``get``, ``create``, ``update``.
@@ -448,23 +528,33 @@ async def manage_document(
         folder_id: Optional DMSF folder ID for ``list`` and ``create``.
         limit: Max results for ``list`` (1-100, default 100).
         document_id: Required for ``get`` and ``update``.
-        filename: Required for ``create``. Becomes the immutable filename
-            for all future revisions.
+        filename: Required for ``create``. Used as the initial filename;
+            can be changed later by passing ``name`` in ``update``'s
+            ``fields`` dict.
         content_base64: Required for ``create``. Raw file bytes as base64.
         title: Optional human-readable title (``create``).
         description: Optional description (``create``).
         comment: Optional revision comment (``create``).
-        version: Optional version label (``create``).
         custom_fields: Optional list of ``{"id": N, "value": ...}`` dicts.
-        fields: For ``update``: dict of metadata to update. Allowed keys:
-            ``title``, ``description``, ``comment``, ``custom_fields``.
-            Unknown keys are silently filtered.
+            Sent to DMSF as ``custom_field_values``.
+        fields: For ``update``: dict of metadata to change. Allowed keys:
+            ``title``, ``name`` (rename), ``description``, ``comment``,
+            ``custom_fields``. Unknown keys are silently filtered.
 
     Returns:
         For ``list``: list of document metadata dicts.
-        For ``get`` / ``create``: a single document metadata dict.
-        For ``update``: success dict with ``updated_fields``.
+        For ``get``: a single document metadata dict.
+        For ``create``: a sparse dict (``id`` + ``name`` only) plus a
+            ``note`` pointing at ``action="get"`` for full metadata —
+            DMSF's commit endpoint deliberately returns just the id+name.
+        For ``update``: success dict with ``updated_fields`` and a ``note``
+            confirming a new revision was created.
         On any failure: ``{"error": "..."}``.
+
+    Limitations:
+        Document version bumping (major/minor/patch on a new revision) is
+        not exposed by this tool; DMSF auto-increments the patch version
+        on commit. Use the Redmine web UI for explicit version control.
     """
     if not _is_dmsf_enabled():
         return dict(_DMSF_DISABLED_ERROR)
@@ -479,7 +569,6 @@ async def manage_document(
         title=title,
         description=description,
         comment=comment,
-        version=version,
         custom_fields=custom_fields,
         fields=fields,
     )

--- a/src/redmine_mcp_server/tools/documents.py
+++ b/src/redmine_mcp_server/tools/documents.py
@@ -1,0 +1,414 @@
+"""DMSF (Document Management System for Files) plugin tool.
+
+Gated behind ``REDMINE_DMSF_ENABLED=true``. Uses the ``redmine_dmsf`` plugin
+(GPL v2, https://github.com/danmunn/redmine_dmsf), which replaces Redmine's
+built-in (web-UI-only) Documents module with a full document-management
+system that exposes a REST API.
+
+Endpoints used (DMSF plugin REST API):
+
+- ``GET  /projects/{id}/dmsf.json`` — list (folder via ``folder_id``)
+- ``GET  /dmsf_files/{id}.json`` — get metadata
+- ``POST /uploads.json`` — upload binary, returns token (core endpoint)
+- ``POST /projects/{id}/dmsf/commit_files.json`` — finalize upload
+- ``POST /dmsf_files/{id}/revision/create.json`` — update (new revision)
+
+DMSF design notes:
+
+- Every update creates a **new revision**; there is no in-place mutation.
+- Filenames are **immutable**. To replace content, upload a new revision
+  with the same filename.
+- DMSF replaces the built-in Documents module rather than complementing it.
+  Existing native documents are not accessible via DMSF until migrated
+  with ``rake redmine:dmsf_convert_documents`` on the server.
+"""
+
+import base64
+import binascii
+import io
+import json
+from typing import Any, Dict, List, Optional, Union
+
+from .._client import _get_redmine_client
+from .._decorators import ActionMode, action_dispatch
+from .._env import _is_dmsf_enabled
+from .._errors import _handle_redmine_error
+from .._serialization import (
+    _REDMINE_API_PAGE_CAP,
+    _safe_isoformat,
+    wrap_insecure_content,
+)
+from .._validation import _is_positive_int, _is_valid_project_id
+from ..server import mcp
+
+_DMSF_DISABLED_ERROR = {
+    "error": (
+        "DMSF (document management) support is disabled. "
+        "Set REDMINE_DMSF_ENABLED=true to enable it. "
+        "Requires the redmine_dmsf plugin installed on the Redmine server."
+    )
+}
+
+# Fields the caller may update on an existing document via a new revision.
+# Unknown keys are silently filtered out before reaching the API.
+_DOCUMENT_WRITABLE_FIELDS = {
+    "title",
+    "description",
+    "comment",
+    "custom_fields",
+}
+
+# Match the file upload cap used by `upload_file` for consistency.
+_DMSF_UPLOAD_MAX_SIZE_BYTES = 50 * 1024 * 1024
+
+
+def _document_to_dict(node: Dict[str, Any]) -> Dict[str, Any]:
+    """Serialize a DMSF API node (file / folder / link) into a stable dict.
+
+    User-controlled fields (``title``, ``name``, ``description``, ``filename``)
+    are wrapped in ``<insecure-content>`` boundary tags because they may
+    contain prompt-injection payloads.
+    """
+    if not isinstance(node, dict):
+        return {}
+    raw_author = node.get("author")
+    author = raw_author if isinstance(raw_author, dict) else {}
+    return {
+        "id": node.get("id"),
+        "type": node.get("type"),
+        "filename": wrap_insecure_content(node.get("filename", "")),
+        "title": wrap_insecure_content(node.get("title", "")),
+        "name": wrap_insecure_content(node.get("name", "")),
+        "description": wrap_insecure_content(node.get("description", "")),
+        "version": node.get("version"),
+        "size": node.get("size"),
+        "content_type": node.get("content_type"),
+        "folder_id": node.get("folder_id"),
+        "project_id": node.get("project_id"),
+        "author": (
+            {
+                "id": author.get("id"),
+                "name": wrap_insecure_content(author.get("name", "")),
+            }
+            if author
+            else None
+        ),
+        "created_on": _safe_isoformat(node.get("created_on")),
+        "updated_on": _safe_isoformat(node.get("updated_on")),
+    }
+
+
+async def _list_documents_action(
+    project_id: Optional[Union[str, int]] = None,
+    folder_id: Optional[int] = None,
+    limit: int = 100,
+    **_: Any,
+) -> Union[List[Dict[str, Any]], Dict[str, Any]]:
+    if not _is_valid_project_id(project_id):
+        return {
+            "error": (
+                "project_id is required and must be a non-empty string "
+                "identifier or positive integer."
+            )
+        }
+    if folder_id is not None and not _is_positive_int(folder_id):
+        return {"error": "folder_id must be a positive integer."}
+    if not isinstance(limit, int) or isinstance(limit, bool) or limit < 1:
+        return {"error": "limit must be a positive integer."}
+    limit = min(limit, _REDMINE_API_PAGE_CAP)
+    from .. import _client
+
+    try:
+        client = _get_redmine_client()
+        url = f"{_client.REDMINE_URL}/projects/{project_id}/dmsf.json"
+        params: Dict[str, Any] = {"limit": limit}
+        if folder_id is not None:
+            params["folder_id"] = folder_id
+        payload = client.engine.request("get", url, params=params)
+        # DMSF responses commonly wrap items under "dmsf" or return a list.
+        if isinstance(payload, list):
+            raw: List[Dict[str, Any]] = payload
+        elif isinstance(payload, dict):
+            raw = payload.get("dmsf") or payload.get("nodes") or []
+            if not isinstance(raw, list):
+                raw = []
+        else:
+            raw = []
+        return [_document_to_dict(n) for n in raw[:limit]]
+    except Exception as e:
+        return _handle_redmine_error(
+            e,
+            f"listing DMSF documents in project {project_id}",
+            {"resource_type": "documents", "resource_id": project_id},
+        )
+
+
+async def _get_document_action(
+    document_id: Optional[int] = None,
+    **_: Any,
+) -> Dict[str, Any]:
+    if not _is_positive_int(document_id):
+        return {"error": "document_id must be a positive integer."}
+    from .. import _client
+
+    try:
+        client = _get_redmine_client()
+        url = f"{_client.REDMINE_URL}/dmsf_files/{document_id}.json"
+        payload = client.engine.request("get", url)
+        doc = (
+            payload.get("dmsf_file") or payload.get("document") or {}
+            if isinstance(payload, dict)
+            else {}
+        )
+        if not doc:
+            return {"error": f"Document {document_id} not found."}
+        return _document_to_dict(doc)
+    except Exception as e:
+        return _handle_redmine_error(
+            e,
+            f"fetching DMSF document {document_id}",
+            {"resource_type": "document", "resource_id": document_id},
+        )
+
+
+def _decode_content_base64(content_base64: str) -> Union[bytes, Dict[str, str]]:
+    """Decode and size-check base64 content. Returns bytes or an error dict."""
+    try:
+        content_bytes = base64.b64decode(content_base64, validate=True)
+    except (binascii.Error, ValueError) as e:
+        return {"error": f"content_base64 is not valid base64. Details: {e}"}
+    if len(content_bytes) == 0:
+        return {"error": "Decoded file content is empty."}
+    if len(content_bytes) > _DMSF_UPLOAD_MAX_SIZE_BYTES:
+        size_mb = len(content_bytes) / (1024 * 1024)
+        limit_mb = _DMSF_UPLOAD_MAX_SIZE_BYTES / (1024 * 1024)
+        return {
+            "error": (
+                f"File too large: {size_mb:.1f} MiB exceeds the "
+                f"{limit_mb:.0f} MiB upload limit."
+            )
+        }
+    return content_bytes
+
+
+async def _create_document_action(
+    project_id: Optional[Union[str, int]] = None,
+    filename: Optional[str] = None,
+    content_base64: Optional[str] = None,
+    title: Optional[str] = None,
+    description: Optional[str] = None,
+    comment: Optional[str] = None,
+    folder_id: Optional[int] = None,
+    version: Optional[str] = None,
+    custom_fields: Optional[List[Dict[str, Any]]] = None,
+    **_: Any,
+) -> Dict[str, Any]:
+    if not _is_valid_project_id(project_id):
+        return {
+            "error": (
+                "project_id is required and must be a non-empty string "
+                "identifier or positive integer."
+            )
+        }
+    if not isinstance(filename, str) or not filename.strip():
+        return {"error": "filename is required and must be a non-empty string."}
+    if not isinstance(content_base64, str) or not content_base64.strip():
+        return {"error": "content_base64 is required and must be a non-empty string."}
+    if folder_id is not None and not _is_positive_int(folder_id):
+        return {"error": "folder_id must be a positive integer."}
+
+    decoded = _decode_content_base64(content_base64)
+    if isinstance(decoded, dict):
+        return decoded
+    content_bytes: bytes = decoded
+    from .. import _client
+
+    try:
+        client = _get_redmine_client()
+
+        # Step 1: upload raw bytes to /uploads.json, get token (core endpoint).
+        # DMSF accepts the same token mechanism as core file uploads.
+        token = client.upload(io.BytesIO(content_bytes), filename=filename)["token"]
+
+        # Step 2: commit the upload with metadata via the DMSF endpoint.
+        commit_url = (
+            f"{_client.REDMINE_URL}/projects/{project_id}/dmsf/commit_files.json"
+        )
+        commit_body: Dict[str, Any] = {
+            "token": token,
+            "filename": filename,
+        }
+        if title is not None:
+            commit_body["title"] = title
+        if description is not None:
+            commit_body["description"] = description
+        if comment is not None:
+            commit_body["comment"] = comment
+        if folder_id is not None:
+            commit_body["folder_id"] = folder_id
+        if version is not None:
+            commit_body["version"] = version
+        if custom_fields is not None:
+            commit_body["custom_fields"] = custom_fields
+
+        payload = client.engine.request(
+            "post",
+            commit_url,
+            headers={"Content-Type": "application/json"},
+            data=json.dumps({"dmsf_file": commit_body}),
+        )
+        doc = (
+            payload.get("dmsf_file") or payload.get("document") or {}
+            if isinstance(payload, dict)
+            else {}
+        )
+        return _document_to_dict(doc) if doc else {"success": True}
+    except Exception as e:
+        return _handle_redmine_error(
+            e,
+            f"creating DMSF document '{filename}' in project {project_id}",
+            {"resource_type": "document", "resource_id": filename},
+        )
+
+
+async def _update_document_action(
+    document_id: Optional[int] = None,
+    fields: Optional[Dict[str, Any]] = None,
+    **_: Any,
+) -> Dict[str, Any]:
+    if not _is_positive_int(document_id):
+        return {"error": "document_id must be a positive integer."}
+    if not isinstance(fields, dict) or not fields:
+        return {"error": "fields must be a non-empty dict."}
+    filtered = {k: v for k, v in fields.items() if k in _DOCUMENT_WRITABLE_FIELDS}
+    if not filtered:
+        return {
+            "error": (
+                "No writable fields provided. Allowed fields: "
+                f"{sorted(_DOCUMENT_WRITABLE_FIELDS)}. "
+                "Note: DMSF filenames are immutable; to replace content, "
+                "create a new revision via the create action with the same "
+                "filename."
+            )
+        }
+    from .. import _client
+
+    try:
+        client = _get_redmine_client()
+        url = f"{_client.REDMINE_URL}/dmsf_files/{document_id}/revision/create.json"
+        client.engine.request(
+            "post",
+            url,
+            headers={"Content-Type": "application/json"},
+            data=json.dumps({"dmsf_file_revision": filtered}),
+        )
+        return {
+            "success": True,
+            "document_id": document_id,
+            "updated_fields": list(filtered.keys()),
+            "note": (
+                "DMSF created a new revision; previous revisions remain "
+                "accessible via the document's revision history."
+            ),
+        }
+    except Exception as e:
+        return _handle_redmine_error(
+            e,
+            f"updating DMSF document {document_id}",
+            {"resource_type": "document", "resource_id": document_id},
+        )
+
+
+@action_dispatch(
+    {
+        "list": ActionMode.READ,
+        "get": ActionMode.READ,
+        "create": ActionMode.WRITE,
+        "update": ActionMode.WRITE,
+    }
+)
+async def _manage_document_dispatch(action: str, **kwargs: Any) -> Any:
+    return {
+        "list": _list_documents_action,
+        "get": _get_document_action,
+        "create": _create_document_action,
+        "update": _update_document_action,
+    }
+
+
+@mcp.tool()
+async def manage_document(
+    action: str,
+    project_id: Optional[Union[str, int]] = None,
+    folder_id: Optional[int] = None,
+    limit: int = 100,
+    document_id: Optional[int] = None,
+    filename: Optional[str] = None,
+    content_base64: Optional[str] = None,
+    title: Optional[str] = None,
+    description: Optional[str] = None,
+    comment: Optional[str] = None,
+    version: Optional[str] = None,
+    custom_fields: Optional[List[Dict[str, Any]]] = None,
+    fields: Optional[Dict[str, Any]] = None,
+) -> Union[List[Dict[str, Any]], Dict[str, Any]]:
+    """Manage DMSF documents (list / get / create / update).
+
+    Requires the ``redmine_dmsf`` plugin and ``REDMINE_DMSF_ENABLED=true``.
+
+    Actions:
+        * ``list``    — list documents in a project (or a DMSF folder).
+        * ``get``     — fetch a single document's metadata by ID.
+        * ``create``  — upload a new document. Two-step under the hood:
+                        ``POST /uploads.json`` → token, then
+                        ``POST /projects/{id}/dmsf/commit_files.json``.
+                        Accepts file content as ``content_base64``.
+                        Capped at 50 MiB decoded.
+        * ``update``  — update document metadata. **Creates a new revision**
+                        (DMSF is versioned; in-place mutation is not
+                        supported). DMSF filenames are immutable — to
+                        replace content, ``create`` a new revision with
+                        the same filename.
+
+    Args:
+        action: One of ``list``, ``get``, ``create``, ``update``.
+        project_id: Required for ``list`` and ``create``. Project identifier
+            (numeric ID or short-name string).
+        folder_id: Optional DMSF folder ID for ``list`` and ``create``.
+        limit: Max results for ``list`` (1-100, default 100).
+        document_id: Required for ``get`` and ``update``.
+        filename: Required for ``create``. Becomes the immutable filename
+            for all future revisions.
+        content_base64: Required for ``create``. Raw file bytes as base64.
+        title: Optional human-readable title (``create``).
+        description: Optional description (``create``).
+        comment: Optional revision comment (``create``).
+        version: Optional version label (``create``).
+        custom_fields: Optional list of ``{"id": N, "value": ...}`` dicts.
+        fields: For ``update``: dict of metadata to update. Allowed keys:
+            ``title``, ``description``, ``comment``, ``custom_fields``.
+            Unknown keys are silently filtered.
+
+    Returns:
+        For ``list``: list of document metadata dicts.
+        For ``get`` / ``create``: a single document metadata dict.
+        For ``update``: success dict with ``updated_fields``.
+        On any failure: ``{"error": "..."}``.
+    """
+    if not _is_dmsf_enabled():
+        return dict(_DMSF_DISABLED_ERROR)
+    return await _manage_document_dispatch(
+        action,
+        project_id=project_id,
+        folder_id=folder_id,
+        limit=limit,
+        document_id=document_id,
+        filename=filename,
+        content_base64=content_base64,
+        title=title,
+        description=description,
+        comment=comment,
+        version=version,
+        custom_fields=custom_fields,
+        fields=fields,
+    )

--- a/src/redmine_mcp_server/tools/documents.py
+++ b/src/redmine_mcp_server/tools/documents.py
@@ -25,19 +25,30 @@ DMSF design notes:
   controller calls ``.scrub.strip`` on both unconditionally). When the
   caller omits either, ``_update_document_action`` pre-fetches the
   current document and uses the existing values.
+- The caller-facing ``filename`` parameter on ``create`` is sent to DMSF
+  as the ``name`` key inside ``attachments.uploaded_file``. The upload
+  helper reads ``committed_file[:name]`` (not ``[:filename]``) and
+  assigns it to both ``DmsfFile.name`` and ``DmsfFileRevision.name``.
 - ``name`` is the document filename, and DMSF supports renaming via
-  revisions: when a revision's ``name`` differs from the parent file,
-  the controller assigns it back onto the file. (Earlier docs claiming
-  "filenames are immutable" were wrong.)
+  revisions: when an update's ``name`` differs from the parent file's
+  current name, the controller assigns the new name back onto the
+  ``DmsfFile``. (Earlier docs claiming "filenames are immutable" were
+  wrong.)
 - The caller's ``custom_fields`` parameter maps to DMSF's
   ``custom_field_values`` key in both the commit and revision-create
   request bodies.
 - DMSF's commit response is intentionally sparse:
   ``{"dmsf_files": [{"id": N, "name": "..."}], "total_count": N}``.
   Follow up with ``action="get"`` for full metadata.
-- Document version bumping (``version_major`` / ``version_minor`` /
-  ``version_patch``) is not exposed by this tool; DMSF auto-increments
-  the patch version on each new revision.
+- A caller-supplied ``version`` string on ``create`` (e.g. ``"1.2.3"``)
+  is split into ``version_major`` / ``version_minor`` / ``version_patch``
+  and nested inside ``attachments.uploaded_file`` (where DMSF's commit
+  helper reads them). ``update`` does **not** expose version control —
+  DMSF auto-increments the patch version on each new revision. Note the
+  asymmetry: ``commit`` reads version fields nested inside the uploaded
+  file dict, whereas ``create_revision`` reads them from top-level
+  ``params``. The MCP tool covers the more common case
+  (version-at-upload-time).
 - DMSF replaces the built-in Documents module rather than complementing it.
   Existing native documents are not accessible via DMSF until migrated
   with ``rake redmine:dmsf_convert_documents`` on the server.
@@ -293,6 +304,30 @@ def _decode_content_base64(content_base64: str) -> Union[bytes, Dict[str, str]]:
     return content_bytes
 
 
+def _split_dmsf_version(version: str) -> Union[Dict[str, str], Dict[str, str]]:
+    """Split a caller-supplied version string into DMSF's three-part shape.
+
+    Accepts ``"X"``, ``"X.Y"``, or ``"X.Y.Z"`` and pads missing parts with
+    ``"0"``. Each part must be a non-negative integer; non-numeric input
+    is rejected with an error dict (the marker key is ``"error"``, so the
+    caller can distinguish success from failure).
+    """
+    parts = (str(version).split(".") + ["0", "0", "0"])[:3]
+    for part in parts:
+        if not part.isdigit():
+            return {
+                "error": (
+                    f"Invalid version '{version}'. Expected 'X', 'X.Y', "
+                    "or 'X.Y.Z' where each part is a non-negative integer."
+                )
+            }
+    return {
+        "version_major": parts[0],
+        "version_minor": parts[1],
+        "version_patch": parts[2],
+    }
+
+
 async def _create_document_action(
     project_id: Optional[Union[str, int]] = None,
     filename: Optional[str] = None,
@@ -301,6 +336,7 @@ async def _create_document_action(
     description: Optional[str] = None,
     comment: Optional[str] = None,
     folder_id: Optional[int] = None,
+    version: Optional[str] = None,
     custom_fields: Optional[List[Dict[str, Any]]] = None,
     **_: Any,
 ) -> Dict[str, Any]:
@@ -317,6 +353,14 @@ async def _create_document_action(
         return {"error": "content_base64 is required and must be a non-empty string."}
     if folder_id is not None and not _is_positive_int(folder_id):
         return {"error": "folder_id must be a positive integer."}
+
+    # Pre-validate version splitting before the network round-trip.
+    version_parts: Optional[Dict[str, str]] = None
+    if version is not None:
+        split = _split_dmsf_version(version)
+        if "error" in split:
+            return split
+        version_parts = split
 
     decoded = _decode_content_base64(content_base64)
     if isinstance(decoded, dict):
@@ -335,12 +379,22 @@ async def _create_document_action(
         # action `dmsf_upload#commit`). The controller reads
         # ``params[:attachments]``, picks the entries keyed ``uploaded_file``,
         # and uses ``params[:attachments][:folder_id]`` for folder targeting.
-        # ``custom_field_values`` is the key the upload helper reads (NOT
-        # ``custom_fields``).
+        #
+        # Body shape verified against ``dmsf_upload_helper.rb`` (which the
+        # commit action calls into):
+        #   - key for the filename is ``name`` (NOT ``filename``) — the helper
+        #     does ``committed_file[:name]`` and assigns it to both
+        #     ``DmsfFile.name`` and ``DmsfFileRevision.name``
+        #   - version is split into ``version_major`` / ``version_minor`` /
+        #     ``version_patch``, nested inside the uploaded_file dict (the
+        #     ``create_revision`` controller for updates reads these
+        #     top-level instead — different convention per endpoint)
+        #   - custom fields key is ``custom_field_values`` (NOT
+        #     ``custom_fields``)
         commit_url = f"{_client.REDMINE_URL}/projects/{project_id}/dmsf/commit.json"
         uploaded_file: Dict[str, Any] = {
             "token": token,
-            "filename": filename,
+            "name": filename,
         }
         if title is not None:
             uploaded_file["title"] = title
@@ -348,6 +402,8 @@ async def _create_document_action(
             uploaded_file["description"] = description
         if comment is not None:
             uploaded_file["comment"] = comment
+        if version_parts is not None:
+            uploaded_file.update(version_parts)
         if custom_fields is not None:
             uploaded_file["custom_field_values"] = custom_fields
 
@@ -497,6 +553,7 @@ async def manage_document(
     title: Optional[str] = None,
     description: Optional[str] = None,
     comment: Optional[str] = None,
+    version: Optional[str] = None,
     custom_fields: Optional[List[Dict[str, Any]]] = None,
     fields: Optional[Dict[str, Any]] = None,
 ) -> Union[List[Dict[str, Any]], Dict[str, Any]]:
@@ -530,11 +587,19 @@ async def manage_document(
         document_id: Required for ``get`` and ``update``.
         filename: Required for ``create``. Used as the initial filename;
             can be changed later by passing ``name`` in ``update``'s
-            ``fields`` dict.
+            ``fields`` dict. Sent to DMSF as the ``name`` key inside
+            ``attachments.uploaded_file`` (the upload helper reads
+            ``committed_file[:name]``, not ``[:filename]``).
         content_base64: Required for ``create``. Raw file bytes as base64.
         title: Optional human-readable title (``create``).
         description: Optional description (``create``).
         comment: Optional revision comment (``create``).
+        version: Optional semantic version label for the new revision on
+            ``create`` (e.g. ``"1.0"``, ``"1.2.3"``). Accepts ``"X"``,
+            ``"X.Y"``, or ``"X.Y.Z"`` and pads missing parts with ``"0"``.
+            DMSF stores major/minor/patch as separate integer columns;
+            the tool splits the string on ``.`` before sending. Each part
+            must be a non-negative integer.
         custom_fields: Optional list of ``{"id": N, "value": ...}`` dicts.
             Sent to DMSF as ``custom_field_values``.
         fields: For ``update``: dict of metadata to change. Allowed keys:
@@ -552,9 +617,12 @@ async def manage_document(
         On any failure: ``{"error": "..."}``.
 
     Limitations:
-        Document version bumping (major/minor/patch on a new revision) is
-        not exposed by this tool; DMSF auto-increments the patch version
-        on commit. Use the Redmine web UI for explicit version control.
+        Setting a custom revision version on ``update`` is not exposed by
+        this tool — DMSF auto-increments the patch version when a new
+        revision is created. ``create`` supports a ``version`` string
+        (e.g. ``"1.0"`` / ``"1.2.3"``), but ``update`` does not. Use the
+        Redmine web UI if you need explicit version control on existing
+        documents.
     """
     if not _is_dmsf_enabled():
         return dict(_DMSF_DISABLED_ERROR)
@@ -569,6 +637,7 @@ async def manage_document(
         title=title,
         description=description,
         comment=comment,
+        version=version,
         custom_fields=custom_fields,
         fields=fields,
     )

--- a/tests/test_dmsf_support.py
+++ b/tests/test_dmsf_support.py
@@ -467,7 +467,13 @@ class TestManageDocumentCreate:
         assert body["attachments"]["folder_id"] == 7
         uploaded = body["attachments"]["uploaded_file"]
         assert uploaded["token"] == "tok-abc"
-        assert uploaded["filename"] == "spec.pdf"
+        # DMSF's commit_files_internal helper reads ``committed_file[:name]``
+        # (and assigns it to BOTH DmsfFile.name and DmsfFileRevision.name).
+        # Earlier the body sent ``filename`` instead and DMSF crashed in
+        # its filename validator with ``nil#extname``. Regression: ensure
+        # we send the right key.
+        assert uploaded["name"] == "spec.pdf"
+        assert "filename" not in uploaded
         assert uploaded["title"] == "Spec"
         assert uploaded["description"] == "The spec"
         assert uploaded["comment"] == "Initial upload"
@@ -480,6 +486,78 @@ class TestManageDocumentCreate:
         # ... and a `note` pointing the caller at action="get" for full metadata
         assert "note" in result
         assert "action='get'" in result["note"]
+
+    @pytest.mark.asyncio
+    @patch("redmine_mcp_server._client.REDMINE_URL", "http://localhost:3000")
+    @patch("redmine_mcp_server._client.redmine")
+    async def test_create_splits_version_into_major_minor_patch(self, mock_redmine):
+        """DMSF stores major/minor/patch as separate integer columns and
+        reads them as separate keys on the uploaded_file dict (the helper
+        does ``committed_file[:version_major]`` etc.). The tool accepts a
+        caller-friendly ``"X.Y.Z"`` / ``"X.Y"`` / ``"X"`` string and splits
+        it before sending."""
+        mock_redmine.upload.return_value = {"token": "tok"}
+        mock_redmine.engine.request.return_value = {
+            "dmsf_files": [{"id": 1, "name": "f.pdf"}],
+            "total_count": 1,
+        }
+
+        with patch.dict(os.environ, {"REDMINE_DMSF_ENABLED": "true"}):
+            await manage_document(
+                action="create",
+                project_id="proj",
+                filename="f.pdf",
+                content_base64=_b64(b"x"),
+                version="1.2.3",
+            )
+
+        uploaded = json.loads(mock_redmine.engine.request.call_args.kwargs["data"])[
+            "attachments"
+        ]["uploaded_file"]
+        assert uploaded["version_major"] == "1"
+        assert uploaded["version_minor"] == "2"
+        assert uploaded["version_patch"] == "3"
+        # The single-string ``version`` key must NOT be sent — DMSF doesn't
+        # read it; only the three split keys.
+        assert "version" not in uploaded
+
+    @pytest.mark.asyncio
+    @patch("redmine_mcp_server._client.REDMINE_URL", "http://localhost:3000")
+    @patch("redmine_mcp_server._client.redmine")
+    async def test_create_pads_short_version(self, mock_redmine):
+        """``"1"`` and ``"1.2"`` pad missing parts with ``"0"``."""
+        mock_redmine.upload.return_value = {"token": "tok"}
+        mock_redmine.engine.request.return_value = {
+            "dmsf_files": [{"id": 1, "name": "f.pdf"}],
+            "total_count": 1,
+        }
+        with patch.dict(os.environ, {"REDMINE_DMSF_ENABLED": "true"}):
+            await manage_document(
+                action="create",
+                project_id="proj",
+                filename="f.pdf",
+                content_base64=_b64(b"x"),
+                version="2",
+            )
+        uploaded = json.loads(mock_redmine.engine.request.call_args.kwargs["data"])[
+            "attachments"
+        ]["uploaded_file"]
+        assert uploaded["version_major"] == "2"
+        assert uploaded["version_minor"] == "0"
+        assert uploaded["version_patch"] == "0"
+
+    @pytest.mark.asyncio
+    async def test_create_rejects_invalid_version(self):
+        with patch.dict(os.environ, {"REDMINE_DMSF_ENABLED": "true"}):
+            result = await manage_document(
+                action="create",
+                project_id="proj",
+                filename="f.pdf",
+                content_base64=_b64(b"x"),
+                version="1.x.0",
+            )
+        assert "error" in result
+        assert "Invalid version" in result["error"]
 
     @pytest.mark.asyncio
     @patch("redmine_mcp_server._client.REDMINE_URL", "http://localhost:3000")

--- a/tests/test_dmsf_support.py
+++ b/tests/test_dmsf_support.py
@@ -1,0 +1,427 @@
+"""Unit tests for the DMSF (redmine_dmsf plugin) `manage_document` tool."""
+
+import base64
+import json
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from redmine_mcp_server._env import _is_dmsf_enabled  # noqa: E402
+from redmine_mcp_server.tools.documents import manage_document  # noqa: E402
+
+
+def _make_doc(doc_id: int = 1, filename: str = "spec.pdf") -> dict:
+    return {
+        "id": doc_id,
+        "type": "file",
+        "filename": filename,
+        "title": f"Title {doc_id}",
+        "name": filename,
+        "description": "A document",
+        "version": "1.0",
+        "size": 1234,
+        "content_type": "application/pdf",
+        "folder_id": None,
+        "project_id": 5,
+        "author": {"id": 7, "name": "Alice"},
+        "created_on": "2026-05-01T10:00:00Z",
+        "updated_on": "2026-05-02T11:00:00Z",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Feature flag
+# ---------------------------------------------------------------------------
+
+
+class TestIsDmsfEnabled:
+    def test_false_by_default(self):
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("REDMINE_DMSF_ENABLED", None)
+            assert _is_dmsf_enabled() is False
+
+    def test_true_when_env_set(self):
+        with patch.dict(os.environ, {"REDMINE_DMSF_ENABLED": "true"}):
+            assert _is_dmsf_enabled() is True
+
+
+# ---------------------------------------------------------------------------
+# Dispatch + feature flag gating
+# ---------------------------------------------------------------------------
+
+
+class TestManageDocumentDispatch:
+    @pytest.mark.asyncio
+    async def test_disabled_returns_error(self):
+        with patch.dict(os.environ, {"REDMINE_DMSF_ENABLED": "false"}):
+            result = await manage_document(action="list", project_id="proj")
+        assert "error" in result
+        assert "REDMINE_DMSF_ENABLED" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_invalid_action(self):
+        with patch.dict(os.environ, {"REDMINE_DMSF_ENABLED": "true"}):
+            result = await manage_document(action="bogus", project_id="proj")
+        assert "error" in result
+        assert "Invalid action" in result["error"]
+
+
+# ---------------------------------------------------------------------------
+# list
+# ---------------------------------------------------------------------------
+
+
+class TestManageDocumentList:
+    @pytest.mark.asyncio
+    @patch("redmine_mcp_server._client.REDMINE_URL", "http://localhost:3000")
+    @patch("redmine_mcp_server._client.redmine")
+    async def test_list_success(self, mock_redmine):
+        mock_redmine.engine.request.return_value = {
+            "dmsf": [_make_doc(1), _make_doc(2, "design.pdf")]
+        }
+        with patch.dict(os.environ, {"REDMINE_DMSF_ENABLED": "true"}):
+            result = await manage_document(action="list", project_id="proj")
+
+        assert isinstance(result, list)
+        assert len(result) == 2
+        assert "spec.pdf" in result[0]["filename"]
+        # User-controlled field wrapped in insecure-content boundary tags
+        assert "<insecure-content-" in result[0]["filename"]
+
+    @pytest.mark.asyncio
+    @patch("redmine_mcp_server._client.REDMINE_URL", "http://localhost:3000")
+    @patch("redmine_mcp_server._client.redmine")
+    async def test_list_with_folder_filter(self, mock_redmine):
+        mock_redmine.engine.request.return_value = {"dmsf": []}
+        with patch.dict(os.environ, {"REDMINE_DMSF_ENABLED": "true"}):
+            await manage_document(
+                action="list", project_id="proj", folder_id=42, limit=25
+            )
+
+        call_kwargs = mock_redmine.engine.request.call_args.kwargs
+        assert call_kwargs["params"]["folder_id"] == 42
+        assert call_kwargs["params"]["limit"] == 25
+
+    @pytest.mark.asyncio
+    @patch("redmine_mcp_server._client.REDMINE_URL", "http://localhost:3000")
+    @patch("redmine_mcp_server._client.redmine")
+    async def test_list_handles_bare_array_response(self, mock_redmine):
+        """Some DMSF versions may return a bare list instead of {dmsf: [...]}.."""
+        mock_redmine.engine.request.return_value = [_make_doc(1)]
+        with patch.dict(os.environ, {"REDMINE_DMSF_ENABLED": "true"}):
+            result = await manage_document(action="list", project_id="proj")
+        assert isinstance(result, list)
+        assert len(result) == 1
+
+    @pytest.mark.asyncio
+    @patch("redmine_mcp_server._client.REDMINE_URL", "http://localhost:3000")
+    @patch("redmine_mcp_server._client.redmine")
+    async def test_clamps_limit_to_100(self, mock_redmine):
+        mock_redmine.engine.request.return_value = {"dmsf": []}
+        with patch.dict(os.environ, {"REDMINE_DMSF_ENABLED": "true"}):
+            await manage_document(action="list", project_id="proj", limit=500)
+        call_kwargs = mock_redmine.engine.request.call_args.kwargs
+        assert call_kwargs["params"]["limit"] == 100
+
+    @pytest.mark.asyncio
+    @patch("redmine_mcp_server._client.REDMINE_URL", "http://localhost:3000")
+    @patch("redmine_mcp_server._client.redmine")
+    async def test_slices_oversized_response(self, mock_redmine):
+        many = [_make_doc(i) for i in range(200)]
+        mock_redmine.engine.request.return_value = {"dmsf": many}
+        with patch.dict(os.environ, {"REDMINE_DMSF_ENABLED": "true"}):
+            result = await manage_document(action="list", project_id="proj", limit=50)
+        assert len(result) == 50
+
+    @pytest.mark.asyncio
+    async def test_rejects_missing_project_id(self):
+        with patch.dict(os.environ, {"REDMINE_DMSF_ENABLED": "true"}):
+            result = await manage_document(action="list")
+        assert "error" in result
+        assert "project_id" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_rejects_empty_project_id(self):
+        with patch.dict(os.environ, {"REDMINE_DMSF_ENABLED": "true"}):
+            result = await manage_document(action="list", project_id="")
+        assert "error" in result
+        assert "project_id" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_rejects_invalid_folder_id(self):
+        with patch.dict(os.environ, {"REDMINE_DMSF_ENABLED": "true"}):
+            result = await manage_document(
+                action="list", project_id="proj", folder_id=-1
+            )
+        assert "error" in result
+        assert "folder_id" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_rejects_invalid_limit(self):
+        with patch.dict(os.environ, {"REDMINE_DMSF_ENABLED": "true"}):
+            result = await manage_document(action="list", project_id="proj", limit=0)
+        assert "error" in result
+        assert "limit" in result["error"]
+
+    @pytest.mark.asyncio
+    @patch("redmine_mcp_server._client.REDMINE_URL", "http://localhost:3000")
+    @patch("redmine_mcp_server._client.redmine")
+    async def test_handles_api_error(self, mock_redmine):
+        mock_redmine.engine.request.side_effect = Exception("boom")
+        with patch.dict(os.environ, {"REDMINE_DMSF_ENABLED": "true"}):
+            result = await manage_document(action="list", project_id="proj")
+        assert "error" in result
+
+
+# ---------------------------------------------------------------------------
+# get
+# ---------------------------------------------------------------------------
+
+
+class TestManageDocumentGet:
+    @pytest.mark.asyncio
+    @patch("redmine_mcp_server._client.REDMINE_URL", "http://localhost:3000")
+    @patch("redmine_mcp_server._client.redmine")
+    async def test_get_success(self, mock_redmine):
+        mock_redmine.engine.request.return_value = {"dmsf_file": _make_doc(42)}
+        with patch.dict(os.environ, {"REDMINE_DMSF_ENABLED": "true"}):
+            result = await manage_document(action="get", document_id=42)
+        assert result["id"] == 42
+        assert "spec.pdf" in result["filename"]
+        mock_redmine.engine.request.assert_called_once_with(
+            "get", "http://localhost:3000/dmsf_files/42.json"
+        )
+
+    @pytest.mark.asyncio
+    @patch("redmine_mcp_server._client.REDMINE_URL", "http://localhost:3000")
+    @patch("redmine_mcp_server._client.redmine")
+    async def test_get_not_found(self, mock_redmine):
+        mock_redmine.engine.request.return_value = {}
+        with patch.dict(os.environ, {"REDMINE_DMSF_ENABLED": "true"}):
+            result = await manage_document(action="get", document_id=999)
+        assert "error" in result
+        assert "not found" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_rejects_invalid_document_id(self):
+        with patch.dict(os.environ, {"REDMINE_DMSF_ENABLED": "true"}):
+            result = await manage_document(action="get", document_id=-1)
+        assert "error" in result
+        assert "document_id" in result["error"]
+
+
+# ---------------------------------------------------------------------------
+# create
+# ---------------------------------------------------------------------------
+
+
+def _b64(content: bytes) -> str:
+    return base64.b64encode(content).decode("ascii")
+
+
+class TestManageDocumentCreate:
+    @pytest.mark.asyncio
+    @patch("redmine_mcp_server._client.REDMINE_URL", "http://localhost:3000")
+    @patch("redmine_mcp_server._client.redmine")
+    async def test_create_success(self, mock_redmine):
+        # Step 1 (client.upload) returns {"token": ...}; Step 2 returns dmsf_file
+        mock_redmine.upload.return_value = {"token": "tok-abc"}
+        mock_redmine.engine.request.return_value = {"dmsf_file": _make_doc(99)}
+
+        with patch.dict(os.environ, {"REDMINE_DMSF_ENABLED": "true"}):
+            result = await manage_document(
+                action="create",
+                project_id="proj",
+                filename="spec.pdf",
+                content_base64=_b64(b"%PDF-fake-content"),
+                title="Spec",
+                description="The spec",
+            )
+
+        assert result["id"] == 99
+        # Step 1: upload called
+        assert mock_redmine.upload.called
+        # Step 2: POST to dmsf/commit_files.json with token + filename
+        call_args = mock_redmine.engine.request.call_args
+        assert call_args.args[0] == "post"
+        assert call_args.args[1].endswith("/projects/proj/dmsf/commit_files.json")
+        body = json.loads(call_args.kwargs["data"])
+        assert body["dmsf_file"]["token"] == "tok-abc"
+        assert body["dmsf_file"]["filename"] == "spec.pdf"
+        assert body["dmsf_file"]["title"] == "Spec"
+        assert body["dmsf_file"]["description"] == "The spec"
+
+    @pytest.mark.asyncio
+    async def test_blocked_in_read_only_mode(self):
+        with patch.dict(
+            os.environ,
+            {"REDMINE_MCP_READ_ONLY": "true", "REDMINE_DMSF_ENABLED": "true"},
+        ):
+            result = await manage_document(
+                action="create",
+                project_id="proj",
+                filename="f.txt",
+                content_base64=_b64(b"x"),
+            )
+        assert "error" in result
+        assert "read-only" in result["error"].lower()
+
+    @pytest.mark.asyncio
+    async def test_rejects_missing_filename(self):
+        with patch.dict(os.environ, {"REDMINE_DMSF_ENABLED": "true"}):
+            result = await manage_document(
+                action="create",
+                project_id="proj",
+                content_base64=_b64(b"x"),
+            )
+        assert "error" in result
+        assert "filename" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_rejects_missing_content(self):
+        with patch.dict(os.environ, {"REDMINE_DMSF_ENABLED": "true"}):
+            result = await manage_document(
+                action="create",
+                project_id="proj",
+                filename="f.txt",
+            )
+        assert "error" in result
+        assert "content_base64" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_rejects_invalid_base64(self):
+        with patch.dict(os.environ, {"REDMINE_DMSF_ENABLED": "true"}):
+            result = await manage_document(
+                action="create",
+                project_id="proj",
+                filename="f.txt",
+                content_base64="!!! not base64 !!!",
+            )
+        assert "error" in result
+        assert "base64" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_rejects_empty_decoded_content(self):
+        with patch.dict(os.environ, {"REDMINE_DMSF_ENABLED": "true"}):
+            result = await manage_document(
+                action="create",
+                project_id="proj",
+                filename="f.txt",
+                content_base64=_b64(b""),
+            )
+        assert "error" in result
+        assert "empty" in result["error"].lower()
+
+    @pytest.mark.asyncio
+    async def test_rejects_oversized_content(self):
+        big = b"x" * (50 * 1024 * 1024 + 1)
+        with patch.dict(os.environ, {"REDMINE_DMSF_ENABLED": "true"}):
+            result = await manage_document(
+                action="create",
+                project_id="proj",
+                filename="f.bin",
+                content_base64=_b64(big),
+            )
+        assert "error" in result
+        assert "too large" in result["error"].lower()
+
+    @pytest.mark.asyncio
+    async def test_rejects_missing_project_id(self):
+        with patch.dict(os.environ, {"REDMINE_DMSF_ENABLED": "true"}):
+            result = await manage_document(
+                action="create",
+                filename="f.txt",
+                content_base64=_b64(b"x"),
+            )
+        assert "error" in result
+        assert "project_id" in result["error"]
+
+
+# ---------------------------------------------------------------------------
+# update
+# ---------------------------------------------------------------------------
+
+
+class TestManageDocumentUpdate:
+    @pytest.mark.asyncio
+    @patch("redmine_mcp_server._client.REDMINE_URL", "http://localhost:3000")
+    @patch("redmine_mcp_server._client.redmine")
+    async def test_update_success(self, mock_redmine):
+        mock_redmine.engine.request.return_value = True
+        with patch.dict(os.environ, {"REDMINE_DMSF_ENABLED": "true"}):
+            result = await manage_document(
+                action="update",
+                document_id=42,
+                fields={"title": "New", "description": "Updated"},
+            )
+        assert result["success"] is True
+        assert set(result["updated_fields"]) == {"title", "description"}
+        call_args = mock_redmine.engine.request.call_args
+        assert call_args.args[0] == "post"
+        assert call_args.args[1].endswith("/dmsf_files/42/revision/create.json")
+
+    @pytest.mark.asyncio
+    @patch("redmine_mcp_server._client.REDMINE_URL", "http://localhost:3000")
+    @patch("redmine_mcp_server._client.redmine")
+    async def test_filters_unknown_fields(self, mock_redmine):
+        mock_redmine.engine.request.return_value = True
+        with patch.dict(os.environ, {"REDMINE_DMSF_ENABLED": "true"}):
+            result = await manage_document(
+                action="update",
+                document_id=42,
+                fields={"title": "New", "evil": "bad", "filename": "x"},
+            )
+        # filename should be filtered (immutable in DMSF)
+        assert result["updated_fields"] == ["title"]
+        body = json.loads(mock_redmine.engine.request.call_args.kwargs["data"])
+        assert "evil" not in body["dmsf_file_revision"]
+        assert "filename" not in body["dmsf_file_revision"]
+
+    @pytest.mark.asyncio
+    async def test_blocked_in_read_only_mode(self):
+        with patch.dict(
+            os.environ,
+            {"REDMINE_MCP_READ_ONLY": "true", "REDMINE_DMSF_ENABLED": "true"},
+        ):
+            result = await manage_document(
+                action="update", document_id=1, fields={"title": "X"}
+            )
+        assert "error" in result
+        assert "read-only" in result["error"].lower()
+
+    @pytest.mark.asyncio
+    async def test_rejects_invalid_document_id(self):
+        with patch.dict(os.environ, {"REDMINE_DMSF_ENABLED": "true"}):
+            result = await manage_document(
+                action="update", document_id=-1, fields={"title": "X"}
+            )
+        assert "error" in result
+        assert "document_id" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_rejects_empty_fields(self):
+        with patch.dict(os.environ, {"REDMINE_DMSF_ENABLED": "true"}):
+            result = await manage_document(action="update", document_id=1, fields={})
+        assert "error" in result
+
+    @pytest.mark.asyncio
+    async def test_rejects_no_writable_fields(self):
+        with patch.dict(os.environ, {"REDMINE_DMSF_ENABLED": "true"}):
+            result = await manage_document(
+                action="update",
+                document_id=1,
+                fields={"filename": "X", "rogue": "y"},
+            )
+        assert "error" in result
+        assert "writable" in result["error"].lower()
+
+
+# ---------------------------------------------------------------------------
+# Suppress unused-mock warning when MagicMock isn't actually referenced below
+# ---------------------------------------------------------------------------
+
+_ = MagicMock

--- a/tests/test_dmsf_support.py
+++ b/tests/test_dmsf_support.py
@@ -75,14 +75,32 @@ class TestManageDocumentDispatch:
 # ---------------------------------------------------------------------------
 
 
+def _dmsf_list_response(*docs: dict, total_count: int = None) -> dict:
+    """Build a response in the **real** DMSF list shape, as verified
+    against a live `redmine_dmsf` instance:
+
+        {"dmsf": {"dmsf_nodes": [...], "total_count": N}}
+
+    The previous test fixtures used ``{"dmsf": [...]}`` and missed a
+    real-world bug where the inner ``dmsf`` value is a *dict*, not a
+    list, and our parser silently emptied the result.
+    """
+    return {
+        "dmsf": {
+            "dmsf_nodes": list(docs),
+            "total_count": total_count if total_count is not None else len(docs),
+        }
+    }
+
+
 class TestManageDocumentList:
     @pytest.mark.asyncio
     @patch("redmine_mcp_server._client.REDMINE_URL", "http://localhost:3000")
     @patch("redmine_mcp_server._client.redmine")
     async def test_list_success(self, mock_redmine):
-        mock_redmine.engine.request.return_value = {
-            "dmsf": [_make_doc(1), _make_doc(2, "design.pdf")]
-        }
+        mock_redmine.engine.request.return_value = _dmsf_list_response(
+            _make_doc(1), _make_doc(2, "design.pdf")
+        )
         with patch.dict(os.environ, {"REDMINE_DMSF_ENABLED": "true"}):
             result = await manage_document(action="list", project_id="proj")
 
@@ -95,8 +113,32 @@ class TestManageDocumentList:
     @pytest.mark.asyncio
     @patch("redmine_mcp_server._client.REDMINE_URL", "http://localhost:3000")
     @patch("redmine_mcp_server._client.redmine")
+    async def test_list_regression_real_dmsf_shape(self, mock_redmine):
+        """Regression test for the bug where ``payload["dmsf"]`` is a dict
+        (the real DMSF shape) but the parser assumed a list and emptied
+        the result. Verifies that both documents survive parsing."""
+        mock_redmine.engine.request.return_value = {
+            "dmsf": {
+                "dmsf_nodes": [_make_doc(1, "spec.pdf"), _make_doc(2, "design.pdf")],
+                "total_count": 2,
+            }
+        }
+        with patch.dict(os.environ, {"REDMINE_DMSF_ENABLED": "true"}):
+            result = await manage_document(action="list", project_id="web")
+
+        assert isinstance(result, list)
+        assert len(result) == 2, (
+            "Both documents must be returned. If only 0 are returned, the "
+            "parser is silently dropping the real DMSF response shape."
+        )
+        assert "spec.pdf" in result[0]["filename"]
+        assert "design.pdf" in result[1]["filename"]
+
+    @pytest.mark.asyncio
+    @patch("redmine_mcp_server._client.REDMINE_URL", "http://localhost:3000")
+    @patch("redmine_mcp_server._client.redmine")
     async def test_list_with_folder_filter(self, mock_redmine):
-        mock_redmine.engine.request.return_value = {"dmsf": []}
+        mock_redmine.engine.request.return_value = _dmsf_list_response()
         with patch.dict(os.environ, {"REDMINE_DMSF_ENABLED": "true"}):
             await manage_document(
                 action="list", project_id="proj", folder_id=42, limit=25
@@ -110,7 +152,7 @@ class TestManageDocumentList:
     @patch("redmine_mcp_server._client.REDMINE_URL", "http://localhost:3000")
     @patch("redmine_mcp_server._client.redmine")
     async def test_list_handles_bare_array_response(self, mock_redmine):
-        """Some DMSF versions may return a bare list instead of {dmsf: [...]}.."""
+        """Some DMSF versions may return a bare list at the top level."""
         mock_redmine.engine.request.return_value = [_make_doc(1)]
         with patch.dict(os.environ, {"REDMINE_DMSF_ENABLED": "true"}):
             result = await manage_document(action="list", project_id="proj")
@@ -120,8 +162,20 @@ class TestManageDocumentList:
     @pytest.mark.asyncio
     @patch("redmine_mcp_server._client.REDMINE_URL", "http://localhost:3000")
     @patch("redmine_mcp_server._client.redmine")
+    async def test_list_handles_dmsf_value_as_list(self, mock_redmine):
+        """Defensive: older plugin builds may put a bare list directly
+        under the ``dmsf`` key. Tolerate both shapes."""
+        mock_redmine.engine.request.return_value = {"dmsf": [_make_doc(1)]}
+        with patch.dict(os.environ, {"REDMINE_DMSF_ENABLED": "true"}):
+            result = await manage_document(action="list", project_id="proj")
+        assert isinstance(result, list)
+        assert len(result) == 1
+
+    @pytest.mark.asyncio
+    @patch("redmine_mcp_server._client.REDMINE_URL", "http://localhost:3000")
+    @patch("redmine_mcp_server._client.redmine")
     async def test_clamps_limit_to_100(self, mock_redmine):
-        mock_redmine.engine.request.return_value = {"dmsf": []}
+        mock_redmine.engine.request.return_value = _dmsf_list_response()
         with patch.dict(os.environ, {"REDMINE_DMSF_ENABLED": "true"}):
             await manage_document(action="list", project_id="proj", limit=500)
         call_kwargs = mock_redmine.engine.request.call_args.kwargs
@@ -132,7 +186,7 @@ class TestManageDocumentList:
     @patch("redmine_mcp_server._client.redmine")
     async def test_slices_oversized_response(self, mock_redmine):
         many = [_make_doc(i) for i in range(200)]
-        mock_redmine.engine.request.return_value = {"dmsf": many}
+        mock_redmine.engine.request.return_value = _dmsf_list_response(*many)
         with patch.dict(os.environ, {"REDMINE_DMSF_ENABLED": "true"}):
             result = await manage_document(action="list", project_id="proj", limit=50)
         assert len(result) == 50
@@ -205,6 +259,28 @@ class TestManageDocumentGet:
             result = await manage_document(action="get", document_id=999)
         assert "error" in result
         assert "not found" in result["error"]
+
+    @pytest.mark.asyncio
+    @patch("redmine_mcp_server._client.REDMINE_URL", "http://localhost:3000")
+    @patch("redmine_mcp_server._client.redmine")
+    async def test_get_handles_nested_dmsf_wrapper(self, mock_redmine):
+        """Defensive: tolerate ``{"dmsf": {"dmsf_file": {...}}}`` in case a
+        plugin version applies the same outer wrapping to single-resource
+        responses that it does to list responses."""
+        mock_redmine.engine.request.return_value = {"dmsf": {"dmsf_file": _make_doc(7)}}
+        with patch.dict(os.environ, {"REDMINE_DMSF_ENABLED": "true"}):
+            result = await manage_document(action="get", document_id=7)
+        assert result["id"] == 7
+
+    @pytest.mark.asyncio
+    @patch("redmine_mcp_server._client.REDMINE_URL", "http://localhost:3000")
+    @patch("redmine_mcp_server._client.redmine")
+    async def test_get_handles_document_key_variant(self, mock_redmine):
+        """Defensive: tolerate ``{"document": {...}}`` from older builds."""
+        mock_redmine.engine.request.return_value = {"document": _make_doc(8)}
+        with patch.dict(os.environ, {"REDMINE_DMSF_ENABLED": "true"}):
+            result = await manage_document(action="get", document_id=8)
+        assert result["id"] == 8
 
     @pytest.mark.asyncio
     async def test_rejects_invalid_document_id(self):

--- a/tests/test_dmsf_support.py
+++ b/tests/test_dmsf_support.py
@@ -419,10 +419,25 @@ class TestManageDocumentCreate:
     @pytest.mark.asyncio
     @patch("redmine_mcp_server._client.REDMINE_URL", "http://localhost:3000")
     @patch("redmine_mcp_server._client.redmine")
-    async def test_create_success(self, mock_redmine):
-        # Step 1 (client.upload) returns {"token": ...}; Step 2 returns dmsf_file
+    async def test_create_real_dmsf_shape(self, mock_redmine):
+        """Regression: verify the request and response shapes match the
+        actual ``redmine_dmsf`` plugin.
+
+        - URL is ``POST /projects/{id}/dmsf/commit.json`` (NOT
+          ``commit_files.json`` — that route doesn't exist).
+        - Body is wrapped as ``{"attachments": {"uploaded_file": {...},
+          "folder_id": N}}``; the controller selects entries keyed
+          ``uploaded_file`` and reads ``folder_id`` at the attachments
+          level.
+        - Response is sparse: ``{"dmsf_files": [{"id": N, "name": "..."}],
+          "total_count": N}`` — no description / size / mime / timestamps.
+        """
         mock_redmine.upload.return_value = {"token": "tok-abc"}
-        mock_redmine.engine.request.return_value = {"dmsf_file": _make_doc(99)}
+        # Real DMSF commit response shape (verified against live instance)
+        mock_redmine.engine.request.return_value = {
+            "dmsf_files": [{"id": 99, "name": "spec.pdf"}],
+            "total_count": 1,
+        }
 
         with patch.dict(os.environ, {"REDMINE_DMSF_ENABLED": "true"}):
             result = await manage_document(
@@ -432,20 +447,82 @@ class TestManageDocumentCreate:
                 content_base64=_b64(b"%PDF-fake-content"),
                 title="Spec",
                 description="The spec",
+                comment="Initial upload",
+                folder_id=7,
             )
 
-        assert result["id"] == 99
-        # Step 1: upload called
+        # Step 1: upload binary
         assert mock_redmine.upload.called
-        # Step 2: POST to dmsf/commit_files.json with token + filename
+
+        # Step 2: POST to /projects/{id}/dmsf/commit.json
         call_args = mock_redmine.engine.request.call_args
         assert call_args.args[0] == "post"
-        assert call_args.args[1].endswith("/projects/proj/dmsf/commit_files.json")
+        assert (
+            call_args.args[1] == "http://localhost:3000/projects/proj/dmsf/commit.json"
+        )
+
+        # Body has the attachments → uploaded_file shape
         body = json.loads(call_args.kwargs["data"])
-        assert body["dmsf_file"]["token"] == "tok-abc"
-        assert body["dmsf_file"]["filename"] == "spec.pdf"
-        assert body["dmsf_file"]["title"] == "Spec"
-        assert body["dmsf_file"]["description"] == "The spec"
+        assert "attachments" in body
+        assert body["attachments"]["folder_id"] == 7
+        uploaded = body["attachments"]["uploaded_file"]
+        assert uploaded["token"] == "tok-abc"
+        assert uploaded["filename"] == "spec.pdf"
+        assert uploaded["title"] == "Spec"
+        assert uploaded["description"] == "The spec"
+        assert uploaded["comment"] == "Initial upload"
+        # No "dmsf_file" wrapper (that was the old wrong shape)
+        assert "dmsf_file" not in body
+
+        # Response surfaces id + name from dmsf_files[0]
+        assert result["id"] == 99
+        assert "spec.pdf" in result["filename"]  # filename falls back from `name`
+        # ... and a `note` pointing the caller at action="get" for full metadata
+        assert "note" in result
+        assert "action='get'" in result["note"]
+
+    @pytest.mark.asyncio
+    @patch("redmine_mcp_server._client.REDMINE_URL", "http://localhost:3000")
+    @patch("redmine_mcp_server._client.redmine")
+    async def test_create_maps_custom_fields_to_custom_field_values(self, mock_redmine):
+        """Caller passes ``custom_fields``; DMSF reads ``custom_field_values``."""
+        mock_redmine.upload.return_value = {"token": "tok-xyz"}
+        mock_redmine.engine.request.return_value = {
+            "dmsf_files": [{"id": 1, "name": "f.pdf"}],
+            "total_count": 1,
+        }
+        with patch.dict(os.environ, {"REDMINE_DMSF_ENABLED": "true"}):
+            await manage_document(
+                action="create",
+                project_id="proj",
+                filename="f.pdf",
+                content_base64=_b64(b"x"),
+                custom_fields=[{"id": 5, "value": "hello"}],
+            )
+        body = json.loads(mock_redmine.engine.request.call_args.kwargs["data"])
+        uploaded = body["attachments"]["uploaded_file"]
+        # Key must be the DMSF-expected name
+        assert "custom_field_values" in uploaded
+        assert uploaded["custom_field_values"] == [{"id": 5, "value": "hello"}]
+        assert "custom_fields" not in uploaded
+
+    @pytest.mark.asyncio
+    @patch("redmine_mcp_server._client.REDMINE_URL", "http://localhost:3000")
+    @patch("redmine_mcp_server._client.redmine")
+    async def test_create_empty_response(self, mock_redmine):
+        """If the commit response is unexpectedly empty (no ``dmsf_files``
+        key, or empty list), return ``{"success": True}`` so the caller
+        knows the upload didn't outright fail."""
+        mock_redmine.upload.return_value = {"token": "tok"}
+        mock_redmine.engine.request.return_value = {"dmsf_files": []}
+        with patch.dict(os.environ, {"REDMINE_DMSF_ENABLED": "true"}):
+            result = await manage_document(
+                action="create",
+                project_id="proj",
+                filename="f.txt",
+                content_base64=_b64(b"x"),
+            )
+        assert result == {"success": True}
 
     @pytest.mark.asyncio
     async def test_blocked_in_read_only_mode(self):
@@ -538,40 +615,169 @@ class TestManageDocumentCreate:
 # ---------------------------------------------------------------------------
 
 
+def _real_dmsf_get_response(
+    doc_id: int = 42, title: str = "first-file", name: str = "spec.pdf"
+) -> dict:
+    """Build a response in the real DMSF GET /dmsf_files/{id}.json shape."""
+    return {
+        "dmsf_file": {
+            "id": doc_id,
+            "title": title,
+            "name": name,
+            "project_id": 1,
+            "dmsf_file_revisions": [
+                {
+                    "id": 1,
+                    "version": "0.1",
+                    "size": 100,
+                    "description": "initial",
+                    "mime_type": "application/pdf",
+                    "user_id": 1,
+                    "created_at": "2026-05-12T10:00:00Z",
+                    "updated_at": "2026-05-12T10:00:00Z",
+                }
+            ],
+        }
+    }
+
+
 class TestManageDocumentUpdate:
     @pytest.mark.asyncio
     @patch("redmine_mcp_server._client.REDMINE_URL", "http://localhost:3000")
     @patch("redmine_mcp_server._client.redmine")
-    async def test_update_success(self, mock_redmine):
-        mock_redmine.engine.request.return_value = True
+    async def test_update_uses_canonical_url_and_real_body(self, mock_redmine):
+        """Regression: verify the request hits the canonical revision-create
+        URL (``/dmsf/files/{id}/revision/create.json`` with a slash, not
+        ``/dmsf_files/...`` which doesn't exist for this POST) and that
+        the body wraps fields under ``dmsf_file_revision``.
+
+        Also verifies the auto-fetch behavior: when the caller updates
+        only ``description``, the tool pre-fetches the current document
+        to populate the required ``title`` and ``name`` fields (DMSF's
+        controller crashes on nil for either)."""
+        # First request: GET /dmsf_files/42.json (auto-fetch current state).
+        # Second request: POST /dmsf/files/42/revision/create.json.
+        mock_redmine.engine.request.side_effect = [
+            _real_dmsf_get_response(42, title="first-file", name="spec.pdf"),
+            True,
+        ]
         with patch.dict(os.environ, {"REDMINE_DMSF_ENABLED": "true"}):
             result = await manage_document(
                 action="update",
                 document_id=42,
-                fields={"title": "New", "description": "Updated"},
+                fields={"description": "Updated description"},
             )
+
         assert result["success"] is True
-        assert set(result["updated_fields"]) == {"title", "description"}
-        call_args = mock_redmine.engine.request.call_args
-        assert call_args.args[0] == "post"
-        assert call_args.args[1].endswith("/dmsf_files/42/revision/create.json")
+        assert result["updated_fields"] == ["description"]
+
+        # Two HTTP calls: pre-fetch GET and revision-create POST
+        assert mock_redmine.engine.request.call_count == 2
+        get_call, post_call = mock_redmine.engine.request.call_args_list
+
+        # Pre-fetch GET uses the underscore (legacy) show route
+        assert get_call.args[0] == "get"
+        assert get_call.args[1].endswith("/dmsf_files/42.json")
+
+        # POST uses the canonical /dmsf/files/.../revision/create route
+        assert post_call.args[0] == "post"
+        assert post_call.args[1] == (
+            "http://localhost:3000/dmsf/files/42/revision/create.json"
+        )
+
+        body = json.loads(post_call.kwargs["data"])
+        rev = body["dmsf_file_revision"]
+        # Required fields auto-populated from the current document
+        assert rev["title"] == "first-file"
+        assert rev["name"] == "spec.pdf"
+        # Caller's update
+        assert rev["description"] == "Updated description"
+        # No legacy "dmsf_files" URL or wrong key
+        assert "comment" not in rev
 
     @pytest.mark.asyncio
     @patch("redmine_mcp_server._client.REDMINE_URL", "http://localhost:3000")
     @patch("redmine_mcp_server._client.redmine")
-    async def test_filters_unknown_fields(self, mock_redmine):
-        mock_redmine.engine.request.return_value = True
+    async def test_update_caller_can_override_title_and_name(self, mock_redmine):
+        """If the caller supplies ``title`` or ``name`` in ``fields``, that
+        value takes precedence over the current document's values."""
+        mock_redmine.engine.request.side_effect = [
+            _real_dmsf_get_response(1, title="old-title", name="old.pdf"),
+            True,
+        ]
+        with patch.dict(os.environ, {"REDMINE_DMSF_ENABLED": "true"}):
+            result = await manage_document(
+                action="update",
+                document_id=1,
+                fields={"title": "new-title", "name": "new.pdf"},
+            )
+        assert set(result["updated_fields"]) == {"title", "name"}
+        body = json.loads(mock_redmine.engine.request.call_args_list[1].kwargs["data"])
+        assert body["dmsf_file_revision"]["title"] == "new-title"
+        assert body["dmsf_file_revision"]["name"] == "new.pdf"
+
+    @pytest.mark.asyncio
+    @patch("redmine_mcp_server._client.REDMINE_URL", "http://localhost:3000")
+    @patch("redmine_mcp_server._client.redmine")
+    async def test_update_maps_custom_fields_to_custom_field_values(self, mock_redmine):
+        """Caller passes ``custom_fields``; DMSF reads ``custom_field_values``."""
+        mock_redmine.engine.request.side_effect = [
+            _real_dmsf_get_response(),
+            True,
+        ]
+        with patch.dict(os.environ, {"REDMINE_DMSF_ENABLED": "true"}):
+            await manage_document(
+                action="update",
+                document_id=42,
+                fields={"custom_fields": [{"id": 5, "value": "foo"}]},
+            )
+        body = json.loads(mock_redmine.engine.request.call_args_list[1].kwargs["data"])
+        rev = body["dmsf_file_revision"]
+        # Key must be the DMSF-expected name
+        assert rev["custom_field_values"] == [{"id": 5, "value": "foo"}]
+        assert "custom_fields" not in rev
+
+    @pytest.mark.asyncio
+    @patch("redmine_mcp_server._client.REDMINE_URL", "http://localhost:3000")
+    @patch("redmine_mcp_server._client.redmine")
+    async def test_update_filters_unknown_and_immutable_keys(self, mock_redmine):
+        """Unknown keys and DMSF-immutable keys (``filename``, ``id``, etc.)
+        are silently filtered. ``name`` is the canonical mutable-filename
+        key and is accepted; ``filename`` (the list-shape synonym) is NOT
+        accepted for updates."""
+        mock_redmine.engine.request.side_effect = [
+            _real_dmsf_get_response(),
+            True,
+        ]
         with patch.dict(os.environ, {"REDMINE_DMSF_ENABLED": "true"}):
             result = await manage_document(
                 action="update",
                 document_id=42,
                 fields={"title": "New", "evil": "bad", "filename": "x"},
             )
-        # filename should be filtered (immutable in DMSF)
+        # Only "title" is writable; "evil" and "filename" are filtered out
         assert result["updated_fields"] == ["title"]
-        body = json.loads(mock_redmine.engine.request.call_args.kwargs["data"])
-        assert "evil" not in body["dmsf_file_revision"]
-        assert "filename" not in body["dmsf_file_revision"]
+        body = json.loads(mock_redmine.engine.request.call_args_list[1].kwargs["data"])
+        rev = body["dmsf_file_revision"]
+        assert "evil" not in rev
+        assert "filename" not in rev
+
+    @pytest.mark.asyncio
+    @patch("redmine_mcp_server._client.REDMINE_URL", "http://localhost:3000")
+    @patch("redmine_mcp_server._client.redmine")
+    async def test_update_returns_error_when_document_not_found(self, mock_redmine):
+        """If the pre-fetch finds no document, return a clean not-found
+        error instead of trying to POST the revision (which would fail
+        with the same 404 anyway, but less clearly)."""
+        mock_redmine.engine.request.return_value = {}  # empty payload from GET
+        with patch.dict(os.environ, {"REDMINE_DMSF_ENABLED": "true"}):
+            result = await manage_document(
+                action="update", document_id=999, fields={"title": "X"}
+            )
+        assert "error" in result
+        assert "not found" in result["error"]
+        # We should NOT have attempted the POST after a failed pre-fetch
+        assert mock_redmine.engine.request.call_count == 1
 
     @pytest.mark.asyncio
     async def test_blocked_in_read_only_mode(self):

--- a/tests/test_dmsf_support.py
+++ b/tests/test_dmsf_support.py
@@ -283,6 +283,122 @@ class TestManageDocumentGet:
         assert result["id"] == 8
 
     @pytest.mark.asyncio
+    @patch("redmine_mcp_server._client.REDMINE_URL", "http://localhost:3000")
+    @patch("redmine_mcp_server._client.redmine")
+    async def test_get_real_dmsf_shape_merges_revision(self, mock_redmine):
+        """Regression: DMSF's GET /dmsf_files/{id}.json wraps the document
+        in ``{"dmsf_file": {...}}`` and nests almost all metadata
+        (``description``, ``size``, ``mime_type``, ``user_id``,
+        ``created_at``, ``updated_at``) under the latest entry of
+        ``dmsf_file_revisions``. The filename is exposed as ``name``,
+        not ``filename``.
+
+        Earlier serializer read everything as flat top-level keys and
+        silently dropped description, version, size, content_type,
+        author, and timestamps. This test asserts that all of those
+        fields surface correctly when given the real shape."""
+        real_dmsf_response = {
+            "dmsf_file": {
+                "id": 1,
+                "title": "first-file",
+                "name": "ai-366-plan.md",
+                "project_id": 1,
+                "dmsf_file_revisions": [
+                    {
+                        "id": 1,
+                        "version": "0.1",
+                        "size": 13005,
+                        "description": "File number one!",
+                        "mime_type": "text/markdown",
+                        "user_id": 1,
+                        "created_at": "2026-05-12T10:00:00Z",
+                        "updated_at": "2026-05-12T10:05:00Z",
+                    }
+                ],
+            }
+        }
+        mock_redmine.engine.request.return_value = real_dmsf_response
+        with patch.dict(os.environ, {"REDMINE_DMSF_ENABLED": "true"}):
+            result = await manage_document(action="get", document_id=1)
+
+        assert result["id"] == 1
+        assert "first-file" in result["title"]
+        # Filename surfaces from `name` (DMSF get shape, not `filename`)
+        assert "ai-366-plan.md" in result["filename"]
+        assert "ai-366-plan.md" in result["name"]
+        # Metadata pulled from latest revision
+        assert "File number one!" in result["description"]
+        assert result["version"] == "0.1"
+        assert result["size"] == 13005
+        assert result["content_type"] == "text/markdown"
+        # Author is reconstructed from user_id when no nested dict is present
+        assert result["author"] == {"id": 1, "name": None}
+        # Timestamps come from revision's created_at / updated_at
+        assert result["created_on"] == "2026-05-12T10:00:00Z"
+        assert result["updated_on"] == "2026-05-12T10:05:00Z"
+        assert result["project_id"] == 1
+
+    @pytest.mark.asyncio
+    @patch("redmine_mcp_server._client.REDMINE_URL", "http://localhost:3000")
+    @patch("redmine_mcp_server._client.redmine")
+    async def test_get_uses_latest_revision_when_multiple(self, mock_redmine):
+        """When a document has several revisions, the latest one (last in
+        the array per DMSF's ascending order) supplies the current
+        metadata."""
+        response = {
+            "dmsf_file": {
+                "id": 5,
+                "title": "spec",
+                "name": "spec.pdf",
+                "project_id": 1,
+                "dmsf_file_revisions": [
+                    {
+                        "id": 1,
+                        "version": "0.1",
+                        "size": 100,
+                        "description": "initial draft",
+                        "mime_type": "application/pdf",
+                        "user_id": 1,
+                        "created_at": "2026-05-10T10:00:00Z",
+                        "updated_at": "2026-05-10T10:00:00Z",
+                    },
+                    {
+                        "id": 2,
+                        "version": "1.0",
+                        "size": 200,
+                        "description": "release version",
+                        "mime_type": "application/pdf",
+                        "user_id": 2,
+                        "created_at": "2026-05-12T10:00:00Z",
+                        "updated_at": "2026-05-12T10:00:00Z",
+                    },
+                ],
+            }
+        }
+        mock_redmine.engine.request.return_value = response
+        with patch.dict(os.environ, {"REDMINE_DMSF_ENABLED": "true"}):
+            result = await manage_document(action="get", document_id=5)
+
+        assert result["version"] == "1.0"
+        assert result["size"] == 200
+        assert "release version" in result["description"]
+        assert result["author"]["id"] == 2
+
+    @pytest.mark.asyncio
+    @patch("redmine_mcp_server._client.REDMINE_URL", "http://localhost:3000")
+    @patch("redmine_mcp_server._client.redmine")
+    async def test_get_no_revisions_field_still_works(self, mock_redmine):
+        """If a response somehow has no ``dmsf_file_revisions`` (e.g.,
+        the mock fixture in existing tests), the serializer must still
+        return the top-level fields without crashing."""
+        mock_redmine.engine.request.return_value = {"dmsf_file": _make_doc(99)}
+        with patch.dict(os.environ, {"REDMINE_DMSF_ENABLED": "true"}):
+            result = await manage_document(action="get", document_id=99)
+        assert result["id"] == 99
+        # Top-level fields from the flat fixture still surface
+        assert "spec.pdf" in result["filename"]
+
+    @pytest.mark.asyncio
     async def test_rejects_invalid_document_id(self):
         with patch.dict(os.environ, {"REDMINE_DMSF_ENABLED": "true"}):
             result = await manage_document(action="get", document_id=-1)


### PR DESCRIPTION
# Redmine MCP — DMSF document management (`manage_document`)

## Summary

Adds **1 new MCP tool** — `manage_document` — exposing the `redmine_dmsf` plugin's REST API for document management. Follows the codebase's current `manage_X(action=...)` convention (one tool, action-dispatched) rather than splitting into four separate tools.

Tool count: **43 → 44**.

| Action | Description | Endpoint |
|---|---|---|
| `list` | List documents in a project (or specific DMSF folder) | `GET /projects/{id}/dmsf.json` |
| `get` | Fetch a single document's metadata | `GET /dmsf_files/{id}.json` |
| `create` | Upload a new document (two-step) | `POST /uploads.json` → token → `POST /projects/{id}/dmsf/commit_files.json` |
| `update` | Update metadata (creates a new revision) | `POST /dmsf_files/{id}/revision/create.json` |

---

## Why a plugin is required

Redmine core's `DocumentsController` has zero `accept_api_auth` calls and no JSON/XML responders — the built-in Documents module is web-UI-only. Feature #18245 (REST API for documents) has been open since 2014 and never implemented.

The only viable path is the **[`redmine_dmsf`](https://github.com/danmunn/redmine_dmsf)** plugin (free, GPL v2), which *replaces* the built-in Documents module with a versioned document-management system that exposes a comprehensive REST API.

---

## Feature flag

New env var: **`REDMINE_DMSF_ENABLED`** (default `false`). Follows the existing `REDMINE_AGILE_ENABLED` / `REDMINE_CHECKLISTS_ENABLED` / `REDMINE_PRODUCTS_ENABLED` / `REDMINE_CRM_ENABLED` pattern.

When unset, the tool returns a clear error: *"DMSF (document management) support is disabled. Set REDMINE_DMSF_ENABLED=true to enable it. Requires the redmine_dmsf plugin installed on the Redmine server."*

---

## Implementation details

### Plugin integration pattern

Follows the established `client.engine.request()` pattern used by every other plugin-gated tool in the codebase (Agile, Checklists, Products, CRM):

- Feature-flag check (`_is_dmsf_enabled()`) at the top of `manage_document` — runs before any client construction
- All HTTP issued through the same `client.engine.request(method, url, ...)` interface — inherits the configured auth (legacy API key or OAuth Bearer)
- Errors funnel through `_handle_redmine_error()` for credential scrubbing

### Action dispatch via `@action_dispatch`

Reuses the existing `@action_dispatch` decorator from `_decorators.py`:

```python
@action_dispatch(
    {
        "list": ActionMode.READ,
        "get": ActionMode.READ,
        "create": ActionMode.WRITE,
        "update": ActionMode.WRITE,
    }
)
async def _manage_document_dispatch(action: str, **kwargs: Any) -> Any:
    return {
        "list": _list_documents_action,
        "get": _get_document_action,
        "create": _create_document_action,
        "update": _update_document_action,
    }
```

The decorator handles invalid-action rejection, read-only-mode guarding for WRITE actions, and `_ensure_cleanup_started()` for writes.

### Two-step upload (`create`)

Identical pattern to the existing `upload_file` tool:

1. **Step 1**: `client.upload(io.BytesIO(content_bytes), filename=filename)` — POSTs to `/uploads.json`, returns a `token`
2. **Step 2**: `client.engine.request("post", "/projects/{id}/dmsf/commit_files.json", data={"dmsf_file": {"token": ..., "filename": ..., "title": ..., ...}})` — finalizes the upload as a DMSF document

### Helpers added

- `_is_dmsf_enabled()` in `_env.py`
- `_document_to_dict()` — stable serializer with `<insecure-content>` wrapping on user-controlled fields, `_safe_isoformat` on timestamps, and isinstance-guarded nested `author` dict
- `_decode_content_base64()` — shared decode/size-check used by `_create_document_action` (50 MiB cap matching `upload_file`)

---

## Security hardening

Same defense-in-depth as every other plugin-gated tool in the codebase:

### Prompt-injection defense

User-controlled fields wrapped in `<insecure-content>` boundary tags:

- `filename`, `title`, `name`, `description` on every document node
- Nested `author.name`

### Input validation

- `project_id` validated via `_is_valid_project_id()` before URL interpolation (rejects empty strings, whitespace, path-traversal characters, uppercase letters)
- `document_id`, `folder_id` validated via `_is_positive_int()` (rejects booleans, negatives, zero, non-int types)
- `filename` and `content_base64` required for `create`, type-checked as non-empty strings
- `limit` clamped to Redmine's server-side cap of 100 per request

### Resource exhaustion protection

- **50 MiB decoded payload cap** on `create` (matches `upload_file`); rejects oversized base64 before any network call
- Empty decoded content rejected with a clear error
- Invalid base64 caught with a clear error pointing at the malformed input

### Writable-fields whitelist (`update`)

Only `title`, `description`, `comment`, `custom_fields` accepted. Unknown keys — **including `filename`** (DMSF filenames are immutable) — silently filtered out before reaching the API. The error message when no writable fields are provided points users at the immutability constraint and the create-new-revision workaround.

### Read-only mode

`create` and `update` blocked by `@action_dispatch`'s ActionMode.WRITE handling. `list` and `get` remain available.

### Error scrubbing

All exceptions go through `_handle_redmine_error()`, which redacts API keys, Bearer tokens, and basic-auth credentials from raw error messages before returning to the caller.

---

## DMSF design caveats (documented for callers)

- **Every update creates a new revision.** DMSF is versioned — there is no in-place mutation. Previous revisions remain accessible via the document's revision history in the Redmine UI.
- **Filenames are immutable.** To change file content, call `action="create"` again with the same `filename` — DMSF will add the new content as a new revision under the existing document.
- **DMSF replaces the built-in Documents module** rather than complementing it. If the Redmine instance has existing native documents, the server admin must run `rake redmine:dmsf_convert_documents` to migrate them before they're accessible via this tool.
- The `update` response includes a `note` field reminding the caller that a new revision was created.

---

## Testing

### Automated tests

**31 new unit tests** in `tests/test_dmsf_support.py` covering:

- **Feature flag** (`TestIsDmsfEnabled`): default off, explicit on
- **Dispatch + gating** (`TestManageDocumentDispatch`): disabled-error, invalid-action rejection
- **`list`** (`TestManageDocumentList`, 10 tests): happy path, folder filter, bare-array response shape, limit clamping to 100, defensive oversized-response slicing, missing/empty `project_id`, invalid `folder_id`, invalid `limit`, API error
- **`get`** (`TestManageDocumentGet`, 3 tests): happy path, not-found, invalid `document_id`
- **`create`** (`TestManageDocumentCreate`, 8 tests): two-step upload (verifies both `client.upload()` and the commit POST with correct body), read-only blocked, missing `filename` / `content_base64`, invalid base64, empty decoded content, oversized payload (>50 MiB), missing `project_id`
- **`update`** (`TestManageDocumentUpdate`, 6 tests): happy path, unknown-field filtering (including filename), read-only blocked, invalid `document_id`, empty `fields`, no-writable-fields error

Mocking pattern matches the existing `test_products_support.py` / `test_crm_support.py` files — patches `redmine_mcp_server._client.REDMINE_URL` and `redmine_mcp_server._client.redmine`.

**Total suite: 1111 tests pass** (was 1080 — 31 new). `black --check` and `flake8 --max-line-length=88 --extend-ignore=E203` clean.

### Manual testing checklist (suggested before merge)

- [ ] Set `REDMINE_DMSF_ENABLED=true`; confirm `manage_document(action="list", project_id="...")` returns the DMSF tree
- [ ] `manage_document(action="get", document_id=N)` returns metadata for a known document
- [ ] `manage_document(action="create", project_id="...", filename="test.pdf", content_base64=...)` uploads a new document; verify it appears in Redmine
- [ ] `manage_document(action="update", document_id=N, fields={"title": "..."})` creates a new revision; verify previous revision is preserved
- [ ] Verify clear error when `REDMINE_DMSF_ENABLED=false`
- [ ] Verify read-only mode blocks `create` and `update` but not `list` / `get`

### Endpoint-format note for live testing

The DMSF plugin's REST endpoint paths have shifted across plugin versions over the years. If a live call returns 404 on a specific path, it's a one-line string change in `tools/documents.py`. Most commonly seen variants:

| What the plugin uses (most recent) | Older variants |
|---|---|
| `GET /projects/{id}/dmsf.json` | `GET /projects/{id}/dmsf_files.json` |
| `POST /projects/{id}/dmsf/commit_files.json` | `POST /projects/{id}/dmsf/commit.json` |
| `GET /dmsf_files/{id}.json` | `GET /dmsf/files/{id}.json` |
| `POST /dmsf_files/{id}/revision/create.json` | `POST /dmsf/files/{id}/revision/create.json` |

---

## Files changed

| File | Change |
|---|---|
| `src/redmine_mcp_server/_env.py` | `+5` lines: `_is_dmsf_enabled()` helper |
| `src/redmine_mcp_server/tools/documents.py` | new file (~360 lines): `manage_document` + 4 action handlers + `_document_to_dict` + `_decode_content_base64` |
| `src/redmine_mcp_server/tools/__init__.py` | `+1` line: register the new module |
| `tests/test_dmsf_support.py` | new file: 31 tests |
| `.env.example` | New `REDMINE_DMSF_ENABLED` block with migration note |
| `.env.docker.example` | `REDMINE_DMSF_ENABLED=false` placeholder |
| `README.md` | Tool count 43→44, env-var row, Documents section in "Available Tools" |
| `CHANGELOG.md` | Full entry under `[Unreleased] → Added` |
| `docs/tool-reference.md` | New "Documents (DMSF plugin)" section with examples, parameter table, design notes, endpoint paths |

---

## Stats

- **1 new MCP tool** (43 → 44)
- **+~700 lines** across source + tests + docs
- **31 new unit tests; 1111 total pass** (was 1080)
- **1 new feature flag** (`REDMINE_DMSF_ENABLED`)
- Black + flake8 clean
- Supports Python 3.10 – 3.13
