### PR TITLE
fix: enforce OAuth token scopes on MCP tool calls (#185)

### DIFF
--- a/.env.docker.example
+++ b/.env.docker.example
@@ -30,6 +30,12 @@ REDMINE_AUTH_MODE=legacy
 # e.g. https://redmine.mcp.example.com or http://localhost:3040
 REDMINE_MCP_BASE_URL=http://localhost:3040
 
+# Per-tool OAuth scope enforcement (oauth / oauth-proxy modes only).
+# Default: on. Tokens must carry the Redmine permission scopes each tool
+# needs (see oauth_scopes.py TOOL_SCOPES). Set to "off" temporarily if
+# tokens issued before scope enforcement lack scopes and need re-consent.
+# REDMINE_OAUTH_SCOPE_ENFORCEMENT=on
+
 # Server configuration
 SERVER_HOST=0.0.0.0
 SERVER_PORT=8000

--- a/.env.example
+++ b/.env.example
@@ -44,6 +44,12 @@ REDMINE_INTROSPECT_CLIENT_ID=
 REDMINE_INTROSPECT_CLIENT_SECRET=
 # REDMINE_INTROSPECT_CLIENT_SECRET_FILE=/run/secrets/redmine_introspect_client_secret
 
+# Per-tool OAuth scope enforcement (oauth / oauth-proxy modes only).
+# Default: on. Tokens must carry the Redmine permission scopes each tool
+# needs (see oauth_scopes.py TOOL_SCOPES). Set to "off" temporarily if
+# tokens issued before scope enforcement lack scopes and need re-consent.
+# REDMINE_OAUTH_SCOPE_ENFORCEMENT=on
+
 # OAuthProxy signing key (required when REDMINE_AUTH_MODE=oauth-proxy).
 # Use a stable secret value; changing it invalidates FastMCP proxy tokens/storage.
 REDMINE_MCP_JWT_SIGNING_KEY=

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Security
+- OAuth token scopes are now enforced on MCP tool calls ([#185](https://github.com/jztan/redmine-mcp-server/issues/185)):
+  each tool requires the Redmine permission scopes it uses (per-action for
+  `manage_X` tools), unmapped tools are denied by default, `tools/list` is
+  filtered to the token's scopes, and the `admin` scope bypasses the check.
+  Enforcement is on by default; set `REDMINE_OAUTH_SCOPE_ENFORCEMENT=off`
+  as a temporary bridge while re-consenting tokens issued before this
+  release (see docs/oauth-setup.md, "Scope Enforcement"). Reported by
+  @stevehollis-orderflow.
+
+### Contributors
+- @stevehollis-orderflow — reported that OAuth token scopes were advertised but not enforced on tool calls, with a precise repro and a sound enforcement design ([#185](https://github.com/jztan/redmine-mcp-server/issues/185))
 
 ## [2.7.0] - 2026-07-20
 ### Added
@@ -24,22 +36,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   wheels, and two `file_manager` tests that relied on pre-3.14 pathlib
   internals were rewritten to be version-independent.
 
-### Security
-- OAuth token scopes are now enforced on MCP tool calls ([#185](https://github.com/jztan/redmine-mcp-server/issues/185)):
-  each tool requires the Redmine permission scopes it uses (per-action for
-  `manage_X` tools), unmapped tools are denied by default, `tools/list` is
-  filtered to the token's scopes, and the `admin` scope bypasses the check.
-  Enforcement is on by default; set `REDMINE_OAUTH_SCOPE_ENFORCEMENT=off`
-  as a temporary bridge while re-consenting tokens issued before this
-  release (see docs/oauth-setup.md, "Scope Enforcement"). Reported by
-  @stevehollis-orderflow.
-- Raised security floors for two transitive dependencies via `[tool.uv]`
-  `constraint-dependencies`, clearing all known advisories from the audit:
-  `click>=8.3.3` (PYSEC-2026-2132) and `mcp>=1.28.1` (CVE-2026-52870,
-  CVE-2026-52869, CVE-2026-59950). Both are pulled in indirectly and not
-  imported directly; each constraint can be dropped once an upstream dependency
-  raises its own floor.
-
 ### Fixed
 - Docker container now honors `SERVER_HOST` and `SERVER_PORT`. The Dockerfile
   `CMD` previously hardcoded `--host 0.0.0.0 --port 8000` in the uvicorn
@@ -49,6 +45,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `${SERVER_PORT:-8000}`. The runtime image also sets `SERVER_HOST=0.0.0.0` as
   a default so an ad-hoc `docker run` without a full env file still binds to a
   reachable address (overridable via `env_file` or `-e`).
+
+### Security
+- Raised security floors for two transitive dependencies via `[tool.uv]`
+  `constraint-dependencies`, clearing all known advisories from the audit:
+  `click>=8.3.3` (PYSEC-2026-2132) and `mcp>=1.28.1` (CVE-2026-52870,
+  CVE-2026-52869, CVE-2026-59950). Both are pulled in indirectly and not
+  imported directly; each constraint can be dropped once an upstream dependency
+  raises its own floor.
 
 ### Contributors
 - @pdostal — fixed the Dockerfile to respect `SERVER_HOST`/`SERVER_PORT` env vars ([#179](https://github.com/jztan/redmine-mcp-server/pull/179))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   wheels, and two `file_manager` tests that relied on pre-3.14 pathlib
   internals were rewritten to be version-independent.
 
+### Security
+- OAuth token scopes are now enforced on MCP tool calls ([#185](https://github.com/jztan/redmine-mcp-server/issues/185)):
+  each tool requires the Redmine permission scopes it uses (per-action for
+  `manage_X` tools), unmapped tools are denied by default, `tools/list` is
+  filtered to the token's scopes, and the `admin` scope bypasses the check.
+  Enforcement is on by default; set `REDMINE_OAUTH_SCOPE_ENFORCEMENT=off`
+  as a temporary bridge while re-consenting tokens issued before this
+  release (see docs/oauth-setup.md, "Scope Enforcement"). Reported by
+  @stevehollis-orderflow.
+- Raised security floors for two transitive dependencies via `[tool.uv]`
+  `constraint-dependencies`, clearing all known advisories from the audit:
+  `click>=8.3.3` (PYSEC-2026-2132) and `mcp>=1.28.1` (CVE-2026-52870,
+  CVE-2026-52869, CVE-2026-59950). Both are pulled in indirectly and not
+  imported directly; each constraint can be dropped once an upstream dependency
+  raises its own floor.
+
 ### Fixed
 - Docker container now honors `SERVER_HOST` and `SERVER_PORT`. The Dockerfile
   `CMD` previously hardcoded `--host 0.0.0.0 --port 8000` in the uvicorn
@@ -33,14 +49,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `${SERVER_PORT:-8000}`. The runtime image also sets `SERVER_HOST=0.0.0.0` as
   a default so an ad-hoc `docker run` without a full env file still binds to a
   reachable address (overridable via `env_file` or `-e`).
-
-### Security
-- Raised security floors for two transitive dependencies via `[tool.uv]`
-  `constraint-dependencies`, clearing all known advisories from the audit:
-  `click>=8.3.3` (PYSEC-2026-2132) and `mcp>=1.28.1` (CVE-2026-52870,
-  CVE-2026-52869, CVE-2026-59950). Both are pulled in indirectly and not
-  imported directly; each constraint can be dropped once an upstream dependency
-  raises its own floor.
 
 ### Contributors
 - @pdostal — fixed the Dockerfile to respect `SERVER_HOST`/`SERVER_PORT` env vars ([#179](https://github.com/jztan/redmine-mcp-server/pull/179))

--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ The server runs on `http://localhost:8000` with the MCP endpoint at `/mcp`, heal
 | `REDMINE_SSL_CERT` | No | – | Path to custom CA certificate file |
 | `REDMINE_SSL_CLIENT_CERT` | No | – | Path to client certificate for mutual TLS |
 | `REDMINE_MCP_READ_ONLY` | No | `false` | Block all write operations (create/update/delete) when set to `true` |
+| `REDMINE_OAUTH_SCOPE_ENFORCEMENT` | No | `on` | OAuth modes only: deny tool calls whose access token lacks the tool's Redmine permission scopes, and filter `tools/list` accordingly. Set to `off` temporarily while re-consenting older tokens ([details](docs/oauth-setup.md#scope-enforcement)) |
 | `REDMINE_AGILE_ENABLED` | No | `false` | Enable RedmineUP Agile plugin support: `get_redmine_issue` returns `story_points`, `agile_sprint_id`, `agile_position`; `update_redmine_issue` accepts `story_points` |
 | `REDMINE_CHECKLISTS_ENABLED` | No | `false` | Enable RedmineUP Checklists plugin support: `get_checklist`, `create_checklist_item`, `update_checklist_item` (requires Checklists Pro plugin) |
 | `REDMINE_PRODUCTS_ENABLED` | No | `false` | Enable RedmineUP Products plugin support: `manage_product` (action=list/get/create/update) |

--- a/docs/oauth-setup.md
+++ b/docs/oauth-setup.md
@@ -194,6 +194,44 @@ Set this in Redmine's OAuth app (Step 1) to match your client:
 > **Note on DCR:** Some clients (Claude Desktop, VS Code) expect Dynamic Client Registration. Redmine's Doorkeeper does not support DCR, so you must pre-register the app manually (Step 1) and configure the client with the `client_id`/`client_secret`.
 > Use `REDMINE_AUTH_MODE=oauth-proxy` when MCP clients need DCR/CIMD onboarding.
 
+## Scope Enforcement
+
+The server enforces OAuth scopes per tool (on by default). Every MCP
+tool maps to the Redmine permission scopes it needs, and a
+call is refused with code `INSUFFICIENT_SCOPE` when the access token
+does not carry them. `tools/list` only shows the tools the token can
+use. Tokens with the `admin` scope bypass the check, matching Redmine's
+own semantics.
+
+The authoritative tool-to-scope map is `TOOL_SCOPES` in
+`src/redmine_mcp_server/oauth_scopes.py`.
+
+Notes:
+
+- The map gates each tool's base permission. Argument-conditional
+  permissions (for example `manage_subtasks` when changing
+  `parent_issue_id`, or tag scopes for `tag_list`) are still enforced
+  by Redmine itself.
+- RedmineUP plugin tools (`manage_product`, `manage_contact`,
+  checklists) cannot require plugin scopes because those are not
+  advertised; Redmine enforces its own plugin permissions for them.
+
+### Tokens issued before scope enforcement
+
+Tokens obtained before scopes were requested (or from OAuth apps with a
+blank scope list) introspect with empty scopes and will be denied for
+every tool. Fix: update the OAuth application's scopes in Redmine,
+disconnect and re-authorize the MCP client so a new consent grants the
+scopes. As a temporary bridge you can set:
+
+```bash
+REDMINE_OAUTH_SCOPE_ENFORCEMENT=off
+```
+
+which restores the pre-enforcement behavior (any active token can call
+any tool) and logs a warning at startup. Re-enable it once clients have
+re-consented.
+
 ## Migrating from Legacy Mode
 
 1. Set `REDMINE_AUTH_MODE=oauth` and restart — no downtime needed

--- a/docs/oauth-setup.md
+++ b/docs/oauth-setup.md
@@ -215,6 +215,9 @@ Notes:
 - RedmineUP plugin tools (`manage_product`, `manage_contact`,
   checklists) cannot require plugin scopes because those are not
   advertised; Redmine enforces its own plugin permissions for them.
+- A notes-only `update_redmine_issue` call (fields containing nothing but
+  `notes` / `private_notes`, no uploads) requires `add_issue_notes` instead
+  of `edit_issues`, mirroring Redmine's own note-adding permission.
 
 ### Tokens issued before scope enforcement
 

--- a/src/redmine_mcp_server/_auth.py
+++ b/src/redmine_mcp_server/_auth.py
@@ -53,9 +53,9 @@ class RedmineAuthProvider(RemoteAuthProvider):
             introspection_url=str(self.redmine_endpoint("/oauth/introspect")),
             client_id=introspect_client_id,
             client_secret=introspect_client_secret,
-            # required_scopes is intentionally unset: today we advertise scopes
-            # but do not gate tool calls on them. Per-tool scope enforcement is
-            # a follow-up roadmap item.
+            # required_scopes is intentionally unset: it would apply a
+            # global AND over every token. Per-tool enforcement lives in
+            # ScopeEnforcementMiddleware (#185).
         )
 
         super().__init__(

--- a/src/redmine_mcp_server/_env.py
+++ b/src/redmine_mcp_server/_env.py
@@ -44,6 +44,16 @@ def _is_dmsf_enabled() -> bool:
     return _is_true_env("REDMINE_DMSF_ENABLED", "false")
 
 
+def _is_scope_enforcement_enabled() -> bool:
+    """Check if per-tool OAuth scope enforcement is enabled (#185).
+
+    Default on. Set REDMINE_OAUTH_SCOPE_ENFORCEMENT=off to restore the
+    pre-enforcement behavior (any active token can call any tool) while
+    users re-consent tokens with the required scopes.
+    """
+    return _is_true_env("REDMINE_OAUTH_SCOPE_ENFORCEMENT", "true")
+
+
 def _admin_tools_enabled() -> bool:
     """Check if operator-facing admin tools are exposed on the MCP surface.
 

--- a/src/redmine_mcp_server/_scope_middleware.py
+++ b/src/redmine_mcp_server/_scope_middleware.py
@@ -31,7 +31,7 @@ from fastmcp.server.dependencies import get_access_token
 from fastmcp.server.middleware import Middleware
 
 from ._tool_error_middleware import build_error_tool_result
-from .oauth_scopes import TOOL_SCOPES, scopes_for_action, tool_visible  # noqa: F401
+from .oauth_scopes import TOOL_SCOPES, scopes_for_action, tool_visible
 
 logger = logging.getLogger(__name__)
 
@@ -99,3 +99,20 @@ class ScopeEnforcementMiddleware(Middleware):
             )
 
         return await call_next(context)
+
+    async def on_list_tools(self, context, call_next):
+        tools = await call_next(context)
+        token = get_access_token()
+        if token is None:
+            return tools
+
+        granted = set(token.scopes or [])
+        if "admin" in granted:
+            return tools
+
+        visible = []
+        for tool in tools:
+            entry = TOOL_SCOPES.get(tool.name)
+            if entry is not None and tool_visible(entry, granted):
+                visible.append(tool)
+        return visible

--- a/src/redmine_mcp_server/_scope_middleware.py
+++ b/src/redmine_mcp_server/_scope_middleware.py
@@ -14,6 +14,10 @@ Model:
     tool's own invalid-action error surfaces.
   - ``admin`` scope bypasses the check entirely, matching Redmine's own
     semantics (admin bypasses per-permission checks).
+  - ``update_redmine_issue`` carries a notes-only carve-out: a call whose
+    ``fields`` contain nothing but ``notes``/``private_notes`` (no
+    ``uploads``) requires ``add_issue_notes`` instead of ``edit_issues``,
+    mirroring Redmine's own note-adding permission check.
   - No access token (legacy / legacy-per-user modes, background tasks)
     means no enforcement: those modes have no scopes to check.
   - ``list_tools`` responses are filtered to tools the token can use;
@@ -31,7 +35,7 @@ from fastmcp.server.dependencies import get_access_token
 from fastmcp.server.middleware import Middleware
 
 from ._tool_error_middleware import build_error_tool_result
-from .oauth_scopes import TOOL_SCOPES, scopes_for_action, tool_visible
+from .oauth_scopes import TOOL_SCOPES, required_scopes_for_call, tool_visible_for
 
 logger = logging.getLogger(__name__)
 
@@ -81,7 +85,7 @@ class ScopeEnforcementMiddleware(Middleware):
             )
             return await build_error_tool_result(context, _unmapped_payload(tool_name))
 
-        required = scopes_for_action(entry, context.message.arguments)
+        required = required_scopes_for_call(tool_name, entry, context.message.arguments)
         if required is None:
             # Per-action entry with unknown/missing action: let the
             # tool's own validation produce the error.
@@ -113,6 +117,6 @@ class ScopeEnforcementMiddleware(Middleware):
         visible = []
         for tool in tools:
             entry = TOOL_SCOPES.get(tool.name)
-            if entry is not None and tool_visible(entry, granted):
+            if entry is not None and tool_visible_for(tool.name, entry, granted):
                 visible.append(tool)
         return visible

--- a/src/redmine_mcp_server/_scope_middleware.py
+++ b/src/redmine_mcp_server/_scope_middleware.py
@@ -1,0 +1,101 @@
+"""FastMCP middleware enforcing per-tool OAuth scopes (#185).
+
+In oauth / oauth-proxy modes, Doorkeeper scopes are advertised and
+carried by access tokens but were historically never checked at the
+tool boundary: any active token could invoke any tool, and only
+Redmine's role check applied. This middleware closes that gap.
+
+Model:
+  - ``TOOL_SCOPES`` (oauth_scopes.py) maps every tool to the scopes it
+    requires; the token must hold ALL of them. Deny by default: a tool
+    without a map entry is refused.
+  - ``manage_X(action=...)`` tools use per-action entries keyed on the
+    structured ``action`` argument. Unknown actions pass through so the
+    tool's own invalid-action error surfaces.
+  - ``admin`` scope bypasses the check entirely, matching Redmine's own
+    semantics (admin bypasses per-permission checks).
+  - No access token (legacy / legacy-per-user modes, background tasks)
+    means no enforcement: those modes have no scopes to check.
+  - ``list_tools`` responses are filtered to tools the token can use;
+    ``call_tool`` remains the actual security boundary.
+
+The verifier's ``required_scopes`` stays unset by design: it is a
+global AND over every token, which is the wrong model for per-tool
+requirements (see tests/test_auth_factory.py).
+"""
+
+import logging
+from typing import Any, Dict
+
+from fastmcp.server.dependencies import get_access_token
+from fastmcp.server.middleware import Middleware
+
+from ._tool_error_middleware import build_error_tool_result
+from .oauth_scopes import TOOL_SCOPES, scopes_for_action, tool_visible  # noqa: F401
+
+logger = logging.getLogger(__name__)
+
+
+def _denial_payload(missing: frozenset, granted: set) -> Dict[str, Any]:
+    missing_str = ", ".join(sorted(missing))
+    return {
+        "error": ("Access token lacks required OAuth scope(s): " f"{missing_str}."),
+        "hint": (
+            "Re-authorize with the missing scope(s) included, or ask the "
+            "Redmine administrator to add them to the OAuth application. "
+            f"Missing scopes: {missing_str}. "
+            f"Granted scopes: {', '.join(sorted(granted)) or '(none)'}."
+        ),
+        "code": "INSUFFICIENT_SCOPE",
+    }
+
+
+def _unmapped_payload(tool_name: str) -> Dict[str, Any]:
+    return {
+        "error": (f"Tool '{tool_name}' has no scope mapping; denying by default."),
+        "hint": (
+            "This is a server-side omission. Add the tool to TOOL_SCOPES "
+            "in oauth_scopes.py."
+        ),
+        "code": "INSUFFICIENT_SCOPE",
+    }
+
+
+class ScopeEnforcementMiddleware(Middleware):
+    """Deny tool calls whose access token lacks the mapped scopes."""
+
+    async def on_call_tool(self, context, call_next):
+        token = get_access_token()
+        if token is None:
+            return await call_next(context)
+
+        granted = set(token.scopes or [])
+        if "admin" in granted:
+            return await call_next(context)
+
+        tool_name = context.message.name
+        entry = TOOL_SCOPES.get(tool_name)
+        if entry is None:
+            logger.warning(
+                "Denying call to unmapped tool %r (deny-by-default)", tool_name
+            )
+            return await build_error_tool_result(context, _unmapped_payload(tool_name))
+
+        required = scopes_for_action(entry, context.message.arguments)
+        if required is None:
+            # Per-action entry with unknown/missing action: let the
+            # tool's own validation produce the error.
+            return await call_next(context)
+
+        missing = required - granted
+        if missing:
+            logger.info(
+                "Denying %r: token lacks scope(s) %s",
+                tool_name,
+                ", ".join(sorted(missing)),
+            )
+            return await build_error_tool_result(
+                context, _denial_payload(missing, granted)
+            )
+
+        return await call_next(context)

--- a/src/redmine_mcp_server/_tool_error_middleware.py
+++ b/src/redmine_mcp_server/_tool_error_middleware.py
@@ -111,6 +111,40 @@ def _format_argument_error(exc: ValidationError) -> Dict[str, Any]:
     return payload
 
 
+async def build_error_tool_result(context, payload: Dict[str, Any]) -> ToolResult:
+    """Build a ToolResult carrying an error envelope for a tool call.
+
+    Honors FastMCP's output-schema wrap convention. Tools whose return
+    type is not a plain dict (e.g. Union[List, Dict]) get an
+    outputSchema with ``x-fastmcp-wrap-result: True``; the client-side
+    parser looks for the value under a ``result`` key and trips a
+    misleading "Output validation error: 'result' is a required
+    property" if we hand it a flat dict instead. Detect that case and
+    mirror the wrapping so the envelope reaches the caller intact
+    regardless of return-type shape.
+    """
+    wrap_result = False
+    try:
+        fastmcp_ctx = getattr(context, "fastmcp_context", None)
+        if fastmcp_ctx is not None:
+            tool = await fastmcp_ctx.fastmcp.get_tool(context.message.name)
+            output_schema = getattr(tool, "output_schema", None) or {}
+            wrap_result = bool(output_schema.get("x-fastmcp-wrap-result"))
+    except Exception:
+        # Tool lookup failures are non-fatal: the envelope is still
+        # readable via ``content``; the only cost is that strict
+        # clients may surface the wrap-result mismatch.
+        wrap_result = False
+
+    structured: Dict[str, Any] = {"result": payload} if wrap_result else payload
+    meta = {"fastmcp": {"wrap_result": True}} if wrap_result else None
+    return ToolResult(
+        content=[TextContent(type="text", text=json.dumps(payload))],
+        structured_content=structured,
+        meta=meta,
+    )
+
+
 class CleanValidationErrorMiddleware(Middleware):
     """Catches argument-validation Pydantic errors at the tool boundary."""
 
@@ -135,33 +169,4 @@ class CleanValidationErrorMiddleware(Middleware):
             if not isinstance(pydantic_exc, ValidationError):
                 raise
             payload = _format_argument_error(pydantic_exc)
-
-            # Honor FastMCP's output-schema wrap convention. Tools whose
-            # return type is not a plain dict (e.g. Union[List, Dict])
-            # get an outputSchema with ``x-fastmcp-wrap-result: True``;
-            # the client-side parser looks for the value under a
-            # ``result`` key and trips a misleading
-            # "Output validation error: 'result' is a required property"
-            # if we hand it a flat dict instead. Detect that case and
-            # mirror the wrapping so the envelope reaches the caller
-            # intact regardless of return-type shape.
-            wrap_result = False
-            try:
-                fastmcp_ctx = getattr(context, "fastmcp_context", None)
-                if fastmcp_ctx is not None:
-                    tool = await fastmcp_ctx.fastmcp.get_tool(context.message.name)
-                    output_schema = getattr(tool, "output_schema", None) or {}
-                    wrap_result = bool(output_schema.get("x-fastmcp-wrap-result"))
-            except Exception:
-                # Tool lookup failures are non-fatal: the envelope is
-                # still readable via ``content``; the only cost is that
-                # strict clients may surface the wrap-result mismatch.
-                wrap_result = False
-
-            structured: Dict[str, Any] = {"result": payload} if wrap_result else payload
-            meta = {"fastmcp": {"wrap_result": True}} if wrap_result else None
-            return ToolResult(
-                content=[TextContent(type="text", text=json.dumps(payload))],
-                structured_content=structured,
-                meta=meta,
-            )
+            return await build_error_tool_result(context, payload)

--- a/src/redmine_mcp_server/oauth_scopes.py
+++ b/src/redmine_mcp_server/oauth_scopes.py
@@ -59,7 +59,7 @@ WRITE_SCOPES: list[str] = [
     "manage_issue_relations",  # manage_issue_relation
     "add_issue_watchers",  # manage_issue_watcher(action=add)
     "delete_issue_watchers",  # manage_issue_watcher(action=remove)
-    "add_issue_notes",  # update_redmine_issue (notes parameter)
+    "add_issue_notes",  # update_redmine_issue notes-only carve-out
     "edit_issue_notes",  # manage_issue_note(action=edit)
     "set_notes_private",  # manage_issue_note(action=set_private)
     "log_time",  # manage_time_entry(action=create), import_time_entries
@@ -225,7 +225,7 @@ TOOL_SCOPES: Dict[str, ToolScopeEntry] = {
     "upload_file": frozenset({"manage_files"}),
     "delete_file": frozenset({"manage_files"}),
     # Local attachment-store maintenance; no Redmine call. Registered
-    # only when REDMINE_ADMIN_TOOLS_ENABLED is truthy.
+    # only when REDMINE_MCP_EXPOSE_ADMIN_TOOLS is truthy.
     "cleanup_attachment_files": frozenset(),
     # --- documents ---
     "manage_document": {
@@ -282,6 +282,10 @@ def scopes_for_action(
     """
     if isinstance(entry, dict):
         action = (arguments or {}).get("action")
+        if not isinstance(action, str):
+            # Non-string actions cannot match a map key; pass through so
+            # argument validation rejects them cleanly.
+            return None
         return entry.get(action)
     return entry
 
@@ -291,3 +295,39 @@ def tool_visible(entry: ToolScopeEntry, token_scopes: set) -> bool:
     if isinstance(entry, dict):
         return any(req <= token_scopes for req in entry.values())
     return entry <= token_scopes
+
+
+# update_redmine_issue carve-out (#185 review): a notes-only update is
+# Redmine's "add a comment" operation. Redmine gates it on
+# add_issue_notes (Issue#notes_addable?), not edit_issues, so a
+# commenter token must pass and an edit-only token must be denied,
+# mirroring Redmine's own check. Attaching uploads or touching any
+# other field remains a real edit.
+_NOTES_ONLY_FIELDS = frozenset({"notes", "private_notes"})
+_NOTES_ONLY_SCOPES = frozenset({"add_issue_notes"})
+
+
+def _is_notes_only_update(arguments: Optional[dict]) -> bool:
+    args = arguments or {}
+    fields = args.get("fields")
+    if not isinstance(fields, dict) or not fields:
+        return False
+    if args.get("uploads"):
+        return False
+    return set(fields) <= _NOTES_ONLY_FIELDS
+
+
+def required_scopes_for_call(
+    tool_name: str, entry: ToolScopeEntry, arguments: Optional[dict]
+) -> Optional[frozenset]:
+    """Scope requirement for one call: per-tool carve-outs, then the map."""
+    if tool_name == "update_redmine_issue" and _is_notes_only_update(arguments):
+        return _NOTES_ONLY_SCOPES
+    return scopes_for_action(entry, arguments)
+
+
+def tool_visible_for(tool_name: str, entry: ToolScopeEntry, token_scopes: set) -> bool:
+    """Visibility for tools/list, including per-tool carve-outs."""
+    if tool_name == "update_redmine_issue":
+        return tool_visible(entry, token_scopes) or (_NOTES_ONLY_SCOPES <= token_scopes)
+    return tool_visible(entry, token_scopes)

--- a/src/redmine_mcp_server/oauth_scopes.py
+++ b/src/redmine_mcp_server/oauth_scopes.py
@@ -24,6 +24,8 @@ Exclusions:
       scopes a Redmine doesn't recognize causes consent errors.
 """
 
+from typing import Dict, Optional, Union
+
 from ._env import _is_agile_enabled, _is_read_only_mode, _is_tags_enabled
 
 # Redmine permissions used by the read-only MCP tools.
@@ -45,7 +47,7 @@ READ_SCOPES: list[str] = [
     "view_wiki_pages",  # manage_redmine_wiki_page(action=get|list)
     "view_time_entries",  # list_time_entries, list_time_entry_activities
     "view_private_notes",  # get_private_notes
-    "view_issue_watchers",  # manage_issue_watcher(action=list)
+    "view_issue_watchers",  # get_redmine_issue(include_watchers=True)
 ]
 
 # Redmine permissions used by the mutation MCP tools.
@@ -57,18 +59,21 @@ WRITE_SCOPES: list[str] = [
     "manage_issue_relations",  # manage_issue_relation
     "add_issue_watchers",  # manage_issue_watcher(action=add)
     "delete_issue_watchers",  # manage_issue_watcher(action=remove)
-    "add_issue_notes",  # manage_issue_note(action=create)
-    "edit_issue_notes",  # manage_issue_note(action=update)
-    "set_notes_private",  # manage_issue_note with private flag
+    "add_issue_notes",  # update_redmine_issue (notes parameter)
+    "edit_issue_notes",  # manage_issue_note(action=edit)
+    "set_notes_private",  # manage_issue_note(action=set_private)
     "log_time",  # manage_time_entry(action=create), import_time_entries
-    "edit_time_entries",  # manage_time_entry(action=update|delete)
+    "edit_time_entries",  # manage_time_entry(action=update)
     "manage_versions",  # manage_redmine_version
     "manage_categories",  # manage_issue_category
-    "manage_wiki",  # manage_redmine_wiki_page(action=create|update|delete)
-    "edit_wiki_pages",  # manage_redmine_wiki_page(action=update)
+    "manage_wiki",  # wiki administration; not required by any MCP tool today
+    "edit_wiki_pages",  # manage_redmine_wiki_page(action=create|update)
+    "rename_wiki_pages",  # manage_redmine_wiki_page(action=rename)
+    "delete_wiki_pages",  # manage_redmine_wiki_page(action=delete)
     "add_documents",  # manage_document(action=create)
     "edit_documents",  # manage_document(action=update)
-    "delete_documents",  # manage_document(action=delete)
+    "delete_documents",  # advertised for parity; manage_document has no
+    # delete action yet
     "manage_files",  # upload_file, delete_file
     "manage_members",  # manage_project_member
 ]
@@ -129,3 +134,160 @@ def advertised_scopes() -> list[str]:
         if not _is_read_only_mode():
             scopes += list(TAGS_WRITE_SCOPES)
     return scopes
+
+
+# ---------------------------------------------------------------------------
+# Per-tool scope enforcement map (#185).
+#
+# Consumed by ScopeEnforcementMiddleware. Values are either:
+#   - frozenset[str]: required scopes regardless of arguments, or
+#   - dict[action, frozenset[str]]: per-action requirements for
+#     manage_X(action=...) tools; unknown actions pass through so the
+#     tool's own invalid-action error surfaces.
+#
+# Semantics: token must hold ALL scopes in the matching entry.
+# frozenset() means any authenticated token may call the tool (no
+# Redmine permission gates it, or Redmine itself requires admin and
+# admin tokens bypass this map anyway).
+#
+# Boundary: this map gates each tool's base permission only. Argument-
+# conditional permissions (manage_subtasks when parent_issue_id changes,
+# set_notes_private via update flags, create_issue_tags/edit_issue_tags
+# for tag_list, plugin permissions for RedmineUP products/contacts/
+# checklists) remain enforced by Redmine's own role and scope checks.
+#
+# Anti-drift: tests/test_scope_enforcement.py asserts every registered
+# tool is mapped and every enforced scope is advertised.
+# ---------------------------------------------------------------------------
+
+ToolScopeEntry = Union[frozenset, Dict[str, frozenset]]
+
+TOOL_SCOPES: Dict[str, ToolScopeEntry] = {
+    # --- projects ---
+    "list_redmine_projects": frozenset({"view_project"}),
+    "get_project_modules": frozenset({"view_project"}),
+    "list_project_trackers": frozenset({"view_project"}),
+    "summarize_project_status": frozenset({"view_project", "view_issues"}),
+    "list_project_members": frozenset({"view_members"}),
+    # GET /roles.json needs authentication only.
+    "list_redmine_roles": frozenset(),
+    # GET /custom_fields.json is admin-gated by Redmine itself.
+    "list_project_issue_custom_fields": frozenset(),
+    "manage_project_member": frozenset({"manage_members"}),
+    # Redmine gates GET /projects/.../versions.json on view_issues.
+    "list_redmine_versions": frozenset({"view_issues"}),
+    "manage_redmine_version": frozenset({"manage_versions"}),
+    # --- issues ---
+    "list_redmine_issues": frozenset({"view_issues"}),
+    "get_redmine_issue": frozenset({"view_issues"}),
+    "list_subtasks": frozenset({"view_issues"}),
+    "list_redmine_queries": frozenset({"view_issues"}),
+    "get_gantt_chart": frozenset({"view_issues"}),
+    "search_redmine_issues": frozenset({"search_project"}),
+    "create_redmine_issue": frozenset({"add_issues"}),
+    "copy_issue": frozenset({"add_issues"}),
+    "update_redmine_issue": frozenset({"edit_issues"}),
+    "delete_redmine_issue": frozenset({"delete_issues"}),
+    "get_private_notes": frozenset({"view_issues", "view_private_notes"}),
+    "manage_issue_relation": {
+        "list": frozenset({"view_issues"}),
+        "create": frozenset({"manage_issue_relations"}),
+        "delete": frozenset({"manage_issue_relations"}),
+    },
+    "manage_issue_watcher": {
+        "add": frozenset({"add_issue_watchers"}),
+        "remove": frozenset({"delete_issue_watchers"}),
+    },
+    "manage_issue_note": {
+        "edit": frozenset({"edit_issue_notes"}),
+        "set_private": frozenset({"set_notes_private"}),
+    },
+    "manage_issue_category": {
+        "list": frozenset({"view_issues"}),
+        "create": frozenset({"manage_categories"}),
+        "update": frozenset({"manage_categories"}),
+        "delete": frozenset({"manage_categories"}),
+    },
+    # --- search ---
+    "search_entire_redmine": frozenset({"search_project"}),
+    # --- enumerations (authentication only, no Redmine permission) ---
+    "list_redmine_trackers": frozenset(),
+    "list_redmine_issue_statuses": frozenset(),
+    "list_redmine_issue_priorities": frozenset(),
+    # GET /users.json is admin-gated by Redmine itself.
+    "list_redmine_users": frozenset(),
+    "get_current_user": frozenset(),
+    # --- meta ---
+    "get_mcp_server_info": frozenset(),
+    # --- files / attachments ---
+    "get_redmine_attachment": frozenset({"view_files"}),
+    "list_files": frozenset({"view_files"}),
+    "upload_file": frozenset({"manage_files"}),
+    "delete_file": frozenset({"manage_files"}),
+    # Local attachment-store maintenance; no Redmine call. Registered
+    # only when REDMINE_ADMIN_TOOLS_ENABLED is truthy.
+    "cleanup_attachment_files": frozenset(),
+    # --- documents ---
+    "manage_document": {
+        "list": frozenset({"view_documents"}),
+        "get": frozenset({"view_documents"}),
+        "create": frozenset({"add_documents"}),
+        "update": frozenset({"edit_documents"}),
+    },
+    # --- wiki ---
+    "manage_redmine_wiki_page": {
+        "list": frozenset({"view_wiki_pages"}),
+        "get": frozenset({"view_wiki_pages"}),
+        "create": frozenset({"edit_wiki_pages"}),
+        "update": frozenset({"edit_wiki_pages"}),
+        "rename": frozenset({"rename_wiki_pages"}),
+        "delete": frozenset({"delete_wiki_pages"}),
+    },
+    # --- time tracking ---
+    "list_time_entries": frozenset({"view_time_entries"}),
+    "list_time_entry_activities": frozenset({"view_time_entries"}),
+    "import_time_entries": frozenset({"log_time"}),
+    "manage_time_entry": {
+        "create": frozenset({"log_time"}),
+        "update": frozenset({"edit_time_entries"}),
+    },
+    # --- checklists (RedmineUP plugin; vendor scopes are not advertised,
+    # so gate on the host-issue permissions; the plugin's own
+    # view_checklists/edit_checklists checks remain with Redmine) ---
+    "get_checklist": frozenset({"view_issues"}),
+    "create_checklist_item": frozenset({"edit_issues"}),
+    "update_checklist_item": frozenset({"edit_issues"}),
+    # --- products / CRM (RedmineUP plugins; vendor scopes are not
+    # advertised and cannot be required; Redmine enforces its own
+    # plugin permissions) ---
+    "manage_product": frozenset(),
+    "manage_contact": frozenset(),
+    # --- MCP Apps (read-only issue queries) ---
+    "show_triage_board": frozenset({"view_issues"}),
+    "get_triage_board_data": frozenset({"view_issues"}),
+    "show_project_dashboard": frozenset({"view_issues"}),
+    "get_project_dashboard_data": frozenset({"view_issues"}),
+}
+
+
+def scopes_for_action(
+    entry: ToolScopeEntry, arguments: Optional[dict]
+) -> Optional[frozenset]:
+    """Resolve the scope requirement for one call.
+
+    Flat entries apply regardless of arguments. Dict entries key on the
+    call's ``action`` argument; an unknown or missing action returns
+    ``None`` (pass through) so the tool's own invalid-action or
+    missing-argument error surfaces instead of a scope denial.
+    """
+    if isinstance(entry, dict):
+        action = (arguments or {}).get("action")
+        return entry.get(action)
+    return entry
+
+
+def tool_visible(entry: ToolScopeEntry, token_scopes: set) -> bool:
+    """True when a token can invoke the tool (any action, for dict entries)."""
+    if isinstance(entry, dict):
+        return any(req <= token_scopes for req in entry.values())
+    return entry <= token_scopes

--- a/src/redmine_mcp_server/server.py
+++ b/src/redmine_mcp_server/server.py
@@ -15,11 +15,15 @@ tokens with the same introspection endpoint. In legacy mode the instance is
 built without ``auth=`` and behaves as before.
 """
 
+import logging
 import os
 
 from fastmcp import FastMCP
 
+from ._env import _is_scope_enforcement_enabled
 from ._tool_error_middleware import CleanValidationErrorMiddleware
+
+logger = logging.getLogger(__name__)
 
 REDMINE_AUTH_MODE = os.environ.get("REDMINE_AUTH_MODE", "legacy").lower()
 
@@ -42,7 +46,30 @@ def _select_auth_provider(auth_mode: str):
     return None
 
 
+def _register_middlewares(mcp_instance, auth_provider) -> None:
+    """Attach tool-boundary middlewares.
+
+    Extracted so tests can exercise the registration logic on a fresh
+    FastMCP instance without reloading this module.
+    """
+    mcp_instance.add_middleware(CleanValidationErrorMiddleware())
+    if auth_provider is None:
+        # Legacy modes carry no OAuth scopes; nothing to enforce.
+        return
+    if _is_scope_enforcement_enabled():
+        from ._scope_middleware import ScopeEnforcementMiddleware
+
+        mcp_instance.add_middleware(ScopeEnforcementMiddleware())
+    else:
+        logger.warning(
+            "OAuth scope enforcement is DISABLED "
+            "(REDMINE_OAUTH_SCOPE_ENFORCEMENT=off): any active token can "
+            "call any tool. Re-enable after tokens are re-consented with "
+            "the required scopes."
+        )
+
+
 AUTH_PROVIDER = _select_auth_provider(REDMINE_AUTH_MODE)
 
 mcp = FastMCP("redmine_mcp_tools", auth=AUTH_PROVIDER)
-mcp.add_middleware(CleanValidationErrorMiddleware())
+_register_middlewares(mcp, AUTH_PROVIDER)

--- a/tests/test_auth_factory.py
+++ b/tests/test_auth_factory.py
@@ -82,7 +82,11 @@ class TestBuildRemoteAuth:
             _auth.build_remote_auth()
 
     def test_required_scopes_unset_on_verifier(self, monkeypatch):
-        """required_scopes intentionally unset — we advertise but don't enforce."""
+        """required_scopes stays unset: it is a global AND over every token.
+
+        Per-tool enforcement lives in ScopeEnforcementMiddleware (#185),
+        driven by oauth_scopes.TOOL_SCOPES.
+        """
         monkeypatch.setenv("REDMINE_URL", "https://redmine.example.com")
         monkeypatch.setenv("REDMINE_MCP_BASE_URL", "http://localhost:3040")
         monkeypatch.setenv("REDMINE_INTROSPECT_CLIENT_ID", "cid")

--- a/tests/test_scope_enforcement.py
+++ b/tests/test_scope_enforcement.py
@@ -3,6 +3,12 @@
 import pytest
 
 from redmine_mcp_server._env import _is_scope_enforcement_enabled
+from redmine_mcp_server.oauth_scopes import (
+    TOOL_SCOPES,
+    advertised_scopes,
+    scopes_for_action,
+    tool_visible,
+)
 
 
 class TestScopeEnforcementFlag:
@@ -19,3 +25,78 @@ class TestScopeEnforcementFlag:
     def test_enabled_values(self, monkeypatch, value):
         monkeypatch.setenv("REDMINE_OAUTH_SCOPE_ENFORCEMENT", value)
         assert _is_scope_enforcement_enabled() is True
+
+
+class TestToolScopesMap:
+    @pytest.mark.asyncio
+    async def test_every_registered_tool_is_mapped(self):
+        """Anti-drift guard: a new @mcp.tool() must get a TOOL_SCOPES entry."""
+        from redmine_mcp_server.server import mcp
+        import redmine_mcp_server.tools  # noqa: F401  triggers registration
+        import redmine_mcp_server.apps  # noqa: F401  triggers registration
+
+        tools = await mcp.list_tools()
+        registered = {tool.name for tool in tools}
+        mapped = set(TOOL_SCOPES)
+        assert (
+            registered <= mapped
+        ), f"tools missing from TOOL_SCOPES: {registered - mapped}"
+        # cleanup_attachment_files registers only when
+        # REDMINE_ADMIN_TOOLS_ENABLED is truthy; it must still be mapped.
+        conditional = {"cleanup_attachment_files"}
+        stale = mapped - registered - conditional
+        assert not stale, f"stale TOOL_SCOPES entries: {stale}"
+
+    def test_every_enforced_scope_is_advertised(self):
+        """Enforcement must never demand a scope the consent screen can't grant."""
+        enforced: set = set()
+        for entry in TOOL_SCOPES.values():
+            if isinstance(entry, dict):
+                for req in entry.values():
+                    enforced |= req
+            else:
+                enforced |= entry
+        # Baseline advertisement: read-only off, plugin flags off.
+        advertised = set(advertised_scopes())
+        assert (
+            enforced <= advertised
+        ), f"enforced but not advertised: {enforced - advertised}"
+
+    def test_wiki_write_scopes_advertised(self):
+        advertised = set(advertised_scopes())
+        assert {"rename_wiki_pages", "delete_wiki_pages"} <= advertised
+
+
+class TestScopeHelpers:
+    def test_flat_entry_ignores_arguments(self):
+        entry = frozenset({"edit_issues"})
+        assert scopes_for_action(entry, {"anything": 1}) == entry
+        assert scopes_for_action(entry, None) == entry
+
+    def test_dict_entry_selects_action(self):
+        entry = {
+            "list": frozenset({"view_documents"}),
+            "create": frozenset({"add_documents"}),
+        }
+        assert scopes_for_action(entry, {"action": "create"}) == frozenset(
+            {"add_documents"}
+        )
+
+    def test_dict_entry_unknown_action_passes_through(self):
+        entry = {"list": frozenset({"view_documents"})}
+        assert scopes_for_action(entry, {"action": "explode"}) is None
+        assert scopes_for_action(entry, {}) is None
+        assert scopes_for_action(entry, None) is None
+
+    def test_tool_visible_flat(self):
+        assert tool_visible(frozenset({"view_issues"}), {"view_issues", "x"})
+        assert not tool_visible(frozenset({"edit_issues"}), {"view_issues"})
+        assert tool_visible(frozenset(), set())
+
+    def test_tool_visible_dict_any_action(self):
+        entry = {
+            "list": frozenset({"view_documents"}),
+            "create": frozenset({"add_documents"}),
+        }
+        assert tool_visible(entry, {"view_documents"})
+        assert not tool_visible(entry, {"view_issues"})

--- a/tests/test_scope_enforcement.py
+++ b/tests/test_scope_enforcement.py
@@ -1,0 +1,21 @@
+"""Tests for OAuth per-tool scope enforcement (#185)."""
+
+import pytest
+
+from redmine_mcp_server._env import _is_scope_enforcement_enabled
+
+
+class TestScopeEnforcementFlag:
+    def test_default_is_enabled(self, monkeypatch):
+        monkeypatch.delenv("REDMINE_OAUTH_SCOPE_ENFORCEMENT", raising=False)
+        assert _is_scope_enforcement_enabled() is True
+
+    @pytest.mark.parametrize("value", ["off", "false", "0", "no", "OFF"])
+    def test_disabled_values(self, monkeypatch, value):
+        monkeypatch.setenv("REDMINE_OAUTH_SCOPE_ENFORCEMENT", value)
+        assert _is_scope_enforcement_enabled() is False
+
+    @pytest.mark.parametrize("value", ["on", "true", "1", "yes", "ON"])
+    def test_enabled_values(self, monkeypatch, value):
+        monkeypatch.setenv("REDMINE_OAUTH_SCOPE_ENFORCEMENT", value)
+        assert _is_scope_enforcement_enabled() is True

--- a/tests/test_scope_enforcement.py
+++ b/tests/test_scope_enforcement.py
@@ -1,8 +1,14 @@
 """Tests for OAuth per-tool scope enforcement (#185)."""
 
-import pytest
+import json
+from types import SimpleNamespace
 
+import pytest
+from fastmcp import Client, FastMCP
+
+import redmine_mcp_server._scope_middleware as scope_mw
 from redmine_mcp_server._env import _is_scope_enforcement_enabled
+from redmine_mcp_server._scope_middleware import ScopeEnforcementMiddleware
 from redmine_mcp_server.oauth_scopes import (
     TOOL_SCOPES,
     advertised_scopes,
@@ -100,3 +106,130 @@ class TestScopeHelpers:
         }
         assert tool_visible(entry, {"view_documents"})
         assert not tool_visible(entry, {"view_issues"})
+
+
+def _make_server():
+    mcp = FastMCP("scope-test")
+    mcp.add_middleware(ScopeEnforcementMiddleware())
+
+    @mcp.tool()
+    async def update_redmine_issue(issue_id: int) -> dict:
+        return {"updated": issue_id}
+
+    @mcp.tool()
+    async def list_redmine_issues(project_id: str) -> dict:
+        return {"issues": []}
+
+    @mcp.tool()
+    async def manage_document(action: str, project_id: str = "") -> dict:
+        return {"action": action}
+
+    @mcp.tool()
+    async def get_current_user() -> dict:
+        return {"user": "me"}
+
+    @mcp.tool()
+    async def not_in_map_tool() -> dict:
+        return {"ok": True}
+
+    return mcp
+
+
+def _fake_token(scopes):
+    return SimpleNamespace(token="t", scopes=list(scopes))
+
+
+@pytest.fixture
+def scoped_token(monkeypatch):
+    """Patch get_access_token as seen by the middleware module."""
+
+    def _set(scopes):
+        monkeypatch.setattr(scope_mw, "get_access_token", lambda: _fake_token(scopes))
+
+    return _set
+
+
+class TestCallToolGating:
+    @pytest.mark.asyncio
+    async def test_no_token_passes_through(self, monkeypatch):
+        # Legacy / legacy-per-user / background: middleware is inert.
+        monkeypatch.setattr(scope_mw, "get_access_token", lambda: None)
+        async with Client(_make_server()) as client:
+            result = await client.call_tool("update_redmine_issue", {"issue_id": 1})
+        assert result.structured_content == {"updated": 1}
+
+    @pytest.mark.asyncio
+    async def test_token_with_scope_passes(self, scoped_token):
+        scoped_token(["edit_issues"])
+        async with Client(_make_server()) as client:
+            result = await client.call_tool("update_redmine_issue", {"issue_id": 1})
+        assert result.structured_content == {"updated": 1}
+
+    @pytest.mark.asyncio
+    async def test_token_without_scope_denied(self, scoped_token):
+        # The exact #185 repro: view+notes token must not edit.
+        scoped_token(["view_issues", "add_issue_notes"])
+        async with Client(_make_server()) as client:
+            result = await client.call_tool("update_redmine_issue", {"issue_id": 1})
+        payload = json.loads(result.content[0].text)
+        assert payload["code"] == "INSUFFICIENT_SCOPE"
+        assert "edit_issues" in payload["error"]
+        assert "edit_issues" in payload["hint"]
+
+    @pytest.mark.asyncio
+    async def test_admin_scope_bypasses(self, scoped_token):
+        scoped_token(["admin"])
+        async with Client(_make_server()) as client:
+            result = await client.call_tool("update_redmine_issue", {"issue_id": 1})
+        assert result.structured_content == {"updated": 1}
+
+    @pytest.mark.asyncio
+    async def test_empty_scope_token_denied(self, scoped_token):
+        # Pre-#130 tokens introspect with scope: "" and must be denied.
+        scoped_token([])
+        async with Client(_make_server()) as client:
+            result = await client.call_tool("update_redmine_issue", {"issue_id": 1})
+        payload = json.loads(result.content[0].text)
+        assert payload["code"] == "INSUFFICIENT_SCOPE"
+
+    @pytest.mark.asyncio
+    async def test_empty_requirement_allows_any_token(self, scoped_token):
+        scoped_token([])
+        async with Client(_make_server()) as client:
+            result = await client.call_tool("get_current_user", {})
+        assert result.structured_content == {"user": "me"}
+
+    @pytest.mark.asyncio
+    async def test_unmapped_tool_denied(self, scoped_token):
+        scoped_token(["view_issues", "edit_issues"])
+        async with Client(_make_server()) as client:
+            result = await client.call_tool("not_in_map_tool", {})
+        payload = json.loads(result.content[0].text)
+        assert payload["code"] == "INSUFFICIENT_SCOPE"
+        assert "not_in_map_tool" in payload["error"]
+
+    @pytest.mark.asyncio
+    async def test_action_aware_read_allowed_write_denied(self, scoped_token):
+        scoped_token(["view_documents"])
+        async with Client(_make_server()) as client:
+            ok = await client.call_tool(
+                "manage_document", {"action": "list", "project_id": "p"}
+            )
+            denied = await client.call_tool(
+                "manage_document", {"action": "create", "project_id": "p"}
+            )
+        assert ok.structured_content == {"action": "list"}
+        payload = json.loads(denied.content[0].text)
+        assert payload["code"] == "INSUFFICIENT_SCOPE"
+        assert "add_documents" in payload["error"]
+
+    @pytest.mark.asyncio
+    async def test_unknown_action_passes_to_tool(self, scoped_token):
+        # Middleware must not mask the tool's own invalid-action error.
+        scoped_token(["view_documents"])
+        async with Client(_make_server()) as client:
+            result = await client.call_tool(
+                "manage_document", {"action": "explode", "project_id": "p"}
+            )
+        # Reaches the (test) tool body: no scope denial.
+        assert result.structured_content == {"action": "explode"}

--- a/tests/test_scope_enforcement.py
+++ b/tests/test_scope_enforcement.py
@@ -48,7 +48,7 @@ class TestToolScopesMap:
             registered <= mapped
         ), f"tools missing from TOOL_SCOPES: {registered - mapped}"
         # cleanup_attachment_files registers only when
-        # REDMINE_ADMIN_TOOLS_ENABLED is truthy; it must still be mapped.
+        # REDMINE_MCP_EXPOSE_ADMIN_TOOLS is truthy; it must still be mapped.
         conditional = {"cleanup_attachment_files"}
         stale = mapped - registered - conditional
         assert not stale, f"stale TOOL_SCOPES entries: {stale}"
@@ -113,7 +113,9 @@ def _make_server():
     mcp.add_middleware(ScopeEnforcementMiddleware())
 
     @mcp.tool()
-    async def update_redmine_issue(issue_id: int) -> dict:
+    async def update_redmine_issue(
+        issue_id: int, fields: dict | None = None, uploads: list | None = None
+    ) -> dict:
         return {"updated": issue_id}
 
     @mcp.tool()
@@ -234,6 +236,96 @@ class TestCallToolGating:
         # Reaches the (test) tool body: no scope denial.
         assert result.structured_content == {"action": "explode"}
 
+    @pytest.mark.asyncio
+    async def test_non_string_action_does_not_deny_by_scope(self, scoped_token):
+        # A non-string action can't match a map key; the middleware must
+        # pass it through rather than crash or mis-deny. Whatever error
+        # surfaces belongs to argument validation, not scope enforcement.
+        scoped_token(["view_documents"])
+        async with Client(_make_server()) as client:
+            try:
+                result = await client.call_tool(
+                    "manage_document",
+                    {"action": ["create"], "project_id": "p"},
+                )
+            except Exception as exc:  # noqa: BLE001
+                assert "INSUFFICIENT_SCOPE" not in str(exc)
+                return
+        if result.content and getattr(result.content[0], "text", None):
+            assert "INSUFFICIENT_SCOPE" not in result.content[0].text
+
+
+class TestNotesOnlyCarveOut:
+    @pytest.mark.asyncio
+    async def test_notes_only_allowed_with_add_issue_notes(self, scoped_token):
+        scoped_token(["add_issue_notes"])
+        async with Client(_make_server()) as client:
+            result = await client.call_tool(
+                "update_redmine_issue",
+                {"issue_id": 1, "fields": {"notes": "hi"}},
+            )
+        assert result.structured_content == {"updated": 1}
+
+    @pytest.mark.asyncio
+    async def test_notes_only_denied_without_scope(self, scoped_token):
+        scoped_token([])
+        async with Client(_make_server()) as client:
+            result = await client.call_tool(
+                "update_redmine_issue",
+                {"issue_id": 1, "fields": {"notes": "hi"}},
+            )
+        payload = json.loads(result.content[0].text)
+        assert payload["code"] == "INSUFFICIENT_SCOPE"
+        assert "add_issue_notes" in payload["error"]
+
+    @pytest.mark.asyncio
+    async def test_mixed_fields_require_edit_issues(self, scoped_token):
+        scoped_token(["add_issue_notes"])
+        async with Client(_make_server()) as client:
+            result = await client.call_tool(
+                "update_redmine_issue",
+                {"issue_id": 1, "fields": {"subject": "x", "notes": "hi"}},
+            )
+        payload = json.loads(result.content[0].text)
+        assert payload["code"] == "INSUFFICIENT_SCOPE"
+        assert "edit_issues" in payload["error"]
+
+    @pytest.mark.asyncio
+    async def test_notes_with_uploads_require_edit_issues(self, scoped_token):
+        scoped_token(["add_issue_notes"])
+        async with Client(_make_server()) as client:
+            result = await client.call_tool(
+                "update_redmine_issue",
+                {
+                    "issue_id": 1,
+                    "fields": {"notes": "hi"},
+                    "uploads": [{"path": "f"}],
+                },
+            )
+        payload = json.loads(result.content[0].text)
+        assert payload["code"] == "INSUFFICIENT_SCOPE"
+        assert "edit_issues" in payload["error"]
+
+    @pytest.mark.asyncio
+    async def test_notes_only_denied_for_edit_issues_only_token(self, scoped_token):
+        # Mirrors Redmine: edit_issues alone cannot add notes.
+        scoped_token(["edit_issues"])
+        async with Client(_make_server()) as client:
+            result = await client.call_tool(
+                "update_redmine_issue",
+                {"issue_id": 1, "fields": {"notes": "hi"}},
+            )
+        payload = json.loads(result.content[0].text)
+        assert payload["code"] == "INSUFFICIENT_SCOPE"
+        assert "add_issue_notes" in payload["error"]
+
+    @pytest.mark.asyncio
+    async def test_list_tools_visible_with_add_issue_notes_only(self, scoped_token):
+        scoped_token(["add_issue_notes"])
+        async with Client(_make_server()) as client:
+            tools = {t.name for t in await client.list_tools()}
+        assert "update_redmine_issue" in tools
+
 
 class TestListToolsFiltering:
     @pytest.mark.asyncio
@@ -270,10 +362,7 @@ class TestListToolsFiltering:
 
 class TestServerWiring:
     def _middlewares(self, mcp_instance):
-        # FastMCP stores middleware on .middleware (list). Adjust the
-        # attribute name here if the installed fastmcp differs; check
-        # with: python -c "from fastmcp import FastMCP; m=FastMCP('x');"
-        # then: print([a for a in dir(m) if 'middle' in a.lower()])
+        # FastMCP stores registered middleware on .middleware
         return [type(m).__name__ for m in mcp_instance.middleware]
 
     def test_oauth_mode_registers_scope_middleware(self, monkeypatch):

--- a/tests/test_scope_enforcement.py
+++ b/tests/test_scope_enforcement.py
@@ -233,3 +233,36 @@ class TestCallToolGating:
             )
         # Reaches the (test) tool body: no scope denial.
         assert result.structured_content == {"action": "explode"}
+
+
+class TestListToolsFiltering:
+    @pytest.mark.asyncio
+    async def test_no_token_sees_all(self, monkeypatch):
+        monkeypatch.setattr(scope_mw, "get_access_token", lambda: None)
+        async with Client(_make_server()) as client:
+            tools = {t.name for t in await client.list_tools()}
+        assert "update_redmine_issue" in tools
+        assert "not_in_map_tool" in tools
+
+    @pytest.mark.asyncio
+    async def test_scoped_token_sees_only_permitted(self, scoped_token):
+        scoped_token(["view_documents"])
+        async with Client(_make_server()) as client:
+            tools = {t.name for t in await client.list_tools()}
+        # Dict entry visible because ANY action (list/get) is permitted.
+        assert "manage_document" in tools
+        # frozenset() entry: always visible to authenticated tokens.
+        assert "get_current_user" in tools
+        # Missing scope: hidden.
+        assert "update_redmine_issue" not in tools
+        assert "list_redmine_issues" not in tools
+        # Unmapped: hidden (deny-by-default).
+        assert "not_in_map_tool" not in tools
+
+    @pytest.mark.asyncio
+    async def test_admin_sees_all(self, scoped_token):
+        scoped_token(["admin"])
+        async with Client(_make_server()) as client:
+            tools = {t.name for t in await client.list_tools()}
+        assert "not_in_map_tool" in tools
+        assert "update_redmine_issue" in tools

--- a/tests/test_scope_enforcement.py
+++ b/tests/test_scope_enforcement.py
@@ -266,3 +266,42 @@ class TestListToolsFiltering:
             tools = {t.name for t in await client.list_tools()}
         assert "not_in_map_tool" in tools
         assert "update_redmine_issue" in tools
+
+
+class TestServerWiring:
+    def _middlewares(self, mcp_instance):
+        # FastMCP stores middleware on .middleware (list). Adjust the
+        # attribute name here if the installed fastmcp differs; check
+        # with: python -c "from fastmcp import FastMCP; m=FastMCP('x');"
+        # then: print([a for a in dir(m) if 'middle' in a.lower()])
+        return [type(m).__name__ for m in mcp_instance.middleware]
+
+    def test_oauth_mode_registers_scope_middleware(self, monkeypatch):
+        monkeypatch.delenv("REDMINE_OAUTH_SCOPE_ENFORCEMENT", raising=False)
+        from redmine_mcp_server.server import _register_middlewares
+
+        instance = FastMCP("wiring-test")
+        _register_middlewares(instance, auth_provider=object())
+        names = self._middlewares(instance)
+        assert "CleanValidationErrorMiddleware" in names
+        assert "ScopeEnforcementMiddleware" in names
+
+    def test_legacy_mode_skips_scope_middleware(self, monkeypatch):
+        monkeypatch.delenv("REDMINE_OAUTH_SCOPE_ENFORCEMENT", raising=False)
+        from redmine_mcp_server.server import _register_middlewares
+
+        instance = FastMCP("wiring-test")
+        _register_middlewares(instance, auth_provider=None)
+        names = self._middlewares(instance)
+        assert "ScopeEnforcementMiddleware" not in names
+
+    def test_flag_off_skips_and_warns(self, monkeypatch, caplog):
+        monkeypatch.setenv("REDMINE_OAUTH_SCOPE_ENFORCEMENT", "off")
+        from redmine_mcp_server.server import _register_middlewares
+
+        instance = FastMCP("wiring-test")
+        with caplog.at_level("WARNING"):
+            _register_middlewares(instance, auth_provider=object())
+        names = self._middlewares(instance)
+        assert "ScopeEnforcementMiddleware" not in names
+        assert any("scope enforcement" in r.message.lower() for r in caplog.records)


### PR DESCRIPTION
Fixes #185.

## Problem
The OAuth token verifier left `required_scopes` unset and nothing gated `call_tool`, so advertised token scopes were decorative: a token missing `edit_issues` could still call `update_redmine_issue`. Confirmed against 2.6.0.

## Fix
- FastMCP middleware on `call_tool` and `list_tools` with a central tool-to-scope map (`TOOL_SCOPES` in `oauth_scopes.py`, per-action for `manage_X` tools), deny-by-default for unmapped tools.
- Verifier `required_scopes` stays unset (a global AND across all scopes is the wrong model); enforcement is per-tool.
- `admin` scope bypasses the per-tool check, matching Redmine's semantics.
- `tools/list` is filtered to the token's scopes; `call_tool` remains the actual boundary.
- Notes-only `update_redmine_issue` (only `notes`/`private_notes`, no uploads) requires `add_issue_notes` instead of `edit_issues`, mirroring Redmine's `notes_addable?` check, so commenter tokens can still add notes.
- Enforcement is on by default with a `REDMINE_OAUTH_SCOPE_ENFORCEMENT=off` escape hatch, so tokens issued before this release with blank scope lists can re-consent without bricking. Documented in docs/oauth-setup.md under "Scope Enforcement".
- Two anti-drift guards: every registered tool must have a map entry, and every enforced scope must be advertised.

## Testing
- Unit: 1506 passed, including 41 scope-enforcement tests (deny/allow envelopes, per-action gating, admin bypass, empty-scope denial, unmapped-tool denial, `tools/list` filtering, `off` behavior).
- Integration: 80 passed against a live Redmine 6 + Doorkeeper instance.
- Live end-to-end in `oauth` mode with a real introspected token lacking `delete_wiki_pages`: filtered `tools/list`, permitted calls passed, notes-only update passed via the carve-out, `manage_redmine_wiki_page(action=delete)` rejected with `INSUFFICIENT_SCOPE`.
- Independently retested and confirmed by the reporter (@stevehollis-orderflow) on Cursor + Redmine 6.1.x against `d315e51`.

## Contributors
- @stevehollis-orderflow reported the gap with a clean repro and retested the fix.
