### PR TITLE
fix(security): raise transitive floors for click and mcp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   a default so an ad-hoc `docker run` without a full env file still binds to a
   reachable address (overridable via `env_file` or `-e`).
 
+### Security
+- Raised security floors for two transitive dependencies via `[tool.uv]`
+  `constraint-dependencies`, clearing all known advisories from the audit:
+  `click>=8.3.3` (PYSEC-2026-2132) and `mcp>=1.28.1` (CVE-2026-52870,
+  CVE-2026-52869, CVE-2026-59950). Both are pulled in indirectly and not
+  imported directly; each constraint can be dropped once an upstream dependency
+  raises its own floor.
+
 ### Contributors
 - @pdostal — fixed the Dockerfile to respect `SERVER_HOST`/`SERVER_PORT` env vars ([#179](https://github.com/jztan/redmine-mcp-server/pull/179))
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,13 @@ dev = [
     "pre-commit>=3.0.0,<5",
 ]
 
+[tool.uv]
+# Security floors for transitive dependencies (not imported directly). Drop each
+# entry once an upstream dependency raises its own floor past these versions.
+#   click < 8.3.3  -> PYSEC-2026-2132 (via uvicorn / rich-click stack)
+#   mcp   < 1.28.1 -> CVE-2026-52870, CVE-2026-52869, CVE-2026-59950 (via fastmcp-slim)
+constraint-dependencies = ["click>=8.3.3", "mcp>=1.28.1"]
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,18 @@
 version = 1
 revision = 3
 requires-python = ">=3.10"
+resolution-markers = [
+    "python_full_version >= '3.14' and sys_platform == 'win32'",
+    "python_full_version >= '3.14' and sys_platform != 'win32'",
+    "python_full_version < '3.14' and sys_platform == 'win32'",
+    "python_full_version < '3.14' and sys_platform != 'win32'",
+]
+
+[manifest]
+constraints = [
+    { name = "click", specifier = ">=8.3.3" },
+    { name = "mcp", specifier = ">=1.28.1" },
+]
 
 [[package]]
 name = "aiofile"
@@ -332,14 +344,14 @@ wheels = [
 
 [[package]]
 name = "click"
-version = "8.1.8"
+version = "8.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b9/2e/0090cbf739cee7d23781ad4b89a9894a41538e4fcf4c31dcdd705b78eb8b/click-8.1.8.tar.gz", hash = "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a", size = 226593, upload-time = "2024-12-21T18:38:44.339Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/76/d4/81420972a676e8ffea40450d8c8c92943e7218a78fe9b64359836cc9876b/click-8.4.2.tar.gz", hash = "sha256:9a6cea6e60b17ebe0a44c5cc636d94f09bd66142c1cd7d8b4cd731c4917a15f6", size = 338000, upload-time = "2026-06-24T17:45:15.148Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7e/d4/7ebdbd03970677812aac39c869717059dbb71a4cfc033ca6e5221787892c/click-8.1.8-py3-none-any.whl", hash = "sha256:63c132bbbed01578a06712a2d1f497bb62d9c1c0d329b7903a866228027263b2", size = 98188, upload-time = "2024-12-21T18:38:41.666Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/e2/79c688af8b210d232694e31e59da9f6ec747bae31c3f5946e4e9b98860d5/click-8.4.2-py3-none-any.whl", hash = "sha256:e6f9f66136c816745b9d65817da91d61d957fb16e02e4dcd0552553c5a197b76", size = 119243, upload-time = "2026-06-24T17:45:13.73Z" },
 ]
 
 [[package]]
@@ -918,7 +930,7 @@ wheels = [
 
 [[package]]
 name = "mcp"
-version = "1.25.0"
+version = "1.28.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -936,9 +948,9 @@ dependencies = [
     { name = "typing-inspection" },
     { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d5/2d/649d80a0ecf6a1f82632ca44bec21c0461a9d9fc8934d38cb5b319f2db5e/mcp-1.25.0.tar.gz", hash = "sha256:56310361ebf0364e2d438e5b45f7668cbb124e158bb358333cd06e49e83a6802", size = 605387, upload-time = "2025-12-19T10:19:56.985Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6e/77/9450b8f251a13affb6281997d0523c4615f8a8b35d0b21ff30db3a5aac9d/mcp-1.28.1.tar.gz", hash = "sha256:d51e36a5f5644faea4f85ea649bfffa6bc6c26770d42798ad6a3de3d2ba69683", size = 638501, upload-time = "2026-06-26T12:57:29.093Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e2/fc/6dc7659c2ae5ddf280477011f4213a74f806862856b796ef08f028e664bf/mcp-1.25.0-py3-none-any.whl", hash = "sha256:b37c38144a666add0862614cc79ec276e97d72aa8ca26d622818d4e278b9721a", size = 233076, upload-time = "2025-12-19T10:19:55.416Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/5e/d118fce19f87a2e7d8101c35c8ae0ec289098a4df0ff244cec23e415aca0/mcp-1.28.1-py3-none-any.whl", hash = "sha256:2726bca5e7193f61c5dde8b12500a6de2d9acf6d1a1c0be9e8c2e706437991df", size = 222620, upload-time = "2026-06-26T12:57:27.218Z" },
 ]
 
 [[package]]
@@ -1779,8 +1791,8 @@ name = "secretstorage"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography" },
-    { name = "jeepney" },
+    { name = "cryptography", marker = "sys_platform != 'win32'" },
+    { name = "jeepney", marker = "sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
 wheels = [


### PR DESCRIPTION
## What

Clears every advisory the dependency audit currently flags by pinning security floors for two **transitive** dependencies through `[tool.uv]` `constraint-dependencies`:

| Package | Floor | Advisories fixed | Pulled in via |
|---|---|---|---|
| `click` | `>=8.3.3` | PYSEC-2026-2132 | uvicorn / rich-click stack |
| `mcp` | `>=1.28.1` | CVE-2026-52870, CVE-2026-52869, CVE-2026-59950 | fastmcp-slim |

Neither package is imported directly. `mcp>=1.28.1` stays within `fastmcp-slim`'s `mcp<2.0,>=1.24.0` range.

## Why

The `click` advisory was already failing the audit on `develop` (pre-existing, unrelated to the recent Dependabot bumps). Once `click` was raised, the audit surfaced three newly disclosed `mcp` CVEs (not present when the 2026-07-13 Dependabot checks ran), so both are addressed together to get the audit green.

## Verification

- `pip-audit` (strict, same invocation as CI via `scripts/audit.sh`): **No known vulnerabilities found** (was: click 8.1.8, then mcp 1.25.0 x3).
- Resolver moved `click` 8.1.8 -> 8.4.2 and `mcp` 1.25.0 -> 1.28.1; no other package versions changed.
- Full unit suite: **1465 passed**.

Each constraint can be dropped once an upstream dependency raises its own floor.