### PR TITLE
Dockerfile: respect SERVER_HOST and SERVER_PORT env vars

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,10 +59,10 @@ USER appuser
 
 # Health check
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
-    CMD curl -f http://localhost:8000/health || exit 1
+    CMD curl -f http://localhost:${SERVER_PORT:-8000}/health || exit 1
 
-# Expose port
+# Expose default port (informational only; override with SERVER_PORT env var)
 EXPOSE 8000
 
 # Default command
-CMD ["python", "-m", "uvicorn", "src.redmine_mcp_server.main:app", "--host", "0.0.0.0", "--port", "8000"]
+CMD ["redmine-mcp-server"]


### PR DESCRIPTION
The Dockerfile CMD hardcoded `--host 0.0.0.0 --port 8000` directly in the uvicorn invocation, bypassing `main()` and making `SERVER_HOST`/`SERVER_PORT` env vars completely ineffective when running the container.

Switch CMD to the installed `redmine-mcp-server` console script, which already reads both vars from the environment. Also make the HEALTHCHECK port dynamic via `${SERVER_PORT:-8000}` and update the EXPOSE comment to clarify it's a default hint only.