### PR TITLE
feat(issues): expand full-issue serializer with standard fields (#174)

### DIFF
--- a/src/redmine_mcp_server/tools/issues.py
+++ b/src/redmine_mcp_server/tools/issues.py
@@ -238,12 +238,9 @@ def _issue_to_dict(issue: Any, include_custom_fields: bool = False) -> Dict[str,
             if assigned is not None
             else None
         ),
-        # Standard fields returned by Redmine's default issue JSON. These carry
-        # workflow state clients routinely need (release targeting via
-        # fixed_version, categorization, scheduling dates, progress and effort)
-        # and are already present on the python-redmine object, so no extra
-        # HTTP request is needed. The sibling gantt serializer already exposed
-        # a subset of these; see GitHub issue #174.
+        # Standard fields returned by Redmine's default issue JSON.
+        # The sibling gantt serializer already exposes a subset of these.
+        # see GitHub issue #174.
         "category": (
             {"id": category.id, "name": category.name} if category is not None else None
         ),

--- a/src/redmine_mcp_server/tools/issues.py
+++ b/src/redmine_mcp_server/tools/issues.py
@@ -207,6 +207,9 @@ def _issue_to_dict(issue: Any, include_custom_fields: bool = False) -> Dict[str,
     priority = getattr(issue, "priority", None)
     author = getattr(issue, "author", None)
     tracker = getattr(issue, "tracker", None)
+    category = getattr(issue, "category", None)
+    fixed_version = getattr(issue, "fixed_version", None)
+    parent = getattr(issue, "parent", None)
 
     issue_dict = {
         "id": getattr(issue, "id", None),
@@ -235,6 +238,28 @@ def _issue_to_dict(issue: Any, include_custom_fields: bool = False) -> Dict[str,
             if assigned is not None
             else None
         ),
+        # Standard fields returned by Redmine's default issue JSON. These carry
+        # workflow state clients routinely need (release targeting via
+        # fixed_version, categorization, scheduling dates, progress and effort)
+        # and are already present on the python-redmine object, so no extra
+        # HTTP request is needed. The sibling gantt serializer already exposed
+        # a subset of these; see GitHub issue #174.
+        "category": (
+            {"id": category.id, "name": category.name} if category is not None else None
+        ),
+        "fixed_version": (
+            {"id": fixed_version.id, "name": fixed_version.name}
+            if fixed_version is not None
+            else None
+        ),
+        "parent": ({"id": parent.id} if parent is not None else None),
+        "start_date": _safe_isoformat(getattr(issue, "start_date", None)),
+        "due_date": _safe_isoformat(getattr(issue, "due_date", None)),
+        "done_ratio": getattr(issue, "done_ratio", None),
+        "estimated_hours": getattr(issue, "estimated_hours", None),
+        "spent_hours": getattr(issue, "spent_hours", None),
+        "is_private": getattr(issue, "is_private", None),
+        "closed_on": _safe_isoformat(getattr(issue, "closed_on", None)),
         "created_on": _safe_isoformat(getattr(issue, "created_on", None)),
         "updated_on": _safe_isoformat(getattr(issue, "updated_on", None)),
     }
@@ -266,6 +291,16 @@ def _issue_to_dict_selective(
         - tracker: Tracker/type info (dict with id and name, or None)
         - author: Author info (dict with id and name)
         - assigned_to: Assigned user info (dict with id and name, or None)
+        - category: Issue category (dict with id and name, or None)
+        - fixed_version: Target version (dict with id and name, or None)
+        - parent: Parent issue (dict with id, or None)
+        - start_date: Scheduled start date (ISO format, or None)
+        - due_date: Scheduled due date (ISO format, or None)
+        - done_ratio: Completion percentage (int, or None)
+        - estimated_hours: Estimated effort in hours (float, or None)
+        - spent_hours: Logged effort in hours (float, or None)
+        - is_private: Whether the issue is private (bool, or None)
+        - closed_on: Closure timestamp (ISO format, or None)
         - created_on: Creation timestamp (ISO format)
         - updated_on: Last update timestamp (ISO format)
 
@@ -294,6 +329,9 @@ def _issue_to_dict_selective(
     priority = getattr(issue, "priority", None)
     author = getattr(issue, "author", None)
     tracker = getattr(issue, "tracker", None)
+    category = getattr(issue, "category", None)
+    fixed_version = getattr(issue, "fixed_version", None)
+    parent = getattr(issue, "parent", None)
 
     all_fields = {
         "id": getattr(issue, "id", None),
@@ -322,6 +360,22 @@ def _issue_to_dict_selective(
             if assigned is not None
             else None
         ),
+        "category": (
+            {"id": category.id, "name": category.name} if category is not None else None
+        ),
+        "fixed_version": (
+            {"id": fixed_version.id, "name": fixed_version.name}
+            if fixed_version is not None
+            else None
+        ),
+        "parent": ({"id": parent.id} if parent is not None else None),
+        "start_date": _safe_isoformat(getattr(issue, "start_date", None)),
+        "due_date": _safe_isoformat(getattr(issue, "due_date", None)),
+        "done_ratio": getattr(issue, "done_ratio", None),
+        "estimated_hours": getattr(issue, "estimated_hours", None),
+        "spent_hours": getattr(issue, "spent_hours", None),
+        "is_private": getattr(issue, "is_private", None),
+        "closed_on": _safe_isoformat(getattr(issue, "closed_on", None)),
         "created_on": _safe_isoformat(getattr(issue, "created_on", None)),
         "updated_on": _safe_isoformat(getattr(issue, "updated_on", None)),
     }
@@ -541,7 +595,11 @@ async def get_redmine_issue(
             ``journal_limit``). Defaults to ``0``.
 
     Returns:
-        A dictionary containing issue details. If ``include_journals`` is ``True``
+        A dictionary containing issue details, including the standard fields
+        ``category``, ``fixed_version`` (target version), ``parent``,
+        ``start_date``, ``due_date``, ``done_ratio``, ``estimated_hours``,
+        ``spent_hours``, ``is_private`` and ``closed_on`` (each ``None`` when
+        not set on the issue). If ``include_journals`` is ``True``
         and the issue has journals, they will be returned under the ``"journals"``
         key. If ``include_attachments`` is ``True`` and attachments exist they
         will be returned under the ``"attachments"`` key. On failure a dictionary

--- a/tests/test_issue_to_dict_selective.py
+++ b/tests/test_issue_to_dict_selective.py
@@ -67,6 +67,32 @@ class TestIssueToDictSelective:
         mock_tracker.name = "Bug"
         mock_issue.tracker = mock_tracker
 
+        # Mock category
+        mock_category = Mock()
+        mock_category.id = 5
+        mock_category.name = "Backend"
+        mock_issue.category = mock_category
+
+        # Mock fixed_version (target version)
+        mock_version = Mock()
+        mock_version.id = 6
+        mock_version.name = "v2.0"
+        mock_issue.fixed_version = mock_version
+
+        # Mock parent
+        mock_parent = Mock()
+        mock_parent.id = 100
+        mock_issue.parent = mock_parent
+
+        # Scheduling / progress / effort fields
+        mock_issue.start_date = datetime(2024, 1, 10, 0, 0, 0)
+        mock_issue.due_date = datetime(2024, 1, 20, 0, 0, 0)
+        mock_issue.done_ratio = 40
+        mock_issue.estimated_hours = 8.0
+        mock_issue.spent_hours = 3.5
+        mock_issue.is_private = False
+        mock_issue.closed_on = None
+
         # Mock timestamps
         mock_issue.created_on = datetime(2024, 1, 15, 10, 30, 0)
         mock_issue.updated_on = datetime(2024, 1, 16, 14, 45, 0)
@@ -104,6 +130,18 @@ class TestIssueToDictSelective:
         # No assigned_to (None)
         mock_issue.assigned_to = None
 
+        # Optional standard fields all unset
+        mock_issue.category = None
+        mock_issue.fixed_version = None
+        mock_issue.parent = None
+        mock_issue.start_date = None
+        mock_issue.due_date = None
+        mock_issue.done_ratio = None
+        mock_issue.estimated_hours = None
+        mock_issue.spent_hours = None
+        mock_issue.is_private = None
+        mock_issue.closed_on = None
+
         # No timestamps
         mock_issue.created_on = None
         mock_issue.updated_on = None
@@ -116,7 +154,7 @@ class TestIssueToDictSelective:
         expected = _issue_to_dict(mock_issue)
 
         assert set(result.keys()) == set(expected.keys())
-        assert len(result) == 11  # All 11 fields
+        assert len(result) == 21  # All fields
         assert "id" in result
         assert "subject" in result
         assert "description" in result
@@ -127,7 +165,7 @@ class TestIssueToDictSelective:
         expected = _issue_to_dict(mock_issue)
 
         assert set(result.keys()) == set(expected.keys())
-        assert len(result) == 11
+        assert len(result) == 21
 
     def test_all_keyword_returns_all_fields(self, mock_issue):
         """Test that fields=["all"] returns all fields."""
@@ -135,7 +173,7 @@ class TestIssueToDictSelective:
         expected = _issue_to_dict(mock_issue)
 
         assert set(result.keys()) == set(expected.keys())
-        assert len(result) == 11
+        assert len(result) == 21
 
     def test_single_field_id(self, mock_issue):
         """Test selecting only the id field."""
@@ -238,6 +276,16 @@ class TestIssueToDictSelective:
             "tracker",
             "author",
             "assigned_to",
+            "category",
+            "fixed_version",
+            "parent",
+            "start_date",
+            "due_date",
+            "done_ratio",
+            "estimated_hours",
+            "spent_hours",
+            "is_private",
+            "closed_on",
             "created_on",
             "updated_on",
         ]
@@ -245,7 +293,52 @@ class TestIssueToDictSelective:
         expected = _issue_to_dict(mock_issue)
 
         assert set(result.keys()) == set(expected.keys())
-        assert len(result) == 11
+        assert len(result) == 21
+
+    def test_standard_fields_populated(self, mock_issue):
+        """Standard fields from issue #174 are serialized when present."""
+        result = _issue_to_dict(mock_issue)
+
+        assert result["category"] == {"id": 5, "name": "Backend"}
+        assert result["fixed_version"] == {"id": 6, "name": "v2.0"}
+        assert result["parent"] == {"id": 100}
+        assert result["start_date"] == "2024-01-10T00:00:00"
+        assert result["due_date"] == "2024-01-20T00:00:00"
+        assert result["done_ratio"] == 40
+        assert result["estimated_hours"] == 8.0
+        assert result["spent_hours"] == 3.5
+        assert result["is_private"] is False
+        assert result["closed_on"] is None
+
+    def test_standard_fields_none_when_absent(self, mock_issue_minimal):
+        """Reference/date fields degrade to None rather than raising."""
+        result = _issue_to_dict(mock_issue_minimal)
+
+        for key in (
+            "category",
+            "fixed_version",
+            "parent",
+            "start_date",
+            "due_date",
+            "done_ratio",
+            "estimated_hours",
+            "spent_hours",
+            "is_private",
+            "closed_on",
+        ):
+            assert result[key] is None
+
+    def test_select_standard_field_subset(self, mock_issue):
+        """The new fields are individually selectable via field selection."""
+        result = _issue_to_dict_selective(
+            mock_issue, ["id", "fixed_version", "done_ratio"]
+        )
+
+        assert result == {
+            "id": 123,
+            "fixed_version": {"id": 6, "name": "v2.0"},
+            "done_ratio": 40,
+        }
 
     def test_invalid_field_name_ignored(self, mock_issue):
         """Test that invalid field names are silently ignored."""
@@ -344,7 +437,7 @@ class TestIssueToDictSelective:
         # Minimal should have fewer keys
         assert len(minimal_fields_result) < len(all_fields_result)
         assert len(minimal_fields_result) == 2
-        assert len(all_fields_result) == 11
+        assert len(all_fields_result) == 21
 
     def test_case_sensitive_field_names(self, mock_issue):
         """Test that field names are case-sensitive."""

--- a/tests/test_search_field_selection.py
+++ b/tests/test_search_field_selection.py
@@ -62,6 +62,24 @@ class TestSearchFieldSelection:
         mock_assigned.name = "Jane Smith"
         mock_issue.assigned_to = mock_assigned
 
+        # Mock tracker
+        mock_tracker = Mock()
+        mock_tracker.id = 4
+        mock_tracker.name = "Bug"
+        mock_issue.tracker = mock_tracker
+
+        # Standard fields (issue #174) left unset
+        mock_issue.category = None
+        mock_issue.fixed_version = None
+        mock_issue.parent = None
+        mock_issue.start_date = None
+        mock_issue.due_date = None
+        mock_issue.done_ratio = None
+        mock_issue.estimated_hours = None
+        mock_issue.spent_hours = None
+        mock_issue.is_private = None
+        mock_issue.closed_on = None
+
         # Mock timestamps
         mock_issue.created_on = None
         mock_issue.updated_on = None
@@ -76,10 +94,10 @@ class TestSearchFieldSelection:
 
         result = await search_redmine_issues("bug")
 
-        # Should return all 11 fields
+        # Should return all fields
         assert isinstance(result, list)
         assert len(result) == 1
-        assert len(result[0]) == 11
+        assert len(result[0]) == 21
         assert "id" in result[0]
         assert "subject" in result[0]
         assert "description" in result[0]
@@ -152,7 +170,7 @@ class TestSearchFieldSelection:
         # Minimal should have fewer keys per issue
         assert len(result_minimal[0]) < len(result_all[0])
         assert len(result_minimal[0]) == 2  # Only id and subject
-        assert len(result_all[0]) == 11  # All fields
+        assert len(result_all[0]) == 21  # All fields
 
     @pytest.mark.asyncio
     async def test_fields_asterisk_returns_all(self, mock_redmine):
@@ -162,7 +180,7 @@ class TestSearchFieldSelection:
 
         result = await search_redmine_issues("bug", fields=["*"])
 
-        assert len(result[0]) == 11  # All fields
+        assert len(result[0]) == 21  # All fields
 
     @pytest.mark.asyncio
     async def test_fields_all_keyword(self, mock_redmine):
@@ -172,7 +190,7 @@ class TestSearchFieldSelection:
 
         result = await search_redmine_issues("bug", fields=["all"])
 
-        assert len(result[0]) == 11  # All fields
+        assert len(result[0]) == 21  # All fields
 
     @pytest.mark.asyncio
     async def test_fields_invalid_ignored(self, mock_redmine):
@@ -262,7 +280,7 @@ class TestSearchFieldSelection:
         result = await search_redmine_issues("bug", limit=25)
 
         # Should return all fields (backward compatible)
-        assert len(result[0]) == 11
+        assert len(result[0]) == 21
 
     @pytest.mark.asyncio
     async def test_fields_with_explicit_params(self, mock_redmine):


### PR DESCRIPTION
## Summary

Fixes #174.

`get_redmine_issue` advertises "full context", but its `_issue_to_dict` serializer dropped several core fields that Redmine's default issue JSON already returns — forcing clients to fall back to the raw REST API for triage and scheduling. The sibling `_gantt_issue_to_dict` serializer already exposed a subset (dates, estimated hours, parent), so the dedicated full-issue tool ironically returned *fewer* fields than the gantt tool.

This adds the missing standard fields to `_issue_to_dict`:

- `category` — `{id, name}`
- `fixed_version` (target version) — `{id, name}`
- `parent` — `{id}` (matches Redmine's raw JSON shape)
- `start_date`, `due_date`, `closed_on` — ISO-8601 via the existing `_safe_isoformat`
- `done_ratio`, `estimated_hours`, `spent_hours`
- `is_private`

All values are already present on the python-redmine object, so **no additional HTTP request** is made. Reference fields reuse the existing `{id, name}` convention, and every field degrades to `None` when absent (search API may return sparse objects).

The same fields are mirrored in `_issue_to_dict_selective` (and its docstring) so `list_redmine_issues` / `search_redmine_issues` field selection stays consistent and these fields are individually selectable.

## Testing

- Added tests for populated values, the `None`-when-absent path, and individual field selection.
- Updated existing "all fields" count assertions (11 → 21).
- `uv run pytest -m "not integration" tests/` → **1404 passed**.
- `black --check src/` and `flake8 src/` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)