### PR TITLE
docs(contributing): refresh architecture for the oauth-proxy auth mode

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -101,17 +101,19 @@ Cross-cutting utilities live as flat private modules:
 
 | Module | Responsibility |
 |---|---|
-| `_client.py` | Redmine connection (legacy + OAuth), module-level config, logger |
+| `_client.py` | Redmine connection (legacy, `oauth`, and `oauth-proxy`), module-level config, logger |
 | `_errors.py` | `_handle_redmine_error`, `_scrub_error_message`, `_READ_ONLY_ERROR` |
 | `_validation.py` | Input validators (`_is_positive_int`, `_is_valid_project_id`, `_validate_hours`) |
 | `_serialization.py` | `wrap_insecure_content`, `_safe_isoformat`, `_iter_capped`, `_named_ref`, `_coerce_json_safe` |
-| `_env.py` | Environment-flag accessors (`_is_read_only_mode`, `_is_*_enabled`, `require_introspection_credentials`, `get_health_introspection_ttl_seconds`) |
+| `_env.py` | Environment accessors: read-only / plugin flags (`_is_read_only_mode`, `_is_*_enabled`), secret resolution with Docker/Kubernetes `*_FILE` support (`get_secret`, `get_required`, `get_required_secret`), `require_introspection_credentials`, `get_allowed_client_redirect_uris` (oauth-proxy redirect-URI allowlist), `get_health_introspection_ttl_seconds` |
 | `_custom_fields.py` | Custom-field parsing, autofill, and update coercion |
 | `_ssrf.py` | SSRF protection for `upload_file`'s `source_url` |
 | `_cleanup.py` | Background cleanup task |
-| `_http_routes.py` | Starlette routes (`/health` with Doorkeeper introspection probe in OAuth mode and a Redmine credential probe in legacy mode, `/files/{id}`, `/cleanup/status`) |
+| `_http_routes.py` | Starlette routes (`/health` with a Doorkeeper introspection probe in `oauth` / `oauth-proxy` modes and a Redmine credential probe in legacy mode, `/files/{id}`, `/cleanup/status`) |
 | `_decorators.py` | `@action_dispatch` decorator + `ActionMode` enum |
-| `_auth.py` | `build_remote_auth()` factory: composes `IntrospectionTokenVerifier` (RFC 7662) into a `RemoteAuthProvider` for FastMCP v3 native auth (OAuth mode only). |
+| `_auth.py` | `RedmineAuthProvider` (a `RemoteAuthProvider` subclass) and its `build_remote_auth()` factory: composes `IntrospectionTokenVerifier` (RFC 7662) and adds the RFC 8414 AS-metadata mirror plus the RFC 7009 `/revoke` route. Used by `oauth` mode. |
+| `_oauth_proxy.py` | `build_oauth_proxy()` factory: a FastMCP `OAuthProxy` backed by `IntrospectionTokenVerifier`, proxying `/authorize`, `/token`, and `/revoke` to Doorkeeper with external consent and a loopback-default redirect-URI allowlist. Used by `oauth-proxy` mode. |
+| `_mount.py` | Public base-URL helpers (`mcp_base_url`, `mcp_path_for_http_app`, `mcp_mount_prefix`) for serving the authenticated app behind `REDMINE_MCP_BASE_URL`. |
 | `_tool_error_middleware.py` | FastMCP middleware that surfaces tool-validation errors with a clean payload. |
 | `oauth_scopes.py` | `READ_SCOPES` / `WRITE_SCOPES` inventory + `advertised_scopes()` used by both the protected-resource and AS-metadata discovery documents. |
 
