### PR TITLE
Add OAuthProxy auth mode for Redmine OAuth

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,21 +23,41 @@ REDMINE_PASSWORD=your_password
 # Uncomment and set this if you want to use API key authentication instead
 # REDMINE_API_KEY=your_api_key
 
-# Authentication mode: "oauth" or "legacy" (default: legacy)
+# Authentication mode: "oauth", "oauth-proxy", or "legacy" (default: legacy)
 # - legacy: uses REDMINE_API_KEY or REDMINE_USERNAME/REDMINE_PASSWORD below
 # - oauth:  validates per-request Bearer tokens against Redmine; requires REDMINE_MCP_BASE_URL
+# - oauth-proxy: FastMCP handles DCR/CIMD for MCP clients and uses Redmine as the upstream OAuth provider
 REDMINE_AUTH_MODE=legacy
 
-# OAuth2 configuration (only required when REDMINE_AUTH_MODE=oauth)
+# OAuth2 configuration (required when REDMINE_AUTH_MODE=oauth or oauth-proxy)
 # Public base URL of this MCP server (no trailing slash)
 # e.g. https://redmine.mcp.example.com or http://localhost:3040
 REDMINE_MCP_BASE_URL=http://localhost:3040
 
-# Doorkeeper introspection client credentials (required when REDMINE_AUTH_MODE=oauth).
-# Register a confidential OAuth app in Redmine with protected_resource? permission.
+# Optional FastMCP streamable HTTP path inside REDMINE_MCP_BASE_URL (default /mcp).
+# FASTMCP_STREAMABLE_HTTP_PATH=/mcp
+
+# Doorkeeper introspection client credentials (required when REDMINE_AUTH_MODE=oauth or oauth-proxy).
+# Register a confidential OAuth app in Redmine.
 # See docs/oauth-setup.md Step 2 for the full walkthrough.
 REDMINE_INTROSPECT_CLIENT_ID=
 REDMINE_INTROSPECT_CLIENT_SECRET=
+# REDMINE_INTROSPECT_CLIENT_SECRET_FILE=/run/secrets/redmine_introspect_client_secret
+
+# OAuthProxy signing key (required when REDMINE_AUTH_MODE=oauth-proxy).
+# Use a stable secret value; changing it invalidates FastMCP proxy tokens/storage.
+REDMINE_MCP_JWT_SIGNING_KEY=
+# REDMINE_MCP_JWT_SIGNING_KEY_FILE=/run/secrets/redmine_mcp_jwt_signing_key
+
+# Optional FastMCP data directory. OAuthProxy stores encrypted client
+# registrations, transactions, and upstream tokens below FASTMCP_HOME/oauth-proxy/.
+# FASTMCP_HOME=/app/data/fastmcp
+
+# Optional separate upstream Redmine OAuth client for oauth-proxy.
+# If unset, the introspection client credentials above are reused.
+# REDMINE_OAUTH_CLIENT_ID=
+# REDMINE_OAUTH_CLIENT_SECRET=
+# REDMINE_OAUTH_CLIENT_SECRET_FILE=/run/secrets/redmine_oauth_client_secret
 
 # Optional: cache TTL (seconds) for the /health introspection probe (default 30).
 # HEALTH_INTROSPECTION_TTL_SECONDS=30

--- a/README.md
+++ b/README.md
@@ -99,13 +99,18 @@ The server runs on `http://localhost:8000` with the MCP endpoint at `/mcp`, heal
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|
 | `REDMINE_URL` | Yes | – | Base URL of your Redmine instance |
