### PR TITLE
Serve OAuth AS metadata at MCP path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,9 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Two new required env vars in OAuth mode**: `REDMINE_INTROSPECT_CLIENT_ID` and `REDMINE_INTROSPECT_CLIENT_SECRET`. Operators register a confidential OAuth client in Redmine and patch Doorkeeper's `allow_token_introspection` block (stock Redmine ships with `allow_token_introspection false`). See [`docs/oauth-setup.md`](docs/oauth-setup.md) Step 2 for the walkthrough. Server fails fast at startup if either env var is missing.
 - **Discovery path aliases dropped.** Only the canonical paths remain:
   - `GET /.well-known/oauth-protected-resource/mcp` (RFC 9728 §3.1 suffix-scoped, mounted natively by `RemoteAuthProvider`)
-  - `GET /.well-known/oauth-authorization-server` (canonical root, kept as `custom_route` mirror of Redmine's Doorkeeper AS metadata)
+  - `GET /.well-known/oauth-authorization-server/mcp` (path-scoped RFC 8414 form, kept as `custom_route` mirror of Redmine's Doorkeeper AS metadata)
 
-  These previously-served paths now return 404: `/.well-known/oauth-protected-resource` (root), `/mcp/.well-known/oauth-protected-resource` (prefix), `/.well-known/oauth-authorization-server/mcp` (suffix), `/mcp/.well-known/oauth-authorization-server` (prefix). Clients should follow `WWW-Authenticate: Bearer resource_metadata="..."` headers from 401 responses for RFC 9728 §5.3 compliant discovery.
+  These previously-served paths now return 404: `/.well-known/oauth-protected-resource` (root), `/mcp/.well-known/oauth-protected-resource` (prefix), `/.well-known/oauth-authorization-server` (root), `/mcp/.well-known/oauth-authorization-server` (prefix). Clients should follow `WWW-Authenticate: Bearer resource_metadata="..."` headers from 401 responses for RFC 9728 §5.3 compliant discovery.
 - **Upstream introspection failures now return 401 instead of 503.** When Doorkeeper is unreachable, the previous behavior was `503 upstream_unavailable`. FastMCP's `IntrospectionTokenVerifier` treats transport failures as auth failures, so clients see 401. Operators monitoring 503 spikes as an upstream-Redmine-down signal should switch to monitoring 401-rate or watch `/health`'s new introspection probe (see Added).
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -240,10 +240,10 @@ In OAuth mode the server also exposes OAuth2 discovery and token management endp
 | Endpoint | Standard | Purpose |
 |----------|----------|---------|
 | `/.well-known/oauth-protected-resource/mcp` | RFC 9728 §3.1 | Tells clients where to find the authorization server (mounted by FastMCP `RemoteAuthProvider`) |
-| `/.well-known/oauth-authorization-server` | RFC 8414 | Advertises Redmine's Doorkeeper OAuth endpoints |
+| `/.well-known/oauth-authorization-server/mcp` | RFC 8414 | Advertises Redmine's Doorkeeper OAuth endpoints, scoped to this MCP resource |
 | `POST /revoke` | RFC 7009 | Revokes an OAuth2 token (proxies to Redmine's `/oauth/revoke`) |
 
-Redmine uses the [Doorkeeper](https://github.com/doorkeeper-gem/doorkeeper) gem for OAuth2 but does not serve the RFC 8414 discovery document itself. This server serves it on Redmine's behalf, pointing to Redmine's real `/oauth/authorize`, `/oauth/token`, and `/oauth/revoke` endpoints.
+Redmine uses the [Doorkeeper](https://github.com/doorkeeper-gem/doorkeeper) gem for OAuth2 but does not serve the RFC 8414 discovery document itself. This server serves path-scoped metadata on Redmine's behalf, pointing to Redmine's real `/oauth/authorize`, `/oauth/token`, and `/oauth/revoke` endpoints.
 
 **Prerequisites for OAuth mode:**
 - An OAuth application registered in Redmine admin → **Applications** with the callback URL of your client

--- a/docs/oauth-setup.md
+++ b/docs/oauth-setup.md
@@ -107,7 +107,7 @@ Verify discovery endpoints:
 curl http://localhost:8000/.well-known/oauth-protected-resource/mcp
 
 # RFC 8414 authorization-server metadata (mirror of Redmine's Doorkeeper)
-curl http://localhost:8000/.well-known/oauth-authorization-server
+curl http://localhost:8000/.well-known/oauth-authorization-server/mcp
 
 # /health probes Doorkeeper introspection in OAuth mode
 curl http://localhost:8000/health
@@ -158,7 +158,7 @@ Set this in Redmine's OAuth app (Step 1) to match your client:
 | Every MCP call returns 401 | Introspection client not authorized to introspect tokens of other apps | Re-check Step 2b's `allow_token_introspection` block in `30-redmine.rb`. Confirm the introspection client is **Confidential: Yes**. |
 | `/health` returns `status: "degraded"` | Introspection endpoint unreachable | Check `REDMINE_URL`, introspection credentials, and Doorkeeper's `allow_token_introspection` setting |
 | Server fails to start: "Missing env var(s): REDMINE_INTROSPECT_CLIENT_ID..." | OAuth mode requires introspection creds | Register the introspection client per Step 2, set `REDMINE_INTROSPECT_CLIENT_ID` / `_SECRET` |
-| Discovery endpoints 404 | Not in OAuth mode, or hitting wrong path | Ensure `REDMINE_AUTH_MODE=oauth`. Note: the canonical paths are `/.well-known/oauth-protected-resource/mcp` (suffix-scoped per RFC 9728 §3.1) and `/.well-known/oauth-authorization-server` (root) |
+| Discovery endpoints 404 | Not in OAuth mode, or hitting wrong path | Ensure `REDMINE_AUTH_MODE=oauth`. Note: the canonical paths are `/.well-known/oauth-protected-resource/mcp` (suffix-scoped per RFC 9728 §3.1) and `/.well-known/oauth-authorization-server/mcp` |
 | Token works in Redmine but not MCP | Wrong `REDMINE_URL` | In Docker, use internal hostname (e.g., `http://redmine:3000`) |
 | "Applications" menu missing | Redmine too old | Requires Redmine 6.1+ |
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -864,6 +864,6 @@ If a legacy API key isn't available, revert to the previous application version 
 The v2.1+ release dropped several discovery path aliases. Only these paths remain:
 
 - `GET /.well-known/oauth-protected-resource/mcp` (canonical RFC 9728 §3.1 suffix-scoped form, mounted by `RemoteAuthProvider`)
-- `GET /.well-known/oauth-authorization-server` (canonical root, mirrors Redmine's Doorkeeper AS metadata)
+- `GET /.well-known/oauth-authorization-server/mcp` (path-scoped RFC 8414 form, mirrors Redmine's Doorkeeper AS metadata)
 
 Clients should follow `WWW-Authenticate: Bearer resource_metadata="..."` headers from 401 responses (RFC 9728 §5.3) rather than guessing paths. If a client hardcodes the dropped variants, update the client; we don't plan to restore aliases.

--- a/src/redmine_mcp_server/main.py
+++ b/src/redmine_mcp_server/main.py
@@ -172,7 +172,7 @@ async def revoke_token(request: Request):
 # no Starlette middleware doing auth, so custom_route no longer represents
 # the bypass surface.
 if REDMINE_AUTH_MODE == "oauth":
-    mcp.custom_route("/.well-known/oauth-authorization-server", methods=["GET"])(
+    mcp.custom_route("/.well-known/oauth-authorization-server/mcp", methods=["GET"])(
         oauth_authorization_server
     )
     mcp.custom_route("/revoke", methods=["POST"])(revoke_token)

--- a/src/redmine_mcp_server/oauth_scopes.py
+++ b/src/redmine_mcp_server/oauth_scopes.py
@@ -2,7 +2,7 @@
 
 This module is the single source of truth for the ``scopes_supported``
 list returned by ``/.well-known/oauth-protected-resource`` and
-``/.well-known/oauth-authorization-server``.
+``/.well-known/oauth-authorization-server/mcp``.
 
 Scope identifiers are Redmine Doorkeeper scope names. In stock Redmine
 6.x they match the permission name from ``lib/redmine/access_control.rb``.

--- a/tests/test_oauth_auth.py
+++ b/tests/test_oauth_auth.py
@@ -54,9 +54,9 @@ def _build_test_app(introspect_handler):
         resource_name="Redmine MCP Server",
     )
     local_mcp = FastMCP("oauth_auth_test", auth=provider)
-    local_mcp.custom_route("/.well-known/oauth-authorization-server", methods=["GET"])(
-        main_mod.oauth_authorization_server
-    )
+    local_mcp.custom_route(
+        "/.well-known/oauth-authorization-server/mcp", methods=["GET"]
+    )(main_mod.oauth_authorization_server)
     return local_mcp.http_app(stateless_http=True)
 
 

--- a/tests/test_oauth_discovery.py
+++ b/tests/test_oauth_discovery.py
@@ -37,9 +37,9 @@ def oauth_app(monkeypatch):
     local_mcp = FastMCP("redmine_mcp_tools_test", auth=auth_provider)
 
     # Mirror main.py: register kept custom_routes
-    local_mcp.custom_route("/.well-known/oauth-authorization-server", methods=["GET"])(
-        main_mod.oauth_authorization_server
-    )
+    local_mcp.custom_route(
+        "/.well-known/oauth-authorization-server/mcp", methods=["GET"]
+    )(main_mod.oauth_authorization_server)
     local_mcp.custom_route("/revoke", methods=["POST"])(main_mod.revoke_token)
 
     return local_mcp.http_app(stateless_http=True)
@@ -62,9 +62,9 @@ async def test_protected_resource_suffix_path_returns_200(oauth_app):
 @pytest.mark.parametrize(
     "path",
     [
+        "/.well-known/oauth-authorization-server",
         "/.well-known/oauth-protected-resource",
         "/mcp/.well-known/oauth-protected-resource",
-        "/.well-known/oauth-authorization-server/mcp",
         "/mcp/.well-known/oauth-authorization-server",
     ],
 )
@@ -79,11 +79,11 @@ async def test_dropped_discovery_paths_return_404(oauth_app, path):
 
 
 @pytest.mark.asyncio
-async def test_authorization_server_canonical_path_returns_200(oauth_app):
+async def test_authorization_server_suffix_path_returns_200(oauth_app):
     async with httpx.AsyncClient(
         transport=httpx.ASGITransport(app=oauth_app), base_url="http://test"
     ) as client:
-        r = await client.get("/.well-known/oauth-authorization-server")
+        r = await client.get("/.well-known/oauth-authorization-server/mcp")
     assert r.status_code == 200
     body = r.json()
     assert body["authorization_endpoint"] == "https://r.example.com/oauth/authorize"
@@ -98,7 +98,7 @@ async def test_scope_sources_match(oauth_app):
         transport=httpx.ASGITransport(app=oauth_app), base_url="http://test"
     ) as client:
         pr = (await client.get("/.well-known/oauth-protected-resource/mcp")).json()
-        asm = (await client.get("/.well-known/oauth-authorization-server")).json()
+        asm = (await client.get("/.well-known/oauth-authorization-server/mcp")).json()
     assert pr["scopes_supported"] == asm["scopes_supported"]
 
 
@@ -119,9 +119,9 @@ async def test_scope_sources_filtered_consistently_in_read_only_mode(monkeypatch
 
     auth_provider = _auth.build_remote_auth()
     local_mcp = FastMCP("ro_test", auth=auth_provider)
-    local_mcp.custom_route("/.well-known/oauth-authorization-server", methods=["GET"])(
-        main_mod.oauth_authorization_server
-    )
+    local_mcp.custom_route(
+        "/.well-known/oauth-authorization-server/mcp", methods=["GET"]
+    )(main_mod.oauth_authorization_server)
     app = local_mcp.http_app(stateless_http=True)
 
     from redmine_mcp_server.oauth_scopes import WRITE_SCOPES
@@ -130,7 +130,7 @@ async def test_scope_sources_filtered_consistently_in_read_only_mode(monkeypatch
         transport=httpx.ASGITransport(app=app), base_url="http://test"
     ) as client:
         pr = (await client.get("/.well-known/oauth-protected-resource/mcp")).json()
-        asm = (await client.get("/.well-known/oauth-authorization-server")).json()
+        asm = (await client.get("/.well-known/oauth-authorization-server/mcp")).json()
 
     for write_scope in WRITE_SCOPES:
         assert write_scope not in pr["scopes_supported"]


### PR DESCRIPTION
## Summary

This PR narrows the MCP OAuth Authorization Server Metadata route from the root path to the MCP resource path:

- `/.well-known/oauth-authorization-server` is removed
- `/.well-known/oauth-authorization-server/mcp` becomes the served AS metadata path
- docs, changelog, and OAuth discovery tests are updated for the breaking path change

This keeps the AS metadata path aligned with clients that derive RFC 8414 metadata from the MCP resource path. It also avoids the MCP server claiming the root AS metadata location when it is co-hosted with another app that may own that root discovery document.

## Out of scope

Discovery mirroring / DCR pass-through was split out of this PR. This branch keeps the existing static Doorkeeper metadata behavior and only changes the served path.

## Verification

```bash
UV_CACHE_DIR=/tmp/uv-cache-redmine-mcp uv run --extra dev pytest tests/test_oauth_auth.py tests/test_oauth_discovery.py tests/test_auth_factory.py
# 18 passed

UV_CACHE_DIR=/tmp/uv-cache-redmine-mcp uv run --extra dev black --check --fast src/redmine_mcp_server/main.py tests/test_oauth_discovery.py tests/test_oauth_auth.py
# 3 files would be left unchanged
```