@@ -571,11 +573,13 @@ See [RELEASE_SOP.md](../RELEASE_SOP.md) for complete release procedures.
 ```
 redmine-mcp-server/
 ├── src/redmine_mcp_server/
-│   ├── main.py              # FastMCP entry point + OAuth discovery custom_routes
-│   ├── server.py            # Owns the shared `mcp = FastMCP(...)` instance with native auth wiring
+│   ├── main.py              # Entry point; build_authenticated_app() mounts the MCP app + discovery routes (oauth / oauth-proxy)
+│   ├── server.py            # Owns the shared `mcp = FastMCP(...)` instance; _select_auth_provider() picks the auth provider
 │   ├── tools/               # 13 per-resource tool modules (45 MCP tools + 1 admin-gated)
-│   ├── _auth.py             # RemoteAuthProvider + IntrospectionTokenVerifier factory (OAuth mode)
-│   ├── _client.py           # Redmine connection (legacy + OAuth per-request via get_access_token())
+│   ├── _auth.py             # RedmineAuthProvider (introspection + AS-metadata + revoke), oauth mode
+│   ├── _oauth_proxy.py      # OAuthProxy factory (DCR + authorize/token/revoke proxy), oauth-proxy mode
+│   ├── _mount.py            # Public base-URL / MCP-path / mount-prefix helpers
+│   ├── _client.py           # Redmine connection (legacy singleton; per-request bearer for oauth / oauth-proxy)
 │   ├── _errors.py           # Exception → user-friendly dict
 │   ├── _validation.py       # Input validators
 │   ├── _serialization.py    # Serializer helpers + `wrap_insecure_content`
@@ -602,16 +606,17 @@ redmine-mcp-server/
 
 ### Core Components
 
-- **`main.py`**: Entry point. Builds the Starlette app via `mcp.http_app()`, registers OAuth discovery + `/revoke` `custom_route` handlers (when `REDMINE_AUTH_MODE=oauth`), and triggers tool registration via `from . import tools`. No Starlette middleware is added — auth lives inside FastMCP via the `auth=` constructor parameter.
-- **`server.py`**: Owns the shared `mcp = FastMCP("redmine_mcp_tools", auth=...)` instance imported by every tool module. The `_select_auth_provider(auth_mode)` helper returns `RemoteAuthProvider(...)` in OAuth mode and `None` in legacy mode.
-- **`_auth.py`**: Builds the FastMCP v3 native auth provider. `build_remote_auth()` returns a `RemoteAuthProvider` composed of `IntrospectionTokenVerifier` (RFC 7662 against Doorkeeper's `/oauth/introspect`) plus advertised scopes from `oauth_scopes.py`. Reads `REDMINE_INTROSPECT_CLIENT_ID` / `_SECRET` via `_env.require_introspection_credentials()` (fail-fast on startup).
+- **`main.py`**: Entry point. In an authenticated mode (`oauth` or `oauth-proxy`), `build_authenticated_app()` mounts the FastMCP app under the `REDMINE_MCP_BASE_URL` path prefix and adds the provider's `get_well_known_routes()` (discovery) plus `/health`, `/files`, `/cleanup/status`; in legacy mode it returns `mcp.http_app(stateless_http=True)`. Tool registration is triggered via `from . import tools`. No Starlette middleware is added; auth lives inside FastMCP via the `auth=` constructor parameter.
+- **`server.py`**: Owns the shared `mcp = FastMCP("redmine_mcp_tools", auth=...)` instance imported by every tool module. `_select_auth_provider(auth_mode)` returns `build_remote_auth()` (a `RedmineAuthProvider`) for `oauth`, `build_oauth_proxy()` (a FastMCP `OAuthProxy`) for `oauth-proxy`, and `None` for legacy.
+- **`_auth.py`** (`oauth` mode): `build_remote_auth()` returns a `RedmineAuthProvider`, a `RemoteAuthProvider` subclass that composes `IntrospectionTokenVerifier` (RFC 7662 against Doorkeeper's `/oauth/introspect`) and additionally serves the RFC 8414 AS-metadata mirror and the RFC 7009 `/revoke` route. Reads `REDMINE_INTROSPECT_CLIENT_ID` / `_SECRET` via `_env.require_introspection_credentials()` (fail-fast on startup).
+- **`_oauth_proxy.py`** (`oauth-proxy` mode): `build_oauth_proxy()` returns a FastMCP `OAuthProxy` that makes the MCP server the OAuth authorization server for clients (DCR + `/authorize` / `/token` / `/register`) and proxies upstream to Redmine/Doorkeeper, validating tokens with the same `IntrospectionTokenVerifier`. Keeps consent external (`require_authorization_consent="external"`), requires `REDMINE_MCP_JWT_SIGNING_KEY`, and restricts client redirect URIs to loopback by default (`get_allowed_client_redirect_uris()`).
 - **`tools/`**: Per-resource tool modules. Each file owns its `@mcp.tool()` definitions and resource-specific serializers (`_X_to_dict` helpers). See [Where things live](#where-things-live) earlier in this guide for the full table.
-- **Flat `_X.py` modules**: Cross-cutting helpers (`_client`, `_errors`, `_validation`, `_serialization`, `_env`, `_custom_fields`, `_ssrf`, `_cleanup`, `_http_routes`, `_decorators`, `_auth`, `_tool_error_middleware`). See [Where things live](#where-things-live) for responsibilities.
-- **`_client.py`**: In OAuth mode, builds a per-request `Redmine(...)` from the bearer returned by `fastmcp.server.dependencies.get_access_token()`. In legacy mode, caches a singleton built from `REDMINE_API_KEY` or `REDMINE_USERNAME`/`REDMINE_PASSWORD`. (Pre-v2.1: validated tokens via `GET /users/current.json` through a custom `ContextVar`-based middleware; both removed in the v2.1 native-auth migration.)
+- **Flat `_X.py` modules**: Cross-cutting helpers (`_client`, `_errors`, `_validation`, `_serialization`, `_env`, `_custom_fields`, `_ssrf`, `_cleanup`, `_http_routes`, `_decorators`, `_auth`, `_oauth_proxy`, `_mount`, `_tool_error_middleware`). See [Where things live](#where-things-live) for responsibilities.
+- **`_client.py`**: In `oauth` and `oauth-proxy` modes, builds a per-request `Redmine(...)` from the bearer returned by `fastmcp.server.dependencies.get_access_token()`. In legacy mode, caches a singleton built from `REDMINE_API_KEY` or `REDMINE_USERNAME`/`REDMINE_PASSWORD`. (Pre-v2.1: validated tokens via `GET /users/current.json` through a custom `ContextVar`-based middleware; both removed in the v2.1 native-auth migration.)
 - **`oauth_scopes.py`**: Single source of truth for `scopes_supported` in the protected-resource and AS-metadata discovery documents. Filters `WRITE_SCOPES` out when `REDMINE_MCP_READ_ONLY=true`.
 - **`file_manager.py`**: Attachment file storage manager (UUID-based files + metadata.json with expiry).
 
-This layout was introduced in v2.0 (replacing the previous monolithic `redmine_handler.py`) and updated in v2.1 (auth moved from `oauth_middleware.py` to native FastMCP `auth=` via `_auth.py`).
+This layout was introduced in v2.0 (replacing the previous monolithic `redmine_handler.py`), updated in v2.1 (auth moved from `oauth_middleware.py` to native FastMCP `auth=` via `_auth.py`), and extended in v2.3 with the `oauth-proxy` mode (`_oauth_proxy.py`, `_mount.py`, and the `RemoteAuthProvider` → `RedmineAuthProvider` refactor).
 
 ### Key Technologies
 


### PR DESCRIPTION
## Summary

`docs/contributing.md`'s architecture section predated the `oauth-proxy` work (#153 never touched it), so it described an OAuth-mode-only `RemoteAuthProvider` path and omitted the new modules. Brought it in line with the current code (verified against `server.py`, `_auth.py`, `_oauth_proxy.py`, `_mount.py`, `main.py`):

- **Module inventory + tree:** add `_oauth_proxy.py` and `_mount.py`.
- **`_auth.py`:** corrected from "`RemoteAuthProvider` factory (OAuth mode only)" to the `RedmineAuthProvider` subclass that adds the RFC 8414 AS-metadata mirror and RFC 7009 `/revoke` route.
- **`server.py` / `_select_auth_provider`:** documents the `oauth-proxy` → `build_oauth_proxy()` → `OAuthProxy` branch (was `RemoteAuthProvider`/`None` only).
- **`main.py`:** updated to `build_authenticated_app()` mounting under `REDMINE_MCP_BASE_URL` with provider `get_well_known_routes()` (was "OAuth discovery custom_routes").
- **`_env.py`:** added the `get_secret` / `get_required` / `get_required_secret` (`*_FILE` support) and `get_allowed_client_redirect_uris` helpers.
- **`_http_routes.py` / `_client.py`:** note both `oauth` and `oauth-proxy` modes.
- **Provenance note:** records the v2.3 `oauth-proxy` extension.

Docs-only; developer-facing.