### PR TITLE
fix(issues): include journal details (field changes) in get_redmine_issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Promotional demo page under `pages/`, deployed to GitHub Pages on version tags via a new `deploy-demo.yml` workflow. It is a scripted, client-side walkthrough of an AI agent triaging a sample Redmine sprint backlog (list, read, reassign, comment, log time, close), with tool-call request/response JSON that matches the server's real response shapes, a Kanban board that updates as the agent works, and a light/dark theme toggle. No live Redmine is connected.
 
+### Fixed
+- `get_redmine_issue` now returns journal field-change `details` (status, assignee, custom-field edits) and no longer drops journals that have no note text. The `_journals_to_list` helper previously skipped any journal whose `notes` was empty via `if not notes: continue` and never serialized the `details` array, so field-only history was lost and `details` was missing even on journals with notes. Journals are now kept when they have a note **or** field-change details, and each entry includes `details` (`property`, `name`, `old_value`, `new_value`) plus `private_notes`. `get_private_notes` exposes `details` as well. ([#161](https://github.com/jztan/redmine-mcp-server/issues/161))
+
 ## [2.3.1] - 2026-06-20
 ### Security
 - Bump `python-multipart` 0.0.29 to 0.0.32 to clear CVE-2026-53539 and CVE-2026-53538 (both fixed upstream in 0.0.30). The direct floor in `pyproject.toml` is also raised from `>=0.0.27` to `>=0.0.30` so the fix reaches PyPI installs, not only the pinned lockfile. ([#150](https://github.com/jztan/redmine-mcp-server/pull/150))

--- a/src/redmine_mcp_server/tools/issues.py
+++ b/src/redmine_mcp_server/tools/issues.py
@@ -320,6 +320,30 @@ def _issue_to_dict_selective(
     return {key: all_fields[key] for key in fields if key in all_fields}
 
 
+def _journal_details_to_list(journal: Any) -> List[Dict[str, Any]]:
+    """Convert a journal's raw ``details`` (list of dicts) to a serializable list.
+
+    python-redmine exposes journal field-changes as plain dicts with keys
+    ``property``, ``name``, ``old_value`` and ``new_value``. The ``getattr``
+    fallback defends against the library ever wrapping the items in objects.
+    """
+    raw = getattr(journal, "details", None)
+    if not raw:
+        return []
+    details: List[Dict[str, Any]] = []
+    try:
+        iterator = iter(raw)
+    except TypeError:
+        return []
+    keys = ("property", "name", "old_value", "new_value")
+    for d in iterator:
+        if isinstance(d, dict):
+            details.append({k: d.get(k) for k in keys})
+        else:
+            details.append({k: getattr(d, k, None) for k in keys})
+    return details
+
+
 def _journals_to_list(issue: Any) -> List[Dict[str, Any]]:
     """Convert journals on an issue object to a list of dicts."""
     raw_journals = getattr(issue, "journals", None)
@@ -334,7 +358,10 @@ def _journals_to_list(issue: Any) -> List[Dict[str, Any]]:
 
     for journal in iterator:
         notes = getattr(journal, "notes", "")
-        if not notes:
+        details = _journal_details_to_list(journal)
+        # Keep journals that have a note OR field-change details. Entries with
+        # neither carry no information and are skipped.
+        if not notes and not details:
             continue
         user = getattr(journal, "user", None)
         journals.append(
@@ -348,8 +375,10 @@ def _journals_to_list(issue: Any) -> List[Dict[str, Any]]:
                     if user is not None
                     else None
                 ),
-                "notes": wrap_insecure_content(notes),
+                "notes": wrap_insecure_content(notes) if notes else "",
                 "created_on": _safe_isoformat(getattr(journal, "created_on", None)),
+                "private_notes": bool(getattr(journal, "private_notes", False)),
+                "details": details,
             }
         )
     return journals
@@ -413,6 +442,7 @@ def _journal_to_dict(journal: Any, include_private_flag: bool = True) -> Dict[st
         ),
         "notes": wrap_insecure_content(notes) if notes else "",
         "created_on": _safe_isoformat(getattr(journal, "created_on", None)),
+        "details": _journal_details_to_list(journal),
     }
     if include_private_flag:
         entry["private_notes"] = bool(getattr(journal, "private_notes", False))

--- a/tests/test_redmine_handler.py
+++ b/tests/test_redmine_handler.py
@@ -1370,32 +1370,115 @@ class TestHelperFunctionEdgeCases:
         result = _journals_to_list(mock_issue)
         assert result == []
 
-    def test_journals_to_list_empty_notes_filtered(self):
-        """_journals_to_list filters empty notes (line 695-696)."""
+    def test_journals_to_list_empty_notes_no_details_filtered(self):
+        """_journals_to_list filters journals with no notes AND no details."""
         from redmine_mcp_server.tools.issues import _journals_to_list
 
         mock_issue = Mock()
         mock_journal = Mock()
         mock_journal.notes = ""  # Empty notes
+        mock_journal.details = []  # No field-change details either
         mock_journal.id = 1
         mock_issue.journals = [mock_journal]
         result = _journals_to_list(mock_issue)
-        assert result == []  # Filtered out
+        assert result == []  # Filtered out (no information to surface)
 
-    def test_journals_to_list_whitespace_notes_filtered(self):
-        """Test _journals_to_list filters journals with whitespace-only notes."""
+    def test_journals_to_list_empty_notes_with_details_kept(self):
+        """_journals_to_list keeps note-less journals that carry field changes."""
         from redmine_mcp_server.tools.issues import _journals_to_list
 
         mock_issue = Mock()
         mock_journal = Mock()
-        mock_journal.notes = "   "  # Whitespace only - still falsy when stripped
+        mock_journal.notes = ""
+        mock_journal.id = 34166
+        mock_journal.user = None
+        mock_journal.private_notes = False
+        mock_journal.details = [
+            {
+                "property": "attr",
+                "name": "status_id",
+                "old_value": "1",
+                "new_value": "22",
+            }
+        ]
+        mock_issue.journals = [mock_journal]
+        result = _journals_to_list(mock_issue)
+        assert len(result) == 1
+        assert result[0]["id"] == 34166
+        assert result[0]["notes"] == ""
+        assert result[0]["details"] == [
+            {
+                "property": "attr",
+                "name": "status_id",
+                "old_value": "1",
+                "new_value": "22",
+            }
+        ]
+
+    def test_journals_to_list_custom_field_change_kept(self):
+        """Regression for issue 6823: note-less journal with a cf change is kept."""
+        from redmine_mcp_server.tools.issues import _journals_to_list
+
+        mock_issue = Mock()
+        mock_journal = Mock()
+        mock_journal.notes = ""
+        mock_journal.id = 34182
+        mock_journal.user = None
+        mock_journal.private_notes = False
+        mock_journal.details = [
+            {
+                "property": "cf",
+                "name": "101",
+                "old_value": "",
+                "new_value": "Error ABAP",
+            }
+        ]
+        mock_issue.journals = [mock_journal]
+        result = _journals_to_list(mock_issue)
+        assert len(result) == 1
+        assert result[0]["details"][0]["property"] == "cf"
+        assert result[0]["details"][0]["new_value"] == "Error ABAP"
+
+    def test_journals_to_list_whitespace_notes_kept(self):
+        """Test _journals_to_list keeps journals with whitespace-only notes."""
+        from redmine_mcp_server.tools.issues import _journals_to_list
+
+        mock_issue = Mock()
+        mock_journal = Mock()
+        mock_journal.notes = "   "  # Whitespace only - truthy
+        mock_journal.details = []
         mock_journal.id = 1
         mock_issue.journals = [mock_journal]
-        # Note: The code uses `if not notes:` which won't filter whitespace
-        # but empty string will be filtered
         result = _journals_to_list(mock_issue)
         # Whitespace is truthy, so it won't be filtered
         assert len(result) == 1
+
+    def test_journal_details_to_list_variants(self):
+        """_journal_details_to_list maps dicts and tolerates missing details."""
+        from redmine_mcp_server.tools.issues import _journal_details_to_list
+
+        journal = Mock()
+        journal.details = [
+            {
+                "property": "attr",
+                "name": "assigned_to_id",
+                "old_value": None,
+                "new_value": "143",
+            }
+        ]
+        result = _journal_details_to_list(journal)
+        assert result == [
+            {
+                "property": "attr",
+                "name": "assigned_to_id",
+                "old_value": None,
+                "new_value": "143",
+            }
+        ]
+
+        no_details = Mock()
+        no_details.details = None
+        assert _journal_details_to_list(no_details) == []
 
     def test_attachments_to_list_none_attachments(self):
         """Test _attachments_to_list with None attachments (line 723-724)."""


### PR DESCRIPTION
## Problem

`get_redmine_issue` does not return **journal details** — the audit trail of
attribute and custom-field changes (`status_id`, `assigned_to_id`, custom
fields, etc.). Note-less journals that only record field changes are dropped
from the response entirely.

Example — an issue with field-only history (`/issues/{id}.json?include=journals`)
has journals with `notes: ""` whose actual changes live in `details[]`. Those
journals were missing from the MCP response.

## Root cause

In `src/redmine_mcp_server/tools/issues.py`, `_journals_to_list()`:

1. `if not notes: continue` discarded every journal without a note, even when
   it carried field-change `details`.
2. The serialized dict never extracted `details` (nor `private_notes`).

The API request itself is already correct (`include=journals` is passed).

## Changes

- **New helper `_journal_details_to_list()`** — normalizes a journal's
  `details` into `{property, name, old_value, new_value}`. python-redmine
  exposes these as plain dicts (verified against the library), with a defensive
  `getattr` fallback for object-wrapped items.
- **`_journals_to_list()`** — now keeps a journal if it has a note **or**
  details, and includes `details` and `private_notes` on each entry. Empty
  notes are serialized as `""` instead of being passed to
  `wrap_insecure_content`.
- **`_journal_to_dict()`** (used by `get_private_notes`) — also exposes
  `details`, for consistency.
- **Tests** — updated the empty-notes tests and added coverage for the exact
  reported case (a journal with `details` but empty `notes`), a custom-field
  change regression, and the new helper.
- **CHANGELOG.md** — entry under `## [Unreleased] → Fixed`.

## Verification

- `pytest -k "journal or Journal" tests/test_redmine_handler.py tests/test_issue_tracking_tools.py tests/test_prompt_injection.py` → all pass.
- `flake8 src/ --max-line-length=88` and `black --check src/ --line-length=88` → clean.
- End-to-end simulation through the real code path returns both journals, each
  with its full `details` array (`status_id`, `assigned_to_id`, and a custom
  field change).

Closes #161