### PR TITLE
fix(docker): default SERVER_HOST to 0.0.0.0 for reachable container binding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   in-panel; a Refresh action re-fetches through the app-callable
   `get_project_dashboard_data` tool. Read-only.
 
+### Fixed
+- Docker container now honors `SERVER_HOST` and `SERVER_PORT`. The Dockerfile
+  `CMD` previously hardcoded `--host 0.0.0.0 --port 8000` in the uvicorn
+  invocation, bypassing `main()` and leaving both env vars ineffective in the
+  container. The `CMD` now runs the installed `redmine-mcp-server` console
+  script, which reads both vars, and the `HEALTHCHECK` port follows
+  `${SERVER_PORT:-8000}`. The runtime image also sets `SERVER_HOST=0.0.0.0` as
+  a default so an ad-hoc `docker run` without a full env file still binds to a
+  reachable address (overridable via `env_file` or `-e`).
+
+### Contributors
+- @pdostal — fixed the Dockerfile to respect `SERVER_HOST`/`SERVER_PORT` env vars ([#179](https://github.com/jztan/redmine-mcp-server/pull/179))
+
 ## [2.6.0] - 2026-07-11
 ### Added
 - Interactive `triage-board` MCP App (Interactive UI / `ext-apps` track): the new

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,9 +25,13 @@ RUN uv venv /opt/venv && \
 FROM python:3.13-slim AS runtime
 
 # Set environment variables
+# SERVER_HOST/SERVER_PORT default to a reachable binding so ad-hoc
+# `docker run` works without a full env file; override via env_file or -e.
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
-    PATH="/opt/venv/bin:$PATH"
+    PATH="/opt/venv/bin:$PATH" \
+    SERVER_HOST=0.0.0.0 \
+    SERVER_PORT=8000
 
 # Install system dependencies
 RUN apt-get update && \


### PR DESCRIPTION
Follow-up to #179.

After #179 the Dockerfile `CMD` runs the `redmine-mcp-server` console script, which calls `main()`. `main()` defaults `SERVER_HOST` to `127.0.0.1`, whereas the old hardcoded `CMD` used `0.0.0.0`. So an ad-hoc `docker run` without a full env file would bind to loopback inside the container, leaving the published port dead while the in-container healthcheck still passed and masked it.

This sets `SERVER_HOST=0.0.0.0` and `SERVER_PORT=8000` as defaults in the runtime stage so the out-of-the-box image (including the published GHCR image) stays reachable. `env_file` and `-e` still override them, so the fix from #179 is fully preserved.

### Verification
- `docker build` succeeds.
- `docker run -p 18000:8000` (no full env file): uvicorn logs `Uvicorn running on http://0.0.0.0:8000` and `GET /health` returns 200 from the host through the published port.