-| `REDMINE_AUTH_MODE` | No | `legacy` | Authentication mode: `legacy` or `oauth` (see [Authentication](#authentication)) |
+| `REDMINE_AUTH_MODE` | No | `legacy` | Authentication mode: `legacy`, `oauth`, or `oauth-proxy` (see [Authentication](#authentication)) |
 | `REDMINE_API_KEY` | Yes† | – | API key (legacy mode only) |
 | `REDMINE_USERNAME` | Yes† | – | Username for basic auth (legacy mode only) |
 | `REDMINE_PASSWORD` | Yes† | – | Password for basic auth (legacy mode only) |
-| `REDMINE_MCP_BASE_URL` | Yes‡ | `http://localhost:3040` | Public base URL of this server, no trailing slash (OAuth mode only) |
-| `REDMINE_INTROSPECT_CLIENT_ID` | Yes‡ | – | Doorkeeper OAuth client ID used by the MCP server to introspect Bearer tokens (RFC 7662). Register a confidential OAuth app in Redmine with `protected_resource?` permission — see [`docs/oauth-setup.md`](docs/oauth-setup.md) Step 2. |
+| `REDMINE_MCP_BASE_URL` | Yes‡ | `http://localhost:3040` | Public base URL of this server, no trailing slash (OAuth modes only) |
+| `FASTMCP_STREAMABLE_HTTP_PATH` | No | `/mcp` | MCP transport path inside `REDMINE_MCP_BASE_URL` |
+| `REDMINE_INTROSPECT_CLIENT_ID` | Yes‡ | – | Doorkeeper OAuth client ID used by the MCP server to introspect Bearer tokens (RFC 7662). Register a confidential OAuth app in Redmine — see [`docs/oauth-setup.md`](docs/oauth-setup.md) Step 2. |
 | `REDMINE_INTROSPECT_CLIENT_SECRET` | Yes‡ | – | Secret for the introspection client |
+| `REDMINE_MCP_JWT_SIGNING_KEY` | Yes§ | – | Stable signing/encryption key used by FastMCP OAuthProxy tokens and storage |
+| `REDMINE_OAUTH_CLIENT_ID` | No | – | Optional upstream Redmine OAuth client ID for `oauth-proxy`; defaults to `REDMINE_INTROSPECT_CLIENT_ID` |
+| `REDMINE_OAUTH_CLIENT_SECRET` | No | – | Optional upstream Redmine OAuth client secret for `oauth-proxy`; defaults to `REDMINE_INTROSPECT_CLIENT_SECRET` |
+| `FASTMCP_HOME` | No | platform default | FastMCP data directory. In `oauth-proxy` mode, encrypted OAuthProxy state is stored below `FASTMCP_HOME/oauth-proxy/` |
 | `HEALTH_INTROSPECTION_TTL_SECONDS` | No | `30` | TTL (seconds) for the `/health` Doorkeeper introspection probe cache. Set to `0` to disable caching. |
 | `SERVER_HOST` | No | `0.0.0.0` | Host/IP the MCP server binds to |
 | `SERVER_PORT` | No | `8000` | Port the MCP server listens on |
@@ -132,7 +137,9 @@ The server runs on `http://localhost:8000` with the MCP endpoint at `/mcp`, heal
 | `REDMINE_ALLOW_PRIVATE_FETCH_URLS` | No | `false` | **Warning:** disables all SSRF protection for attachment fetching. Never set to `true` in production. |
 
 *† Required when `REDMINE_AUTH_MODE=legacy`. Either `REDMINE_API_KEY` or `REDMINE_USERNAME`+`REDMINE_PASSWORD` must be set. API key is recommended.*
-*‡ Required when `REDMINE_AUTH_MODE=oauth`.*
+*‡ Required when `REDMINE_AUTH_MODE=oauth` or `REDMINE_AUTH_MODE=oauth-proxy`.*
+*§ Required when `REDMINE_AUTH_MODE=oauth-proxy`.*
+Secret values can also be supplied with Docker/Kubernetes-style file variables: `REDMINE_INTROSPECT_CLIENT_SECRET_FILE`, `REDMINE_MCP_JWT_SIGNING_KEY_FILE`, and `REDMINE_OAUTH_CLIENT_SECRET_FILE`.
 
 When `REDMINE_AUTOFILL_REQUIRED_CUSTOM_FIELDS=true`, `create_redmine_issue` retries once on relevant custom-field validation errors (for example `<Field Name> cannot be blank` or `<Field Name> is not included in the list`) and fills values only from:
 - the Redmine custom field `default_value`, or
@@ -202,7 +209,7 @@ For SSL troubleshooting, see the [Troubleshooting Guide](./docs/troubleshooting.
 
 ## Authentication
 
-The server supports two authentication modes, selected via `REDMINE_AUTH_MODE`.
+The server supports three authentication modes, selected via `REDMINE_AUTH_MODE`.
 
 > **Backward compatibility**: `REDMINE_AUTH_MODE` defaults to `legacy`, so all existing deployments continue to work without any configuration changes. OAuth2 support is purely additive — nothing breaks if you never set the variable.
 
@@ -251,6 +258,25 @@ Redmine uses the [Doorkeeper](https://github.com/doorkeeper-gem/doorkeeper) gem 
 - No Dynamic Client Registration (DCR) is required — register the application manually in Redmine admin
 
 For step-by-step setup instructions, see the [OAuth2 Setup Guide](./docs/oauth-setup.md).
+
+### OAuthProxy mode
+
+For hosted MCP deployments, `REDMINE_AUTH_MODE=oauth-proxy` lets FastMCP act as the MCP-facing authorization server. FastMCP handles DCR/CIMD for MCP clients, then redirects users to Redmine as the upstream OAuth provider and external consent screen.
+
+```bash
+REDMINE_AUTH_MODE=oauth-proxy
+REDMINE_URL=https://redmine.example.com
+REDMINE_MCP_BASE_URL=https://redmine-mcp.example.com   # public URL of this server
+
+# Introspection/upstream client (register a confidential OAuth app in Redmine; see docs/oauth-setup.md)
+REDMINE_INTROSPECT_CLIENT_ID=...
+REDMINE_INTROSPECT_CLIENT_SECRET=...
+REDMINE_MCP_JWT_SIGNING_KEY=...
+```
+
+The upstream Redmine OAuth app should use `${REDMINE_MCP_BASE_URL}/auth/callback` as its redirect URI. If `REDMINE_OAUTH_CLIENT_ID` / `REDMINE_OAUTH_CLIENT_SECRET` are not set, the introspection credentials are reused for the upstream Redmine OAuth app.
+
+OAuthProxy uses FastMCP's default encrypted file storage under `FASTMCP_HOME/oauth-proxy/` for client registrations, transactions, and upstream token state. Mount `FASTMCP_HOME` to persistent storage in container deployments.
 
 ## MCP Client Configuration
 

--- a/docs/oauth-setup.md
+++ b/docs/oauth-setup.md
@@ -4,18 +4,20 @@ Set up the MCP server so each user authenticates with their own Redmine account.
 
 **Requirements:** Redmine 6.1+ and admin access to register an OAuth application.
 
+This guide covers both direct Redmine Bearer-token mode (`REDMINE_AUTH_MODE=oauth`) and hosted OAuthProxy mode (`REDMINE_AUTH_MODE=oauth-proxy`). In `oauth-proxy` mode, FastMCP handles DCR/CIMD for MCP clients and uses Redmine as the upstream OAuth provider and external consent screen.
+
 ## Step 1: Register an OAuth App in Redmine
 
 1. Log in as admin → **Administration → Applications** → **New Application**
 2. Fill in:
    - **Name:** `MCP Server`
-   - **Redirect URI:** `http://127.0.0.1:PORT/callback` (see redirect URIs below)
+   - **Redirect URI:** `http://127.0.0.1:PORT/callback` for direct OAuth mode, or `${REDMINE_MCP_BASE_URL}/auth/callback` for OAuthProxy mode
    - **Confidential:** Yes
 3. Save and note the **Client ID** and **Client Secret**
 
 ## Step 2: Register a Doorkeeper Introspection Client
 
-The MCP server validates incoming Bearer tokens by calling Doorkeeper's RFC 7662 introspection endpoint (`POST /oauth/introspect`). To do this it needs its own confidential OAuth application registered in Redmine, separate from the user-flow OAuth app from Step 1.
+The MCP server validates incoming Bearer tokens by calling Doorkeeper's RFC 7662 introspection endpoint (`POST /oauth/introspect`). To do this it needs a confidential OAuth application registered in Redmine. In `oauth-proxy` mode this can be the same app from Step 1; a separate app is only useful for independent credential rotation or clearer audit labels.
 
 ### 2a. Register the application
 
@@ -82,9 +84,28 @@ REDMINE_MCP_BASE_URL=https://mcp.example.com   # public URL of this server
 # Introspection client (from Step 2)
 REDMINE_INTROSPECT_CLIENT_ID=<UID from Redmine>
 REDMINE_INTROSPECT_CLIENT_SECRET=<Secret from Redmine>
+# Or: REDMINE_INTROSPECT_CLIENT_SECRET_FILE=/run/secrets/redmine_introspect_client_secret
 
 # Optional: /health introspection probe cache TTL in seconds (default 30)
 # HEALTH_INTROSPECTION_TTL_SECONDS=30
+```
+
+For OAuthProxy mode, use `REDMINE_AUTH_MODE=oauth-proxy` and add a stable proxy signing key:
+
+```bash
+REDMINE_AUTH_MODE=oauth-proxy
+REDMINE_MCP_JWT_SIGNING_KEY=<stable-random-secret>
+# Or: REDMINE_MCP_JWT_SIGNING_KEY_FILE=/run/secrets/redmine_mcp_jwt_signing_key
+
+# Optional: mount this directory to persistent storage in container deployments.
+# OAuthProxy stores encrypted state below FASTMCP_HOME/oauth-proxy/.
+# FASTMCP_HOME=/app/data/fastmcp
+
+# Optional: use a separate upstream Redmine OAuth app.
+# If unset, REDMINE_INTROSPECT_CLIENT_ID / _SECRET are reused.
+# REDMINE_OAUTH_CLIENT_ID=<UID from Redmine>
+# REDMINE_OAUTH_CLIENT_SECRET=<Secret from Redmine>
+# Or: REDMINE_OAUTH_CLIENT_SECRET_FILE=/run/secrets/redmine_oauth_client_secret
 ```
 
 Set these in `.env` (local) or `.env.docker` (Docker). Legacy credentials are not needed in OAuth mode.
@@ -108,6 +129,9 @@ curl http://localhost:8000/.well-known/oauth-protected-resource/mcp
 
 # RFC 8414 authorization-server metadata (mirror of Redmine's Doorkeeper)
 curl http://localhost:8000/.well-known/oauth-authorization-server/mcp
+
+# OAuthProxy mode also exposes DCR
+curl -I http://localhost:8000/register
 
 # /health probes Doorkeeper introspection in OAuth mode
 curl http://localhost:8000/health
@@ -142,6 +166,7 @@ Set this in Redmine's OAuth app (Step 1) to match your client:
 | Kiro | Configurable via `oauth.redirectUri` |
 
 > **Note on DCR:** Some clients (Claude Desktop, VS Code) expect Dynamic Client Registration. Redmine's Doorkeeper does not support DCR, so you must pre-register the app manually (Step 1) and configure the client with the `client_id`/`client_secret`.
+> Use `REDMINE_AUTH_MODE=oauth-proxy` when MCP clients need DCR/CIMD onboarding.
 
 ## Migrating from Legacy Mode
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -207,10 +207,10 @@ This guide covers common issues and solutions for the Redmine MCP Server.
 **Symptoms:**
 - MCP client fails to connect with `{"error":"unauthorized"}`
 - Server returns `401 Unauthorized` with a `WWW-Authenticate: Bearer` header
-- Health endpoint shows `"auth_mode":"oauth"` when you expected legacy mode
+- Health endpoint shows `"auth_mode":"oauth"` or `"auth_mode":"oauth-proxy"` when you expected legacy mode
 
-**Cause:** The server is running in OAuth mode (`REDMINE_AUTH_MODE=oauth`) instead of legacy mode. This can happen if:
-- `REDMINE_AUTH_MODE=oauth` is set in your shell environment (e.g., via `export`), which takes precedence over `.env`
+**Cause:** The server is running in OAuth mode (`REDMINE_AUTH_MODE=oauth` or `REDMINE_AUTH_MODE=oauth-proxy`) instead of legacy mode. This can happen if:
+- `REDMINE_AUTH_MODE` is set in your shell environment (e.g., via `export`), which takes precedence over `.env`
 - The `.env` file doesn't explicitly set `REDMINE_AUTH_MODE=legacy`, and a shell variable overrides the default
 - The server was started with a previous configuration and hasn't been restarted after changes
 
@@ -875,6 +875,8 @@ If a legacy API key isn't available, revert to the previous application version 
 The v2.1+ release dropped several discovery path aliases. Only these paths remain:
 
 - `GET /.well-known/oauth-protected-resource/mcp` (canonical RFC 9728 §3.1 suffix-scoped form, mounted by `RemoteAuthProvider`)
-- `GET /.well-known/oauth-authorization-server/mcp` (path-scoped RFC 8414 form, mirrors Redmine's Doorkeeper AS metadata)
+- `GET /.well-known/oauth-authorization-server/mcp` (path-scoped RFC 8414 form, mirrors Redmine's Doorkeeper AS metadata in direct OAuth mode)
+
+In `REDMINE_AUTH_MODE=oauth-proxy`, the authorization-server metadata describes FastMCP's OAuthProxy endpoints instead.
 
 Clients should follow `WWW-Authenticate: Bearer resource_metadata="..."` headers from 401 responses (RFC 9728 §5.3) rather than guessing paths. If a client hardcodes the dropped variants, update the client; we don't plan to restore aliases.

--- a/src/redmine_mcp_server/_auth.py
+++ b/src/redmine_mcp_server/_auth.py
@@ -16,17 +16,156 @@ introspect tokens issued to user-flow OAuth apps (stock Redmine sets
 this to ``false`` and must be patched). See docs/oauth-setup.md Step 2.
 """
 
-import os
-
 from fastmcp.server.auth import RemoteAuthProvider
 from fastmcp.server.auth.providers.introspection import IntrospectionTokenVerifier
+from mcp.server.auth.handlers.metadata import MetadataHandler
+from mcp.server.auth.routes import cors_middleware
+from mcp.shared.auth import OAuthMetadata
 from pydantic import AnyHttpUrl
+from starlette.requests import Request
+from starlette.responses import JSONResponse
+from starlette.routing import Route
+import httpx
+import logging
+import os
+from urllib.parse import urlparse
 
 from ._env import require_introspection_credentials
 from .oauth_scopes import advertised_scopes
 
+logger = logging.getLogger(__name__)
 
-def build_remote_auth() -> RemoteAuthProvider:
+
+class RedmineAuthProvider(RemoteAuthProvider):
+    """Remote auth provider plus Redmine-specific OAuth helper routes."""
+
+    def __init__(
+        self,
+        *,
+        redmine_url: AnyHttpUrl,
+        base_url: str,
+        introspect_client_id: str,
+        introspect_client_secret: str,
+        scopes_supported: list[str],
+    ):
+        self.redmine_url = redmine_url
+        verifier = IntrospectionTokenVerifier(
+            introspection_url=str(self.redmine_endpoint("/oauth/introspect")),
+            client_id=introspect_client_id,
+            client_secret=introspect_client_secret,
+            # required_scopes is intentionally unset: today we advertise scopes
+            # but do not gate tool calls on them. Per-tool scope enforcement is
+            # a follow-up roadmap item.
+        )
+
+        super().__init__(
+            token_verifier=verifier,
+            authorization_servers=[redmine_url],
+            base_url=base_url,
+            scopes_supported=scopes_supported,
+            resource_name="Redmine MCP Server",
+        )
+
+    def redmine_endpoint(self, path: str) -> AnyHttpUrl:
+        """Build a Redmine OAuth endpoint URL from the configured Redmine URL."""
+        return AnyHttpUrl(
+            f"{str(AnyHttpUrl(self.redmine_url)).rstrip('/')}/{path.lstrip('/')}"
+        )
+
+    async def oauth_authorization_server(self, request: Request):
+        """RFC 8414 authorization-server metadata for Redmine Doorkeeper."""
+        metadata = OAuthMetadata(
+            issuer=self.redmine_url,
+            authorization_endpoint=self.redmine_endpoint("/oauth/authorize"),
+            token_endpoint=self.redmine_endpoint("/oauth/token"),
+            revocation_endpoint=self.redmine_endpoint("/oauth/revoke"),
+            response_types_supported=["code"],
+            grant_types_supported=[
+                "authorization_code",
+                "refresh_token",
+            ],
+            code_challenge_methods_supported=["S256"],
+            token_endpoint_auth_methods_supported=[
+                "client_secret_post",
+                "client_secret_basic",
+            ],
+            scopes_supported=self._scopes_supported,
+        )
+        return await MetadataHandler(metadata).handle(request)
+
+    async def revoke_token(self, request: Request):
+        """Proxy RFC 7009 token revocation to Redmine's Doorkeeper endpoint."""
+        token = None
+
+        auth_header = request.headers.get("Authorization", "")
+        if auth_header.startswith("Bearer "):
+            token = auth_header.removeprefix("Bearer ").strip()
+
+        if not token:
+            content_type = request.headers.get("Content-Type", "")
+            if "application/json" in content_type:
+                try:
+                    body = await request.json()
+                    token = body.get("token")
+                except Exception:
+                    pass
+            else:
+                try:
+                    form = await request.form()
+                    token = form.get("token")
+                except Exception:
+                    pass
+
+        if not token:
+            return JSONResponse(
+                status_code=400,
+                content={
+                    "error": "invalid_request",
+                    "error_description": "No token provided",
+                },
+            )
+
+        async with httpx.AsyncClient() as client:
+            try:
+                response = await client.post(
+                    str(self.redmine_endpoint("/oauth/revoke")),
+                    data={"token": token},
+                    timeout=10,
+                )
+            except httpx.RequestError as e:
+                logger.error(f"Failed to reach Redmine for token revocation: {e}")
+                return JSONResponse(
+                    status_code=502,
+                    content={"error": "upstream_unavailable"},
+                )
+
+        if response.status_code not in (200, 204):
+            logger.warning(
+                f"Redmine revocation returned {response.status_code}: "
+                f"{response.text}"
+            )
+
+        return JSONResponse(status_code=200, content={"success": True})
+
+    def get_routes(self, mcp_path: str | None = None) -> list[Route]:
+        routes = super().get_routes(mcp_path)
+        base_path = urlparse(str(self.base_url)).path.rstrip("/")
+        metadata_path = f"{base_path}{mcp_path or ''}"
+
+        routes.append(
+            Route(
+                f"/.well-known/oauth-authorization-server{metadata_path}",
+                endpoint=cors_middleware(
+                    self.oauth_authorization_server, ["GET", "OPTIONS"]
+                ),
+                methods=["GET", "OPTIONS"],
+            )
+        )
+        routes.append(Route("/revoke", self.revoke_token, methods=["POST"]))
+        return routes
+
+
+def build_remote_auth() -> RedmineAuthProvider:
     """Construct the RemoteAuthProvider for OAuth-mode startup.
 
     Raises RuntimeError if required env vars are missing — let the server
@@ -43,19 +182,10 @@ def build_remote_auth() -> RemoteAuthProvider:
 
     client_id, client_secret = require_introspection_credentials()
 
-    verifier = IntrospectionTokenVerifier(
-        introspection_url=f"{redmine_url}/oauth/introspect",
-        client_id=client_id,
-        client_secret=client_secret,
-        # required_scopes is intentionally unset: today we advertise scopes
-        # but do not gate tool calls on them. Per-tool scope enforcement is
-        # a follow-up roadmap item.
-    )
-
-    return RemoteAuthProvider(
-        token_verifier=verifier,
-        authorization_servers=[AnyHttpUrl(redmine_url)],
+    return RedmineAuthProvider(
+        redmine_url=AnyHttpUrl(redmine_url),
         base_url=base_url,
+        introspect_client_id=client_id,
+        introspect_client_secret=client_secret,
         scopes_supported=advertised_scopes(),
-        resource_name="Redmine MCP Server",
     )

--- a/src/redmine_mcp_server/_client.py
+++ b/src/redmine_mcp_server/_client.py
@@ -52,8 +52,9 @@ REDMINE_USERNAME = os.getenv("REDMINE_USERNAME")
 REDMINE_PASSWORD = os.getenv("REDMINE_PASSWORD")
 REDMINE_API_KEY = os.getenv("REDMINE_API_KEY")
 
-# Auth mode: "oauth" uses per-request Bearer tokens via OAuth middleware;
-# "legacy" uses REDMINE_API_KEY or REDMINE_USERNAME/REDMINE_PASSWORD (default).
+# Auth mode:
+# - "oauth" and "oauth-proxy" use per-request Bearer tokens via FastMCP auth.
+# - "legacy" uses REDMINE_API_KEY or REDMINE_USERNAME/REDMINE_PASSWORD (default).
 REDMINE_AUTH_MODE = os.getenv("REDMINE_AUTH_MODE", "legacy").lower()
 
 # SSL Configuration (optional)
@@ -98,13 +99,13 @@ if not REDMINE_URL:
         "REDMINE_URL not set. "
         "Please create a .env file in your working directory with REDMINE_URL defined."
     )
-elif REDMINE_AUTH_MODE != "oauth" and not (
+elif REDMINE_AUTH_MODE not in {"oauth", "oauth-proxy"} and not (
     REDMINE_API_KEY or (REDMINE_USERNAME and REDMINE_PASSWORD)
 ):
     logger.warning(
         "No Redmine authentication configured. "
         "Please set REDMINE_API_KEY or REDMINE_USERNAME/REDMINE_PASSWORD "
-        "in your .env file, or set REDMINE_AUTH_MODE=oauth."
+        "in your .env file, or set REDMINE_AUTH_MODE=oauth or oauth-proxy."
     )
 
 
@@ -153,8 +154,8 @@ def _build_legacy_client() -> Redmine:
     else:
         raise RuntimeError(
             "No Redmine authentication available. "
-            "Set REDMINE_AUTH_MODE=oauth or configure REDMINE_API_KEY / "
-            "REDMINE_USERNAME+REDMINE_PASSWORD."
+            "Set REDMINE_AUTH_MODE=oauth or oauth-proxy, or configure "
+            "REDMINE_API_KEY / REDMINE_USERNAME+REDMINE_PASSWORD."
         )
 
 

--- a/src/redmine_mcp_server/_env.py
+++ b/src/redmine_mcp_server/_env.py
@@ -1,6 +1,7 @@
 """Environment-variable accessor helpers."""
 
 import os
+from pathlib import Path
 
 
 def _is_true_env(var_name: str, default: str = "false") -> bool:
@@ -59,6 +60,51 @@ def _get_int_env(var_name: str, default: int) -> int:
         return default
 
 
+def get_secret(var_name: str) -> str | None:
+    """Return a secret from an env var or Docker/Kubernetes-style file env var."""
+    value = os.getenv(var_name)
+    if value:
+        return value
+
+    file_name = os.getenv(f"{var_name}_FILE")
+    if not file_name:
+        return None
+
+    return Path(file_name).read_text(encoding="utf-8").strip()
+
+
+def get_required(
+    var_name: str,
+    *,
+    error_text: str | None = None,
+) -> str:
+    """Return a required environment variable or raise a clear RuntimeError."""
+    value = os.getenv(var_name)
+    if value:
+        return value
+
+    message = f"Missing required env var: {var_name}."
+    if error_text:
+        message = f"{message} {error_text}"
+    raise RuntimeError(message)
+
+
+def get_required_secret(
+    var_name: str,
+    *,
+    error_text: str | None = None,
+) -> str:
+    """Return a required secret from env or a file env var."""
+    value = get_secret(var_name)
+    if value:
+        return value
+
+    message = f"Missing required secret env var: {var_name} or {var_name}_FILE."
+    if error_text:
+        message = f"{message} {error_text}"
+    raise RuntimeError(message)
+
+
 def get_introspection_credentials() -> tuple[str | None, str | None]:
     """Return (client_id, client_secret) for the Doorkeeper introspection client.
 
@@ -66,9 +112,10 @@ def get_introspection_credentials() -> tuple[str | None, str | None]:
     (None, None) if neither is set. Callers that need fail-fast behaviour
     should use require_introspection_credentials().
     """
-    client_id = os.getenv("REDMINE_INTROSPECT_CLIENT_ID") or None
-    client_secret = os.getenv("REDMINE_INTROSPECT_CLIENT_SECRET") or None
-    return client_id, client_secret
+    return (
+        os.getenv("REDMINE_INTROSPECT_CLIENT_ID") or None,
+        get_secret("REDMINE_INTROSPECT_CLIENT_SECRET"),
+    )
 
 
 def require_introspection_credentials() -> tuple[str, str]:
@@ -77,21 +124,16 @@ def require_introspection_credentials() -> tuple[str, str]:
     Used at OAuth-mode startup so the server fails fast instead of returning
     401 on every request.
     """
-    client_id, client_secret = get_introspection_credentials()
-    missing = []
-    if not client_id:
-        missing.append("REDMINE_INTROSPECT_CLIENT_ID")
-    if not client_secret:
-        missing.append("REDMINE_INTROSPECT_CLIENT_SECRET")
-    if missing:
-        raise RuntimeError(
-            "OAuth mode requires Doorkeeper introspection credentials. "
-            f"Missing env var(s): {', '.join(missing)}. "
-            "Register a confidential OAuth client in Redmine and configure "
-            "Doorkeeper's allow_token_introspection block to accept it "
-            "(see docs/oauth-setup.md Step 2 for the walkthrough)."
-        )
-    return client_id, client_secret
+    error_text = (
+        "OAuth mode requires Doorkeeper introspection credentials. "
+        "Register a confidential OAuth client in Redmine and configure "
+        "Doorkeeper's allow_token_introspection block to accept it "
+        "(see docs/oauth-setup.md Step 2 for the walkthrough)."
+    )
+    return (
+        get_required("REDMINE_INTROSPECT_CLIENT_ID", error_text=error_text),
+        get_required_secret("REDMINE_INTROSPECT_CLIENT_SECRET", error_text=error_text),
+    )
 
 
 def get_health_introspection_ttl_seconds() -> int:

--- a/src/redmine_mcp_server/_http_routes.py
+++ b/src/redmine_mcp_server/_http_routes.py
@@ -146,9 +146,10 @@ async def _probe_redmine_legacy() -> tuple[str, str | None]:
 async def health_check(request):
     """Health check endpoint for container orchestration and monitoring.
 
-    In OAuth mode, also probes Doorkeeper's ``/oauth/introspect`` to surface
-    upstream availability that was lost in the 503->401 collapse when
-    FastMCP native auth replaced the bespoke middleware.
+    In OAuth and OAuth proxy modes, also probes Doorkeeper's
+    ``/oauth/introspect`` to surface upstream availability that was lost in
+    the 503->401 collapse when FastMCP native auth replaced the bespoke
+    middleware.
 
     In legacy mode, probes ``GET /users/current.json`` to verify the configured
     API key (or username/password) is accepted by Redmine.
@@ -172,7 +173,7 @@ async def health_check(request):
         "auth_mode": REDMINE_AUTH_MODE,
     }
 
-    if REDMINE_AUTH_MODE == "oauth":
+    if REDMINE_AUTH_MODE in {"oauth", "oauth-proxy"}:
         probe_status, detail = await _probe_introspection()
         checks: dict = {"introspection": probe_status}
         if detail:

--- a/src/redmine_mcp_server/_mount.py
+++ b/src/redmine_mcp_server/_mount.py
@@ -1,0 +1,38 @@
+"""HTTP mount configuration for authenticated MCP deployments."""
+
+from __future__ import annotations
+
+import os
+from urllib.parse import urlparse
+
+DEFAULT_BASE_URL = "http://localhost:3040"
+DEFAULT_MCP_PATH = "/mcp"
+
+
+def _clean_url(value: str) -> str:
+    return value.rstrip("/")
+
+
+def _clean_path(value: str) -> str:
+    path = value.strip()
+    if not path:
+        return "/"
+    if not path.startswith("/"):
+        path = f"/{path}"
+    return path.rstrip("/") or "/"
+
+
+def mcp_base_url() -> str:
+    """Public base URL of the authenticated OAuth/MCP app."""
+    return _clean_url(os.getenv("REDMINE_MCP_BASE_URL", DEFAULT_BASE_URL))
+
+
+def mcp_path_for_http_app() -> str:
+    """MCP transport path inside the authenticated app."""
+    return _clean_path(os.getenv("FASTMCP_STREAMABLE_HTTP_PATH", DEFAULT_MCP_PATH))
+
+
+def mcp_mount_prefix() -> str:
+    """ASGI mount prefix derived from the public base URL path."""
+    path = urlparse(mcp_base_url()).path.rstrip("/")
+    return path or "/"

--- a/src/redmine_mcp_server/_oauth_proxy.py
+++ b/src/redmine_mcp_server/_oauth_proxy.py
@@ -1,0 +1,86 @@
+"""FastMCP OAuthProxy factory for Redmine OAuth."""
+
+from __future__ import annotations
+
+import os
+
+from fastmcp.server.auth.oauth_proxy import OAuthProxy
+from fastmcp.server.auth.providers.introspection import IntrospectionTokenVerifier
+from pydantic import AnyHttpUrl
+
+from ._env import get_required, get_required_secret, get_secret
+from .oauth_scopes import advertised_scopes
+
+INTROSPECTION_GUIDANCE = (
+    "Register a confidential OAuth client in Redmine and configure "
+    "Doorkeeper's allow_token_introspection block to accept it "
+    "(see docs/oauth-setup.md Step 2 for the walkthrough)."
+)
+
+
+def _redmine_endpoint(redmine_url: str, path: str) -> AnyHttpUrl:
+    """Build a Redmine OAuth endpoint URL from a Redmine issuer URL."""
+    return AnyHttpUrl(f"{str(AnyHttpUrl(redmine_url)).rstrip('/')}/{path.lstrip('/')}")
+
+
+def build_oauth_proxy() -> OAuthProxy:
+    """Construct FastMCP OAuthProxy for Redmine-backed OAuth."""
+    redmine_url = get_required(
+        "REDMINE_URL",
+        error_text="OAuth proxy mode requires this value. See docs/oauth-setup.md.",
+    )
+    base_url = get_required(
+        "REDMINE_MCP_BASE_URL",
+        error_text=(
+            "OAuth proxy mode requires this value. "
+            "Set it to the public MCP base URL."
+        ),
+    )
+    upstream_client_id = os.getenv("REDMINE_OAUTH_CLIENT_ID") or get_required(
+        "REDMINE_INTROSPECT_CLIENT_ID",
+        error_text=INTROSPECTION_GUIDANCE,
+    )
+    upstream_client_secret = get_secret("REDMINE_OAUTH_CLIENT_SECRET") or (
+        get_required_secret(
+            "REDMINE_INTROSPECT_CLIENT_SECRET",
+            error_text=INTROSPECTION_GUIDANCE,
+        )
+    )
+    jwt_signing_key = get_required_secret(
+        "REDMINE_MCP_JWT_SIGNING_KEY",
+        error_text=(
+            "OAuth proxy mode requires this value. FastMCP uses it to sign "
+            "proxy tokens and derive encrypted storage."
+        ),
+    )
+    introspect_client_id = get_required(
+        "REDMINE_INTROSPECT_CLIENT_ID",
+        error_text=INTROSPECTION_GUIDANCE,
+    )
+    introspect_client_secret = get_required_secret(
+        "REDMINE_INTROSPECT_CLIENT_SECRET",
+        error_text=INTROSPECTION_GUIDANCE,
+    )
+
+    verifier = IntrospectionTokenVerifier(
+        introspection_url=str(_redmine_endpoint(redmine_url, "/oauth/introspect")),
+        client_id=introspect_client_id,
+        client_secret=introspect_client_secret,
+    )
+
+    return OAuthProxy(
+        upstream_authorization_endpoint=str(
+            _redmine_endpoint(redmine_url, "/oauth/authorize")
+        ),
+        upstream_token_endpoint=str(_redmine_endpoint(redmine_url, "/oauth/token")),
+        upstream_client_id=upstream_client_id,
+        upstream_client_secret=upstream_client_secret,
+        upstream_revocation_endpoint=str(
+            _redmine_endpoint(redmine_url, "/oauth/revoke")
+        ),
+        token_verifier=verifier,
+        base_url=base_url,
+        jwt_signing_key=jwt_signing_key,
+        valid_scopes=advertised_scopes(),
+        require_authorization_consent="external",
+    )

--- a/src/redmine_mcp_server/main.py
+++ b/src/redmine_mcp_server/main.py
@@ -37,7 +37,7 @@ from ._mount import (  # noqa: E402
 logger = logging.getLogger(__name__)
 
 REDMINE_AUTH_MODE = os.environ.get("REDMINE_AUTH_MODE", "legacy").lower()
-AUTHENTICATED_AUTH_MODES = {"oauth"}
+AUTHENTICATED_AUTH_MODES = {"oauth", "oauth-proxy"}
 
 
 def get_version() -> str:

--- a/src/redmine_mcp_server/main.py
+++ b/src/redmine_mcp_server/main.py
@@ -15,11 +15,9 @@ Modules:
 import logging
 import os
 import uvicorn
-import httpx
 from importlib.metadata import version, PackageNotFoundError
-from pydantic import AnyHttpUrl
-from starlette.requests import Request
-from starlette.responses import JSONResponse
+from starlette.applications import Starlette
+from starlette.routing import Mount, Route
 
 # Configure basic logging before importing modules that log during init
 logging.basicConfig(
@@ -30,16 +28,16 @@ logging.basicConfig(
 
 from . import tools  # noqa: E402,F401  -- triggers @mcp.tool registration
 from . import _http_routes  # noqa: E402,F401  -- registers HTTP custom routes
-from .server import mcp  # noqa: E402
-from .oauth_scopes import advertised_scopes  # noqa: E402
+from .server import AUTH_PROVIDER, mcp  # noqa: E402
+from ._mount import (  # noqa: E402
+    mcp_mount_prefix,
+    mcp_path_for_http_app,
+)
 
 logger = logging.getLogger(__name__)
 
-REDMINE_URL = os.environ.get("REDMINE_URL", "").rstrip("/")
-REDMINE_MCP_BASE_URL = os.environ.get(
-    "REDMINE_MCP_BASE_URL", "http://localhost:3040"
-).rstrip("/")
 REDMINE_AUTH_MODE = os.environ.get("REDMINE_AUTH_MODE", "legacy").lower()
+AUTHENTICATED_AUTH_MODES = {"oauth"}
 
 
 def get_version() -> str:
@@ -50,141 +48,41 @@ def get_version() -> str:
         return "dev"
 
 
-# --- OAuth2 route handlers (registered conditionally) ---
+def build_authenticated_app(mcp_instance, auth_provider):
+    """Build a mounted ASGI app for authenticated modes."""
+    mcp_path = mcp_path_for_http_app()
+    mcp_app = mcp_instance.http_app(path=mcp_path, stateless_http=True)
 
-
-async def oauth_authorization_server(request: Request):
-    """RFC 8414 — Authorization Server Metadata.
-
-    Redmine uses Doorkeeper but does not serve this discovery document itself.
-    We serve it manually, pointing to Redmine's real Doorkeeper endpoints.
-
-    Env vars are read at request time (rather than module-import time) so
-    that the handler responds to runtime configuration changes and is
-    cleanly testable without module reloads.
-    """
-    redmine_url = (os.environ.get("REDMINE_URL", "") or "").rstrip("/")
-    # issuer must be byte-identical to the authorization-server identifier the
-    # protected-resource doc advertises in authorization_servers, which _auth.py
-    # builds as AnyHttpUrl(REDMINE_URL). Reuse the same normalization so a
-    # spec-strict client (RFC 8414 §3.3) treats the two as equal, including the
-    # trailing slash pydantic adds for bare hosts. Sourcing issuer from
-    # REDMINE_MCP_BASE_URL made split-host deployments advertise the MCP server
-    # as the AS (#140).
-    issuer = str(AnyHttpUrl(redmine_url)) if redmine_url else redmine_url
-    return JSONResponse(
-        {
-            "issuer": issuer,
-            "authorization_endpoint": f"{redmine_url}/oauth/authorize",
-            "token_endpoint": f"{redmine_url}/oauth/token",
-            "revocation_endpoint": f"{redmine_url}/oauth/revoke",
-            "response_types_supported": ["code"],
-            "grant_types_supported": [
-                "authorization_code",
-                "refresh_token",
-            ],
-            "code_challenge_methods_supported": ["S256"],
-            "token_endpoint_auth_methods_supported": [
-                "client_secret_post",
-                "client_secret_basic",
-            ],
-            "scopes_supported": advertised_scopes(),
-        }
+    routes = list(auth_provider.get_well_known_routes(mcp_path=mcp_path))
+    routes.extend(
+        [
+            Route("/health", _http_routes.health_check, methods=["GET"]),
+            Route(
+                "/files/{file_id}",
+                _http_routes.serve_attachment,
+                methods=["GET"],
+            ),
+            Route(
+                "/cleanup/status",
+                _http_routes.cleanup_status,
+                methods=["GET"],
+            ),
+            Mount(mcp_mount_prefix(), app=mcp_app),
+        ]
     )
+    return Starlette(routes=routes, lifespan=mcp_app.lifespan)
 
 
-async def revoke_token(request: Request):
-    """RFC 7009 — Revoke an OAuth2 access or refresh token.
+def build_app():
+    """Build the ASGI app."""
+    if REDMINE_AUTH_MODE in AUTHENTICATED_AUTH_MODES and AUTH_PROVIDER is not None:
+        return build_authenticated_app(mcp, AUTH_PROVIDER)
 
-    Proxies token revocation to Redmine's Doorkeeper /oauth/revoke endpoint.
+    return mcp.http_app(stateless_http=True)
 
-    Accepts token via:
-    - Authorization header: Bearer <token>
-    - POST body: {"token": "<token>"} or form-encoded token=<token>
-
-    Returns:
-        200 OK on success (per RFC 7009, even if token was already invalid)
-        400 Bad Request if no token provided
-        502 Bad Gateway if Redmine is unreachable
-    """
-    token = None
-
-    # Try Authorization header first
-    auth_header = request.headers.get("Authorization", "")
-    if auth_header.startswith("Bearer "):
-        token = auth_header.removeprefix("Bearer ").strip()
-
-    # Fall back to request body
-    if not token:
-        content_type = request.headers.get("Content-Type", "")
-        if "application/json" in content_type:
-            try:
-                body = await request.json()
-                token = body.get("token")
-            except Exception:
-                pass
-        else:
-            # form-encoded
-            try:
-                form = await request.form()
-                token = form.get("token")
-            except Exception:
-                pass
-
-    if not token:
-        return JSONResponse(
-            status_code=400,
-            content={
-                "error": "invalid_request",
-                "error_description": "No token provided",
-            },
-        )
-
-    # Forward revocation to Redmine's Doorkeeper endpoint. Env vars are read
-    # at request time so runtime overrides (and tests) are honoured.
-    redmine_url = (os.environ.get("REDMINE_URL", "") or "").rstrip("/")
-    async with httpx.AsyncClient() as client:
-        try:
-            response = await client.post(
-                f"{redmine_url}/oauth/revoke",
-                data={"token": token},
-                timeout=10,
-            )
-        except httpx.RequestError as e:
-            logger.error(f"Failed to reach Redmine for token revocation: {e}")
-            return JSONResponse(
-                status_code=502,
-                content={"error": "upstream_unavailable"},
-            )
-
-    # RFC 7009: return 200 regardless of whether token was valid
-    # (to prevent token scanning attacks)
-    if response.status_code in (200, 204):
-        return JSONResponse(status_code=200, content={"success": True})
-
-    # If Redmine returns an error, log but still return success per RFC 7009
-    logger.warning(
-        f"Redmine revocation returned {response.status_code}: " f"{response.text}"
-    )
-    return JSONResponse(status_code=200, content={"success": True})
-
-
-# Register the kept OAuth custom routes via FastMCP. The
-# /.well-known/oauth-protected-resource route is mounted natively by
-# RemoteAuthProvider at the suffix-scoped path
-# (/.well-known/oauth-protected-resource/mcp). The authorization-server
-# metadata mirror and /revoke remain custom_routes because
-# RemoteAuthProvider doesn't provide them. After this migration there is
-# no Starlette middleware doing auth, so custom_route no longer represents
-# the bypass surface.
-if REDMINE_AUTH_MODE == "oauth":
-    mcp.custom_route("/.well-known/oauth-authorization-server/mcp", methods=["GET"])(
-        oauth_authorization_server
-    )
-    mcp.custom_route("/revoke", methods=["POST"])(revoke_token)
 
 # Export the Starlette app for testing and external use
-app = mcp.http_app(stateless_http=True)
+app = build_app()
 
 # Log version at module load time so it appears regardless of how the server is started
 logger.info("Redmine MCP Server v%s", get_version())

--- a/src/redmine_mcp_server/server.py
+++ b/src/redmine_mcp_server/server.py
@@ -35,5 +35,7 @@ def _select_auth_provider(auth_mode: str):
     return None
 
 
-mcp = FastMCP("redmine_mcp_tools", auth=_select_auth_provider(REDMINE_AUTH_MODE))
+AUTH_PROVIDER = _select_auth_provider(REDMINE_AUTH_MODE)
+
+mcp = FastMCP("redmine_mcp_tools", auth=AUTH_PROVIDER)
 mcp.add_middleware(CleanValidationErrorMiddleware())

--- a/src/redmine_mcp_server/server.py
+++ b/src/redmine_mcp_server/server.py
@@ -8,8 +8,11 @@ Importing this module does NOT register any tools -- only `tools/__init__.py`
 
 In OAuth mode (``REDMINE_AUTH_MODE=oauth``), the FastMCP instance is
 constructed with a ``RemoteAuthProvider`` that validates Bearer tokens
-against Doorkeeper's RFC 7662 introspection endpoint. In legacy mode the
-instance is built without ``auth=`` and behaves as before.
+against Doorkeeper's RFC 7662 introspection endpoint. In OAuth proxy mode
+(``REDMINE_AUTH_MODE=oauth-proxy``), FastMCP's ``OAuthProxy`` handles client
+registration and the authorization code flow, then validates upstream Redmine
+tokens with the same introspection endpoint. In legacy mode the instance is
+built without ``auth=`` and behaves as before.
 """
 
 import os
@@ -32,6 +35,10 @@ def _select_auth_provider(auth_mode: str):
         from ._auth import build_remote_auth
 
         return build_remote_auth()
+    if auth_mode == "oauth-proxy":
+        from ._oauth_proxy import build_oauth_proxy
+
+        return build_oauth_proxy()
     return None
 
 

--- a/tests/test_env_loading.py
+++ b/tests/test_env_loading.py
@@ -31,8 +31,7 @@ class TestEnvLoading:
 
         # Create a test script that imports the module and checks the env vars
         test_script = tmp_path / "test_env_check.py"
-        test_script.write_text(
-            """
+        test_script.write_text("""
 import sys
 import os
 
@@ -46,8 +45,7 @@ from redmine_mcp_server._client import REDMINE_URL, REDMINE_API_KEY
 # Print the values for verification
 print(f"REDMINE_URL={REDMINE_URL}")
 print(f"REDMINE_API_KEY={REDMINE_API_KEY}")
-"""
-        )
+""")
 
         # Run the test script from the temp directory (simulating user's project)
         result = subprocess.run(
@@ -80,8 +78,7 @@ print(f"REDMINE_API_KEY={REDMINE_API_KEY}")
 
         # Create a test script that imports the module
         test_script = tmp_path / "test_warning.py"
-        test_script.write_text(
-            """
+        test_script.write_text("""
 import sys
 import os
 
@@ -91,8 +88,7 @@ for key in ['REDMINE_URL', 'REDMINE_API_KEY', 'REDMINE_USERNAME', 'REDMINE_PASSW
 
 # Import the module which triggers env loading and warnings
 from redmine_mcp_server import _client as redmine_handler
-"""
-        )
+""")
 
         result = subprocess.run(
             [sys.executable, str(test_script)],
@@ -119,8 +115,7 @@ from redmine_mcp_server import _client as redmine_handler
         env_file.write_text("REDMINE_URL=http://example.com\n")
 
         test_script = tmp_path / "test_auth_warning.py"
-        test_script.write_text(
-            """
+        test_script.write_text("""
 import sys
 import os
 
@@ -129,8 +124,7 @@ for key in ['REDMINE_URL', 'REDMINE_API_KEY', 'REDMINE_USERNAME', 'REDMINE_PASSW
     os.environ.pop(key, None)
 
 from redmine_mcp_server import _client as redmine_handler
-"""
-        )
+""")
 
         result = subprocess.run(
             [sys.executable, str(test_script)],
@@ -168,8 +162,7 @@ from redmine_mcp_server import _client as redmine_handler
         env_file.write_text(f"REDMINE_URL={cwd_url}\n" f"REDMINE_API_KEY=cwd_key\n")
 
         test_script = tmp_path / "test_precedence.py"
-        test_script.write_text(
-            """
+        test_script.write_text("""
 import os
 
 # Clear any existing env vars
@@ -178,8 +171,7 @@ for key in ['REDMINE_URL', 'REDMINE_API_KEY', 'REDMINE_USERNAME', 'REDMINE_PASSW
 
 from redmine_mcp_server._client import REDMINE_URL
 print(f"REDMINE_URL={REDMINE_URL}")
-"""
-        )
+""")
 
         result = subprocess.run(
             [sys.executable, str(test_script)],
@@ -242,6 +234,23 @@ class TestOAuthIntrospectionEnv:
             "client-secret-y",
         )
 
+    def test_get_introspection_credentials_reads_secret_file(
+        self, monkeypatch, tmp_path
+    ):
+        secret_file = tmp_path / "introspection-secret"
+        secret_file.write_text("client-secret-from-file\n", encoding="utf-8")
+        monkeypatch.setenv("REDMINE_INTROSPECT_CLIENT_ID", "client-id-x")
+        monkeypatch.delenv("REDMINE_INTROSPECT_CLIENT_SECRET", raising=False)
+        monkeypatch.setenv("REDMINE_INTROSPECT_CLIENT_SECRET_FILE", str(secret_file))
+        import importlib
+        from redmine_mcp_server import _env
+
+        importlib.reload(_env)
+        assert _env.get_introspection_credentials() == (
+            "client-id-x",
+            "client-secret-from-file",
+        )
+
     def test_require_introspection_credentials_raises_when_missing(self, monkeypatch):
         monkeypatch.delenv("REDMINE_INTROSPECT_CLIENT_ID", raising=False)
         monkeypatch.delenv("REDMINE_INTROSPECT_CLIENT_SECRET", raising=False)
@@ -252,6 +261,26 @@ class TestOAuthIntrospectionEnv:
         importlib.reload(_env)
         with pytest.raises(RuntimeError, match="REDMINE_INTROSPECT_CLIENT_ID"):
             _env.require_introspection_credentials()
+
+    def test_get_required_secret_reads_secret_file(self, monkeypatch, tmp_path):
+        secret_file = tmp_path / "secret"
+        secret_file.write_text("from-file\n", encoding="utf-8")
+        monkeypatch.delenv("REDMINE_MCP_JWT_SIGNING_KEY", raising=False)
+        monkeypatch.setenv("REDMINE_MCP_JWT_SIGNING_KEY_FILE", str(secret_file))
+
+        from redmine_mcp_server import _env
+
+        assert _env.get_required_secret("REDMINE_MCP_JWT_SIGNING_KEY") == "from-file"
+
+    def test_get_required_secret_raises_when_missing(self, monkeypatch):
+        monkeypatch.delenv("REDMINE_MCP_JWT_SIGNING_KEY", raising=False)
+        monkeypatch.delenv("REDMINE_MCP_JWT_SIGNING_KEY_FILE", raising=False)
+
+        import pytest
+        from redmine_mcp_server import _env
+
+        with pytest.raises(RuntimeError, match="REDMINE_MCP_JWT_SIGNING_KEY"):
+            _env.get_required_secret("REDMINE_MCP_JWT_SIGNING_KEY")
 
     def test_health_introspection_ttl_default(self, monkeypatch):
         monkeypatch.delenv("HEALTH_INTROSPECTION_TTL_SECONDS", raising=False)

--- a/tests/test_health_probe.py
+++ b/tests/test_health_probe.py
@@ -110,6 +110,57 @@ async def test_oauth_mode_unreachable_probe_returns_degraded(oauth_env):
 
 @pytest.mark.unit
 @pytest.mark.asyncio
+async def test_oauth_proxy_mode_uses_introspection_probe(oauth_env):
+    """OAuth proxy mode validates Redmine reachability through introspection."""
+    monkeypatch_set = pytest.MonkeyPatch()
+    monkeypatch_set.setenv("REDMINE_AUTH_MODE", "oauth-proxy")
+    try:
+        from redmine_mcp_server import _client, _http_routes
+
+        importlib.reload(_client)
+        importlib.reload(_http_routes)
+        _reset_probe_cache()
+        with (
+            patch.object(
+                _http_routes,
+                "_probe_introspection",
+                AsyncMock(return_value=("ok", None)),
+            ) as introspection_probe,
+            patch.object(
+                _http_routes,
+                "_probe_redmine_legacy",
+                AsyncMock(return_value=("unreachable", "AuthError")),
+            ) as legacy_probe,
+            patch(
+                "redmine_mcp_server._cleanup._ensure_cleanup_started",
+                new_callable=AsyncMock,
+            ),
+        ):
+            from starlette.applications import Starlette
+            from starlette.routing import Route
+
+            app = Starlette(routes=[Route("/health", _http_routes.health_check)])
+            async with httpx.AsyncClient(
+                transport=httpx.ASGITransport(app=app), base_url="http://t"
+            ) as client:
+                r = await client.get("/health")
+        assert r.status_code == 200
+        body = r.json()
+        assert body["status"] == "ok"
+        assert body["auth_mode"] == "oauth-proxy"
+        assert body["checks"]["introspection"] == "ok"
+        introspection_probe.assert_awaited_once()
+        legacy_probe.assert_not_awaited()
+    finally:
+        monkeypatch_set.undo()
+        from redmine_mcp_server import _client, _http_routes
+
+        importlib.reload(_client)
+        importlib.reload(_http_routes)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
 async def test_legacy_mode_probes_redmine_not_introspection():
     """Legacy mode runs a Redmine connectivity probe instead of OAuth introspection.
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -117,6 +117,21 @@ class TestAuthWiring:
         provider = _select_auth_provider("oauth")
         assert isinstance(provider, RemoteAuthProvider)
 
+    def test_oauth_proxy_mode_returns_oauth_proxy(self, monkeypatch, tmp_path):
+        from fastmcp import settings
+        from fastmcp.server.auth.oauth_proxy import OAuthProxy
+
+        monkeypatch.setenv("REDMINE_URL", "https://r.example.com")
+        monkeypatch.setenv("REDMINE_MCP_BASE_URL", "https://mcp.example.com")
+        monkeypatch.setenv("REDMINE_INTROSPECT_CLIENT_ID", "cid")
+        monkeypatch.setenv("REDMINE_INTROSPECT_CLIENT_SECRET", "csec")
+        monkeypatch.setenv("REDMINE_MCP_JWT_SIGNING_KEY", "stable-test-signing-key")
+        monkeypatch.setattr(settings, "home", tmp_path)
+        from redmine_mcp_server.server import _select_auth_provider
+
+        provider = _select_auth_provider("oauth-proxy")
+        assert isinstance(provider, OAuthProxy)
+
     def test_legacy_mode_returns_none(self):
         from redmine_mcp_server.server import _select_auth_provider
 

--- a/tests/test_oauth_auth.py
+++ b/tests/test_oauth_auth.py
@@ -31,11 +31,9 @@ def _build_test_app(introspect_handler):
     ``introspect_handler`` is a callable taking an ``httpx.Request`` and
     returning an ``httpx.Response`` that simulates Doorkeeper's /oauth/introspect.
     """
-    from redmine_mcp_server import _auth, oauth_scopes
-    from redmine_mcp_server import main as main_mod
+    from redmine_mcp_server import oauth_scopes
 
     importlib.reload(oauth_scopes)
-    importlib.reload(_auth)
 
     mock_transport = httpx.MockTransport(introspect_handler)
     mock_client = httpx.AsyncClient(transport=mock_transport)
@@ -54,9 +52,6 @@ def _build_test_app(introspect_handler):
         resource_name="Redmine MCP Server",
     )
     local_mcp = FastMCP("oauth_auth_test", auth=provider)
-    local_mcp.custom_route(
-        "/.well-known/oauth-authorization-server/mcp", methods=["GET"]
-    )(main_mod.oauth_authorization_server)
     return local_mcp.http_app(stateless_http=True)
 
 

--- a/tests/test_oauth_discovery.py
+++ b/tests/test_oauth_discovery.py
@@ -28,19 +28,12 @@ def oauth_app(monkeypatch):
     monkeypatch.delenv("REDMINE_MCP_READ_ONLY", raising=False)
 
     from redmine_mcp_server import _auth, oauth_scopes
-    from redmine_mcp_server import main as main_mod
 
     importlib.reload(oauth_scopes)
     importlib.reload(_auth)
 
     auth_provider = _auth.build_remote_auth()
     local_mcp = FastMCP("redmine_mcp_tools_test", auth=auth_provider)
-
-    # Mirror main.py: register kept custom_routes
-    local_mcp.custom_route(
-        "/.well-known/oauth-authorization-server/mcp", methods=["GET"]
-    )(main_mod.oauth_authorization_server)
-    local_mcp.custom_route("/revoke", methods=["POST"])(main_mod.revoke_token)
 
     return local_mcp.http_app(stateless_http=True)
 
@@ -113,16 +106,12 @@ async def test_scope_sources_filtered_consistently_in_read_only_mode(monkeypatch
     monkeypatch.setenv("REDMINE_MCP_READ_ONLY", "true")
 
     from redmine_mcp_server import _auth, oauth_scopes
-    from redmine_mcp_server import main as main_mod
 
     importlib.reload(oauth_scopes)
     importlib.reload(_auth)
 
     auth_provider = _auth.build_remote_auth()
     local_mcp = FastMCP("ro_test", auth=auth_provider)
-    local_mcp.custom_route(
-        "/.well-known/oauth-authorization-server/mcp", methods=["GET"]
-    )(main_mod.oauth_authorization_server)
     app = local_mcp.http_app(stateless_http=True)
 
     from redmine_mcp_server.oauth_scopes import WRITE_SCOPES
@@ -164,3 +153,38 @@ async def test_issuer_matches_authorization_servers(oauth_app):
     # ...and that server is Redmine, not the MCP server's own base URL
     assert "r.example.com" in asm["issuer"]
     assert "localhost:3040" not in asm["issuer"]
+
+
+@pytest.mark.asyncio
+async def test_authenticated_app_mounts_remote_auth_under_base_url_path(monkeypatch):
+    monkeypatch.setenv("REDMINE_URL", "https://r.example.com")
+    monkeypatch.setenv("REDMINE_MCP_BASE_URL", "https://mcp.example/api")
+    monkeypatch.setenv("FASTMCP_STREAMABLE_HTTP_PATH", "/mcp")
+    monkeypatch.setenv("REDMINE_INTROSPECT_CLIENT_ID", "cid")
+    monkeypatch.setenv("REDMINE_INTROSPECT_CLIENT_SECRET", "csec")
+    monkeypatch.delenv("REDMINE_MCP_READ_ONLY", raising=False)
+
+    from redmine_mcp_server import _auth, oauth_scopes
+    from redmine_mcp_server import main as main_mod
+
+    importlib.reload(oauth_scopes)
+    importlib.reload(_auth)
+
+    auth_provider = _auth.build_remote_auth()
+    local_mcp = FastMCP("remote_auth_mount_test", auth=auth_provider)
+    app = main_mod.build_authenticated_app(local_mcp, auth_provider)
+
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="https://mcp.example"
+    ) as client:
+        root_prm = await client.get("/.well-known/oauth-protected-resource")
+        prm = await client.get("/.well-known/oauth-protected-resource/api/mcp")
+        asm = await client.get("/.well-known/oauth-authorization-server/api/mcp")
+        mounted_prm = await client.get("/api/mcp/.well-known/oauth-protected-resource")
+        mcp_get = await client.get("/api/mcp")
+
+    assert root_prm.status_code == 404
+    assert prm.status_code == 200
+    assert asm.status_code == 200
+    assert mounted_prm.status_code == 404
+    assert mcp_get.status_code == 405

--- a/tests/test_oauth_proxy.py
+++ b/tests/test_oauth_proxy.py
@@ -1,0 +1,118 @@
+import httpx
+import pytest
+from fastmcp import FastMCP, settings
+from fastmcp.server.auth.oauth_proxy import OAuthProxy
+from fastmcp.server.auth.providers.introspection import IntrospectionTokenVerifier
+
+from redmine_mcp_server._oauth_proxy import build_oauth_proxy
+
+
+def test_build_oauth_proxy_uses_introspection_verifier(monkeypatch, tmp_path):
+    monkeypatch.setenv("REDMINE_URL", "https://redmine.example")
+    monkeypatch.setenv("REDMINE_MCP_BASE_URL", "https://mcp.example")
+    monkeypatch.setenv("REDMINE_INTROSPECT_CLIENT_ID", "introspect-client")
+    monkeypatch.setenv("REDMINE_INTROSPECT_CLIENT_SECRET", "introspect-secret")
+    monkeypatch.setenv("REDMINE_MCP_JWT_SIGNING_KEY", "stable-test-signing-key")
+    monkeypatch.setattr(settings, "home", tmp_path)
+
+    proxy = build_oauth_proxy()
+
+    assert isinstance(proxy, OAuthProxy)
+    assert isinstance(proxy._token_validator, IntrospectionTokenVerifier)
+    assert proxy._require_authorization_consent == "external"
+    assert proxy._token_validator.introspection_url == (
+        "https://redmine.example/oauth/introspect"
+    )
+
+
+@pytest.mark.asyncio
+async def test_authenticated_app_mounts_oauth_proxy_under_mcp(monkeypatch, tmp_path):
+    monkeypatch.setenv("REDMINE_URL", "https://redmine.example")
+    monkeypatch.setenv("REDMINE_MCP_BASE_URL", "https://mcp.example")
+    monkeypatch.setenv("FASTMCP_STREAMABLE_HTTP_PATH", "/mcp")
+    monkeypatch.setenv("REDMINE_INTROSPECT_CLIENT_ID", "introspect-client")
+    monkeypatch.setenv("REDMINE_INTROSPECT_CLIENT_SECRET", "introspect-secret")
+    monkeypatch.setenv("REDMINE_MCP_JWT_SIGNING_KEY", "stable-test-signing-key")
+    monkeypatch.setattr(settings, "home", tmp_path)
+
+    from redmine_mcp_server.main import build_authenticated_app
+
+    auth = build_oauth_proxy()
+    app = build_authenticated_app(FastMCP("oauth_proxy_test", auth=auth), auth)
+
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="https://mcp.example"
+    ) as client:
+        root_as = await client.get("/.well-known/oauth-authorization-server")
+        resource_as = await client.get("/.well-known/oauth-authorization-server/mcp")
+        prm = await client.get("/.well-known/oauth-protected-resource/mcp")
+        mounted_prm = await client.get("/mcp/.well-known/oauth-protected-resource")
+        authorize = await client.get("/authorize")
+        register = await client.post("/register", json={})
+        mcp_get = await client.get("/mcp")
+        mcp_post = await client.post("/mcp", json={})
+
+    assert root_as.status_code == 200
+    assert resource_as.status_code == 404
+    assert prm.status_code == 200
+    assert mounted_prm.status_code == 404
+    assert authorize.status_code != 404
+    assert register.status_code != 404
+    assert mcp_get.status_code == 405
+    assert mcp_post.status_code == 401
+
+    as_body = root_as.json()
+    prm_body = prm.json()
+    assert as_body["issuer"] == "https://mcp.example/"
+    assert as_body["authorization_endpoint"] == "https://mcp.example/authorize"
+    assert as_body["token_endpoint"] == "https://mcp.example/token"
+    assert as_body["registration_endpoint"] == "https://mcp.example/register"
+    assert prm_body["authorization_servers"] == ["https://mcp.example/"]
+    assert (
+        'resource_metadata="https://mcp.example/.well-known/oauth-protected-resource/mcp'
+        in mcp_post.headers["www-authenticate"]
+    )
+
+
+@pytest.mark.asyncio
+async def test_authenticated_app_derives_mount_prefix_from_base_url(
+    monkeypatch, tmp_path
+):
+    monkeypatch.setenv("REDMINE_URL", "https://redmine.example")
+    monkeypatch.setenv("REDMINE_MCP_BASE_URL", "https://mcp.example/api")
+    monkeypatch.setenv("FASTMCP_STREAMABLE_HTTP_PATH", "/mcp")
+    monkeypatch.setenv("REDMINE_INTROSPECT_CLIENT_ID", "introspect-client")
+    monkeypatch.setenv("REDMINE_INTROSPECT_CLIENT_SECRET", "introspect-secret")
+    monkeypatch.setenv("REDMINE_MCP_JWT_SIGNING_KEY", "stable-test-signing-key")
+    monkeypatch.setattr(settings, "home", tmp_path)
+
+    from redmine_mcp_server.main import build_authenticated_app
+
+    auth = build_oauth_proxy()
+    app = build_authenticated_app(FastMCP("oauth_proxy_test", auth=auth), auth)
+
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="https://mcp.example"
+    ) as client:
+        root_as = await client.get("/.well-known/oauth-authorization-server")
+        scoped_as = await client.get("/.well-known/oauth-authorization-server/api")
+        resource_scoped_as = await client.get(
+            "/.well-known/oauth-authorization-server/api/mcp"
+        )
+        prm = await client.get("/.well-known/oauth-protected-resource/api/mcp")
+        authorize = await client.get("/api/authorize")
+        register = await client.post("/api/register", json={})
+        mcp_post = await client.post("/api/mcp", json={})
+
+    assert root_as.status_code == 404
+    assert scoped_as.status_code == 200
+    assert resource_scoped_as.status_code == 404
+    assert prm.status_code == 200
+    assert authorize.status_code != 404
+    assert register.status_code != 404
+    assert mcp_post.status_code == 401
+    assert scoped_as.json()["issuer"] == "https://mcp.example/api"
+    assert (
+        'resource_metadata="https://mcp.example/.well-known/oauth-protected-resource/api/mcp'
+        in mcp_post.headers["www-authenticate"]
+    )


### PR DESCRIPTION
## Summary

Adds an opt-in `oauth-proxy` auth mode backed by FastMCP's `OAuthProxy`.
In this mode the MCP server is the OAuth-facing authorization server for MCP
clients, while Redmine/Doorkeeper remains the upstream OAuth provider.

This covers clients that require Dynamic Client Registration or CIMD, without
requiring Redmine/Doorkeeper to serve RFC 8414 metadata or implement DCR.

## What changed

- Adds shared env helpers with `*_FILE` support for secrets.
- Refactors the existing Redmine remote OAuth setup into `RedmineAuthProvider`.
- Adds `REDMINE_AUTH_MODE=oauth-proxy`.
- Uses Redmine `/oauth/authorize`, `/oauth/token`, `/oauth/revoke`, and
  `/oauth/introspect` behind FastMCP `OAuthProxy`.
- Keeps consent external with `require_authorization_consent="external"` so
  Redmine remains the visible user consent point.
- Supports mounting behind a public base path through `REDMINE_MCP_BASE_URL`.
- Updates `/health` so both `oauth` and `oauth-proxy` probe Redmine
  introspection.
- Documents setup, env vars, and storage behavior.

## Validation

- `uv run --extra test python -m pytest tests/test_env_loading.py tests/test_oauth_proxy.py tests/test_oauth_discovery.py tests/test_auth_factory.py tests/test_health_probe.py tests/test_main.py tests/test_oauth_auth.py`
- `uv run --extra dev black --check src/ tests/test_env_loading.py tests/test_oauth_proxy.py tests/test_health_probe.py --line-length=88`
- `uv run --extra dev flake8 src/ --max-line-length=88`
- End-to-end smoke tested in a private Redmine 6 OAuth deployment with:
  - Codex CLI
  - Claude Desktop through `mcp-remote`
  - `mcp-remote`
  - `fastmcp-remote`

## Notes

This PR intentionally keeps `oauth-proxy` opt-in. Existing `legacy` and `oauth`
deployments should continue to use their current paths unless operators switch
`REDMINE_AUTH_MODE`.
