### PR TITLE
Fix run_tests.py --all to actually run integration tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Secret `*_FILE` env vars (for example `REDMINE_MCP_JWT_SIGNING_KEY_FILE`) now raise a clear error naming the variable and path when the referenced file cannot be read, instead of surfacing a bare `FileNotFoundError`. `docs/oauth-setup.md` also notes that when the upstream `oauth-proxy` client falls back to the introspection client, that client must have the authorization code grant and the `/auth/callback` redirect URI configured.
 
+### Fixed
+- `python tests/run_tests.py --all` now actually runs the integration suite. The test hermeticity guard introduced in 2.2.0 blanks `REDMINE_*` environment variables for any run that is not an explicit `-m integration` invocation, so the single unmarked `--all` command was treated as a unit run and silently skipped every integration test. `--all` now runs the unit phase (`-m "not integration"`) and the integration phase (`-m integration`) as two separate pytest processes so each gets the correct environment; integration coverage is appended. ([#156](https://github.com/jztan/redmine-mcp-server/pull/156))
+
 ### Contributors
 - @aadnehovda, designed and implemented the `oauth-proxy` authentication mode backed by FastMCP `OAuthProxy`, and refactored the remote OAuth setup into `RedmineAuthProvider` ([#153](https://github.com/jztan/redmine-mcp-server/pull/153))
 

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -21,50 +21,28 @@ import sys
 import os
 
 
-def run_tests(test_type="unit", specific_file=None, coverage=False, verbose=False):
-    """Run tests based on the specified type."""
+def _run_pytest(selector, coverage=False, verbose=False, append_cov=False):
+    """Run a single pytest invocation with the given selector args.
 
-    # Base pytest command
+    ``selector`` is the list of marker/path args (e.g.
+    ``["-m", "not integration", "tests/"]``). Returns the pytest exit code.
+    """
     cmd = ["python", "-m", "pytest"]
+    cmd.append("-v" if verbose else "-q")
 
-    # Add verbosity
-    if verbose:
-        cmd.append("-v")
-    else:
-        cmd.append("-q")
-
-    # Add coverage if requested
     if coverage:
-        cmd.extend(
-            ["--cov=src/redmine_mcp_server", "--cov-report=html", "--cov-report=term"]
-        )
+        cmd.append("--cov=src/redmine_mcp_server")
+        # When accumulating across more than one invocation (e.g. --all),
+        # append to the existing data instead of overwriting it.
+        cmd.append("--cov-append" if append_cov else "--cov-report=html")
+        cmd.append("--cov-report=term")
 
-    # Determine what tests to run
-    if specific_file:
-        # Run specific test file
-        test_file = (
-            f"tests/{specific_file}"
-            if not specific_file.startswith("tests/")
-            else specific_file
-        )
-        cmd.append(test_file)
-    elif test_type == "unit":
-        # Run unit tests (exclude integration marker)
-        cmd.extend(["-m", "not integration", "tests/"])
-    elif test_type == "integration":
-        # Run integration tests only
-        cmd.extend(["-m", "integration", "tests/"])
-    elif test_type == "all":
-        # Run all tests
-        cmd.append("tests/")
-
-    # Add test output formatting
+    cmd.extend(selector)
     cmd.extend(["--tb=short"])
 
     print(f"Running command: {' '.join(cmd)}")
     print("-" * 60)
 
-    # Run the tests
     try:
         result = subprocess.run(
             cmd,
@@ -76,6 +54,40 @@ def run_tests(test_type="unit", specific_file=None, coverage=False, verbose=Fals
     except Exception as e:
         print(f"Error running tests: {e}")
         return 1
+
+
+def run_tests(test_type="unit", specific_file=None, coverage=False, verbose=False):
+    """Run tests based on the specified type."""
+
+    if specific_file:
+        test_file = (
+            f"tests/{specific_file}"
+            if not specific_file.startswith("tests/")
+            else specific_file
+        )
+        return _run_pytest([test_file], coverage, verbose)
+
+    if test_type == "unit":
+        return _run_pytest(["-m", "not integration", "tests/"], coverage, verbose)
+
+    if test_type == "integration":
+        return _run_pytest(["-m", "integration", "tests/"], coverage, verbose)
+
+    if test_type == "all":
+        # Run unit and integration as two separate pytest processes rather than
+        # one unmarked run. conftest.py neutralizes a developer's local .env for
+        # unit runs (so leaked REDMINE_* credentials don't break hermetic tests)
+        # but leaves it intact for an explicit `-m integration` run. A single
+        # unmarked invocation would be treated as non-integration and blank the
+        # env, silently skipping every integration test. Splitting the run lets
+        # each phase get the right environment.
+        rc_unit = _run_pytest(["-m", "not integration", "tests/"], coverage, verbose)
+        rc_integration = _run_pytest(
+            ["-m", "integration", "tests/"], coverage, verbose, append_cov=True
+        )
+        return rc_unit or rc_integration
+
+    return 1
 
 
 def check_dependencies():


### PR DESCRIPTION
## Problem

Since the conftest hermeticity guard added in v2.2.0, `python tests/run_tests.py --all` **silently skipped every integration test** with "REDMINE_URL not configured".

The guard in `tests/conftest.py` neutralizes a developer's local `.env` (blanks `REDMINE_*`) for any run that is **not** an explicit `-m integration` invocation, so leaked credentials don't break the hermetic unit tests. `--all` ran a single unmarked `pytest tests/`, which the guard treated as non-integration and blanked, so the live-Redmine integration suite never executed.

This only affects local runs, but integration tests are **never run in CI** (`pr-tests.yml` and `publish-pypi.yml` both run `-m "not integration"` only), so `--all` was the main way to exercise them, and it was quietly skipping all of them.

## Fix

`--all` now runs two separate pytest processes instead of one unmarked run:

1. `-m "not integration" tests/` (hermetic; the guard blanks the env)
2. `-m integration tests/` (the guard leaves the real `.env` intact)

Each phase gets the right environment via the existing conftest logic, with no per-test changes. Coverage from the integration phase is appended (`--cov-append`) so `--all --coverage` reports both. `--all` returns non-zero if either phase fails.

## Validation

Local `python tests/run_tests.py --all` now runs both phases:
- Unit: 1304 passed (hermetic)
- Integration: 80 passed, 5 skipped (live local Redmine; skips are RedmineUP Agile + destructive OAuth, gated on their own env flags)