### PR TITLE
feat: opt-in self-AS OAuth discovery and scope subsetting (#188, #189)

### DIFF
--- a/.env.docker.example
+++ b/.env.docker.example
@@ -36,6 +36,20 @@ REDMINE_MCP_BASE_URL=http://localhost:3040
 # tokens issued before scope enforcement lack scopes and need re-consent.
 # REDMINE_OAUTH_SCOPE_ENFORCEMENT=on
 
+# OAuth discovery profile (oauth mode only). Default: redmine.
+#   redmine = advertise Redmine as the authorization server (post-#140).
+#   self    = advertise this MCP server as the authorization server
+#             (issuer = REDMINE_MCP_BASE_URL) for clients that probe the
+#             AS canonical well-known location (e.g. Cursor). Authorize and
+#             token endpoints still point at Redmine /oauth/*.
+# REDMINE_OAUTH_DISCOVERY_AS=self
+
+# Advertise only a subset of OAuth scopes in discovery (oauth mode only).
+# Space-separated; must be a subset of the scopes this server would otherwise
+# advertise. Use when the Redmine OAuth Application enables only a subset, so
+# consent does not request scopes it never granted.
+# REDMINE_MCP_SCOPES=view_project search_project view_members view_issues add_issue_notes
+
 # Server configuration
 SERVER_HOST=0.0.0.0
 SERVER_PORT=8000

--- a/.env.example
+++ b/.env.example
@@ -50,6 +50,20 @@ REDMINE_INTROSPECT_CLIENT_SECRET=
 # tokens issued before scope enforcement lack scopes and need re-consent.
 # REDMINE_OAUTH_SCOPE_ENFORCEMENT=on
 
+# OAuth discovery profile (oauth mode only). Default: redmine.
+#   redmine = advertise Redmine as the authorization server (post-#140).
+#   self    = advertise this MCP server as the authorization server
+#             (issuer = REDMINE_MCP_BASE_URL) for clients that probe the
+#             AS canonical well-known location (e.g. Cursor). Authorize and
+#             token endpoints still point at Redmine /oauth/*.
+# REDMINE_OAUTH_DISCOVERY_AS=self
+
+# Advertise only a subset of OAuth scopes in discovery (oauth mode only).
+# Space-separated; must be a subset of the scopes this server would otherwise
+# advertise. Use when the Redmine OAuth Application enables only a subset, so
+# consent does not request scopes it never granted.
+# REDMINE_MCP_SCOPES=view_project search_project view_members view_issues add_issue_notes
+
 # OAuthProxy signing key (required when REDMINE_AUTH_MODE=oauth-proxy).
 # Use a stable secret value; changing it invalidates FastMCP proxy tokens/storage.
 REDMINE_MCP_JWT_SIGNING_KEY=

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Opt-in self-AS OAuth discovery profile ([#188](https://github.com/jztan/redmine-mcp-server/issues/188)):
+  set `REDMINE_OAUTH_DISCOVERY_AS=self` so the server advertises itself as the
+  authorization server (issuer = `REDMINE_MCP_BASE_URL`) and serves RFC 8414
+  metadata at its own canonical well-known location, while authorize and token
+  requests still target Redmine `/oauth/*`. Lets clients that probe the
+  authorization server's canonical location (e.g. Cursor) complete OAuth in
+  stock `oauth` mode. Default (`redmine`) behavior is unchanged.
+- Advertise a subset of OAuth scopes in discovery via `REDMINE_MCP_SCOPES`
+  ([#189](https://github.com/jztan/redmine-mcp-server/issues/189)): when the
+  Redmine OAuth Application enables only a subset of permissions, advertising a
+  matching `scopes_supported` avoids `invalid_scope` at consent for clients
+  that request the full advertised list.
+
 ### Security
 - OAuth token scopes are now enforced on MCP tool calls ([#185](https://github.com/jztan/redmine-mcp-server/issues/185)):
   each tool requires the Redmine permission scopes it uses (per-action for
@@ -19,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Contributors
 - @stevehollis-orderflow — reported that OAuth token scopes were advertised but not enforced on tool calls, with a precise repro and a sound enforcement design ([#185](https://github.com/jztan/redmine-mcp-server/issues/185))
+- @stevehollis-orderflow — reported the Cursor OAuth discovery incompatibility and the scope-subset gap, with precise repros ([#188](https://github.com/jztan/redmine-mcp-server/issues/188), [#189](https://github.com/jztan/redmine-mcp-server/issues/189))
 
 ## [2.7.0] - 2026-07-20
 ### Added

--- a/docs/oauth-setup.md
+++ b/docs/oauth-setup.md
@@ -255,6 +255,13 @@ set `REDMINE_MCP_SCOPES` to that subset so the advertised `scopes_supported`
 matches what the Application can grant and consent does not fail with
 `invalid_scope`.
 
+`REDMINE_MCP_SCOPES` is a subset of the scopes this server already advertises
+(the Redmine permissions its tools actually use), not a mirror of the
+Application's full permission list. Permissions your Application grants but no
+MCP tool uses (for example `view_gantt`, `copy_issues`, `edit_own_time_entries`)
+are not in that set and are rejected at boot; leave them out of
+`REDMINE_MCP_SCOPES`. The boot error lists the full set of accepted scopes.
+
 Note: `REDMINE_OAUTH_DISCOVERY_AS` and `REDMINE_MCP_SCOPES` apply to `oauth`
 mode only and are ignored in `oauth-proxy` mode, where this server is the
 authorization-server gateway.

--- a/docs/oauth-setup.md
+++ b/docs/oauth-setup.md
@@ -235,6 +235,30 @@ which restores the pre-enforcement behavior (any active token can call
 any tool) and logs a warning at startup. Re-enable it once clients have
 re-consented.
 
+### Cursor and self-AS discovery
+
+Some MCP clients (for example Cursor) discover the authorization server by
+probing its canonical RFC 8414 well-known location. Because stock `oauth`
+mode names Redmine as the authorization server and no released Redmine
+Doorkeeper serves `/.well-known/oauth-authorization-server`, those clients
+fail discovery.
+
+Set `REDMINE_OAUTH_DISCOVERY_AS=self` so this server advertises itself as the
+authorization server (issuer = `REDMINE_MCP_BASE_URL`) and serves the RFC 8414
+document at its own canonical well-known location. Authorize and token
+requests still go directly to Redmine `/oauth/authorize` and `/oauth/token`,
+so the client keeps using its static confidential client registered in
+Redmine. This mode is opt-in; the default `redmine` mode is unchanged.
+
+If the Redmine OAuth Application enables only a subset of permissions, also
+set `REDMINE_MCP_SCOPES` to that subset so the advertised `scopes_supported`
+matches what the Application can grant and consent does not fail with
+`invalid_scope`.
+
+The `oauth-proxy` mode is a different model (this server proxies authorize and
+token and issues its own client registrations); it is the alternative when you
+want a full authorization-server gateway rather than direct-to-Redmine consent.
+
 ## Migrating from Legacy Mode
 
 1. Set `REDMINE_AUTH_MODE=oauth` and restart — no downtime needed

--- a/docs/oauth-setup.md
+++ b/docs/oauth-setup.md
@@ -255,6 +255,10 @@ set `REDMINE_MCP_SCOPES` to that subset so the advertised `scopes_supported`
 matches what the Application can grant and consent does not fail with
 `invalid_scope`.
 
+Note: `REDMINE_OAUTH_DISCOVERY_AS` and `REDMINE_MCP_SCOPES` apply to `oauth`
+mode only and are ignored in `oauth-proxy` mode, where this server is the
+authorization-server gateway.
+
 The `oauth-proxy` mode is a different model (this server proxies authorize and
 token and issues its own client registrations); it is the alternative when you
 want a full authorization-server gateway rather than direct-to-Redmine consent.

--- a/src/redmine_mcp_server/_auth.py
+++ b/src/redmine_mcp_server/_auth.py
@@ -5,8 +5,8 @@ Builds a RemoteAuthProvider that:
     (POST {REDMINE_URL}/oauth/introspect).
   - Mounts RFC 9728 protected-resource metadata at
     /.well-known/oauth-protected-resource/mcp.
-  - Advertises scopes_supported from oauth_scopes.advertised_scopes()
-    (filtered when REDMINE_MCP_READ_ONLY=true).
+  - Advertises scopes_supported from oauth_scopes.configured_advertised_scopes()
+    (filtered by REDMINE_MCP_READ_ONLY and REDMINE_MCP_SCOPES).
 
 The MCP server's introspection client_id/secret are read from
 REDMINE_INTROSPECT_CLIENT_ID / REDMINE_INTROSPECT_CLIENT_SECRET. The
@@ -31,7 +31,7 @@ import os
 from urllib.parse import urlparse
 
 from ._env import require_introspection_credentials
-from .oauth_scopes import advertised_scopes
+from .oauth_scopes import configured_advertised_scopes
 
 logger = logging.getLogger(__name__)
 
@@ -187,5 +187,5 @@ def build_remote_auth() -> RedmineAuthProvider:
         base_url=base_url,
         introspect_client_id=client_id,
         introspect_client_secret=client_secret,
-        scopes_supported=advertised_scopes(),
+        scopes_supported=configured_advertised_scopes(),
     )

--- a/src/redmine_mcp_server/_auth.py
+++ b/src/redmine_mcp_server/_auth.py
@@ -157,17 +157,28 @@ class RedmineAuthProvider(RemoteAuthProvider):
     def get_routes(self, mcp_path: str | None = None) -> list[Route]:
         routes = super().get_routes(mcp_path)
         base_path = urlparse(str(self.base_url)).path.rstrip("/")
-        metadata_path = f"{base_path}{mcp_path or ''}"
+        suffix_path = f"{base_path}{mcp_path or ''}"
 
-        routes.append(
-            Route(
-                f"/.well-known/oauth-authorization-server{metadata_path}",
-                endpoint=cors_middleware(
-                    self.oauth_authorization_server, ["GET", "OPTIONS"]
-                ),
-                methods=["GET", "OPTIONS"],
+        as_paths = [f"/.well-known/oauth-authorization-server{suffix_path}"]
+        if self.discovery_as == "self":
+            # RFC 8414 3.1 canonical location for issuer = base_url: insert the
+            # well-known suffix between host and the base path (root when the
+            # base URL has no path). Served in addition to the suffixed path so
+            # clients probing either location succeed.
+            canonical = f"/.well-known/oauth-authorization-server{base_path}"
+            if canonical not in as_paths:
+                as_paths.append(canonical)
+
+        for as_path in as_paths:
+            routes.append(
+                Route(
+                    as_path,
+                    endpoint=cors_middleware(
+                        self.oauth_authorization_server, ["GET", "OPTIONS"]
+                    ),
+                    methods=["GET", "OPTIONS"],
+                )
             )
-        )
         routes.append(Route("/revoke", self.revoke_token, methods=["POST"]))
         return routes
 

--- a/src/redmine_mcp_server/_auth.py
+++ b/src/redmine_mcp_server/_auth.py
@@ -30,7 +30,7 @@ import logging
 import os
 from urllib.parse import urlparse
 
-from ._env import require_introspection_credentials
+from ._env import require_introspection_credentials, _oauth_discovery_as
 from .oauth_scopes import configured_advertised_scopes
 
 logger = logging.getLogger(__name__)
@@ -47,8 +47,15 @@ class RedmineAuthProvider(RemoteAuthProvider):
         introspect_client_id: str,
         introspect_client_secret: str,
         scopes_supported: list[str],
+        discovery_as: str = "redmine",
     ):
         self.redmine_url = redmine_url
+        self.discovery_as = discovery_as
+        # In self-AS mode the MCP server is the authorization server that
+        # clients discover (issuer = base_url); authorize/token still target
+        # Redmine. In redmine mode the issuer names Redmine (post-#140).
+        issuer_source = base_url if discovery_as == "self" else str(redmine_url)
+        self.issuer = AnyHttpUrl(issuer_source)
         verifier = IntrospectionTokenVerifier(
             introspection_url=str(self.redmine_endpoint("/oauth/introspect")),
             client_id=introspect_client_id,
@@ -60,7 +67,7 @@ class RedmineAuthProvider(RemoteAuthProvider):
 
         super().__init__(
             token_verifier=verifier,
-            authorization_servers=[redmine_url],
+            authorization_servers=[self.issuer],
             base_url=base_url,
             scopes_supported=scopes_supported,
             resource_name="Redmine MCP Server",
@@ -75,7 +82,7 @@ class RedmineAuthProvider(RemoteAuthProvider):
     async def oauth_authorization_server(self, request: Request):
         """RFC 8414 authorization-server metadata for Redmine Doorkeeper."""
         metadata = OAuthMetadata(
-            issuer=self.redmine_url,
+            issuer=self.issuer,
             authorization_endpoint=self.redmine_endpoint("/oauth/authorize"),
             token_endpoint=self.redmine_endpoint("/oauth/token"),
             revocation_endpoint=self.redmine_endpoint("/oauth/revoke"),
@@ -188,4 +195,5 @@ def build_remote_auth() -> RedmineAuthProvider:
         introspect_client_id=client_id,
         introspect_client_secret=client_secret,
         scopes_supported=configured_advertised_scopes(),
+        discovery_as=_oauth_discovery_as(),
     )

--- a/src/redmine_mcp_server/_env.py
+++ b/src/redmine_mcp_server/_env.py
@@ -54,6 +54,23 @@ def _is_scope_enforcement_enabled() -> bool:
     return _is_true_env("REDMINE_OAUTH_SCOPE_ENFORCEMENT", "true")
 
 
+def _oauth_discovery_as() -> str:
+    """Select the OAuth discovery profile (#188).
+
+    ``redmine`` (default): advertise Redmine as the authorization server
+    (issuer = REDMINE_URL), the post-#140 behavior. ``self``: advertise this
+    MCP server as the authorization server (issuer = REDMINE_MCP_BASE_URL)
+    while authorize/token stay on Redmine /oauth/*, for clients that probe the
+    authorization server's canonical well-known location (e.g. Cursor).
+    """
+    value = os.getenv("REDMINE_OAUTH_DISCOVERY_AS", "redmine").strip().lower()
+    if value not in {"redmine", "self"}:
+        raise RuntimeError(
+            "REDMINE_OAUTH_DISCOVERY_AS must be 'redmine' or 'self', " f"got '{value}'."
+        )
+    return value
+
+
 def _admin_tools_enabled() -> bool:
     """Check if operator-facing admin tools are exposed on the MCP surface.
 

--- a/src/redmine_mcp_server/oauth_scopes.py
+++ b/src/redmine_mcp_server/oauth_scopes.py
@@ -165,7 +165,7 @@ def configured_advertised_scopes() -> list[str]:
     if invalid:
         raise RuntimeError(
             "REDMINE_MCP_SCOPES contains scope(s) not advertised in this "
-            f"mode: {', '.join(invalid)}. Allowed: {', '.join(full)}."
+            f"mode: {', '.join(dict.fromkeys(invalid))}. Allowed: {', '.join(full)}."
         )
 
     requested_set = set(requested)

--- a/src/redmine_mcp_server/oauth_scopes.py
+++ b/src/redmine_mcp_server/oauth_scopes.py
@@ -24,6 +24,7 @@ Exclusions:
       scopes a Redmine doesn't recognize causes consent errors.
 """
 
+import os
 from typing import Dict, Optional, Union
 
 from ._env import _is_agile_enabled, _is_read_only_mode, _is_tags_enabled
@@ -134,6 +135,41 @@ def advertised_scopes() -> list[str]:
         if not _is_read_only_mode():
             scopes += list(TAGS_WRITE_SCOPES)
     return scopes
+
+
+def configured_advertised_scopes() -> list[str]:
+    """Return the advertised scopes, optionally narrowed by REDMINE_MCP_SCOPES.
+
+    When ``REDMINE_MCP_SCOPES`` (space-separated) is set, discovery advertises
+    exactly that subset instead of the full :func:`advertised_scopes`. This
+    lets a deployment whose Redmine OAuth Application enables only a subset of
+    permissions advertise a matching ``scopes_supported`` so consent does not
+    request scopes the Application never grants (#189). Independent of #185,
+    which gates on *token* scopes.
+
+    Every requested scope must be a member of the current-mode
+    :func:`advertised_scopes` (respecting read-only / agile / tags gating);
+    an out-of-set or unknown entry raises ``RuntimeError`` so the server fails
+    fast at boot rather than advertising a scope its own tools cannot use.
+    The result preserves :func:`advertised_scopes` ordering and is duplicate
+    free, so both discovery documents stay identical and deterministic.
+    """
+    full = advertised_scopes()
+    raw = os.getenv("REDMINE_MCP_SCOPES")
+    if raw is None or not raw.strip():
+        return full
+
+    requested = raw.split()
+    allowed = set(full)
+    invalid = [s for s in requested if s not in allowed]
+    if invalid:
+        raise RuntimeError(
+            "REDMINE_MCP_SCOPES contains scope(s) not advertised in this "
+            f"mode: {', '.join(invalid)}. Allowed: {', '.join(full)}."
+        )
+
+    requested_set = set(requested)
+    return [s for s in full if s in requested_set]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_configured_scopes.py
+++ b/tests/test_configured_scopes.py
@@ -59,3 +59,13 @@ def test_write_scope_rejected_in_read_only_mode(monkeypatch):
     )
     with pytest.raises(RuntimeError, match="edit_issues"):
         mod.configured_advertised_scopes()
+
+
+def test_duplicate_invalid_scope_not_repeated_in_error(monkeypatch):
+    mod = _reload_scopes(monkeypatch, REDMINE_MCP_SCOPES="nope nope")
+    with pytest.raises(RuntimeError) as exc:
+        mod.configured_advertised_scopes()
+    # "nope" appears once in the invalid-scopes portion, not twice
+    msg = str(exc.value)
+    invalid_part = msg.split("Allowed:")[0]
+    assert invalid_part.count("nope") == 1

--- a/tests/test_configured_scopes.py
+++ b/tests/test_configured_scopes.py
@@ -1,0 +1,61 @@
+"""Unit tests for REDMINE_MCP_SCOPES advertised-scope subsetting (#189)."""
+
+import importlib
+
+import pytest
+
+
+def _reload_scopes(monkeypatch, **env):
+    for key in (
+        "REDMINE_MCP_SCOPES",
+        "REDMINE_MCP_READ_ONLY",
+        "REDMINE_AGILE_ENABLED",
+        "REDMINE_TAGS_ENABLED",
+    ):
+        monkeypatch.delenv(key, raising=False)
+    for key, value in env.items():
+        monkeypatch.setenv(key, value)
+    from redmine_mcp_server import oauth_scopes
+
+    importlib.reload(oauth_scopes)
+    return oauth_scopes
+
+
+def test_unset_returns_full_catalogue(monkeypatch):
+    mod = _reload_scopes(monkeypatch)
+    assert mod.configured_advertised_scopes() == mod.advertised_scopes()
+
+
+def test_blank_returns_full_catalogue(monkeypatch):
+    mod = _reload_scopes(monkeypatch, REDMINE_MCP_SCOPES="   ")
+    assert mod.configured_advertised_scopes() == mod.advertised_scopes()
+
+
+def test_valid_subset_narrows_in_advertised_order(monkeypatch):
+    mod = _reload_scopes(
+        monkeypatch,
+        REDMINE_MCP_SCOPES="view_issues view_project add_issue_notes",
+    )
+    result = mod.configured_advertised_scopes()
+    assert result == ["view_project", "view_issues", "add_issue_notes"]
+
+
+def test_duplicate_requests_deduped(monkeypatch):
+    mod = _reload_scopes(monkeypatch, REDMINE_MCP_SCOPES="view_issues view_issues")
+    assert mod.configured_advertised_scopes() == ["view_issues"]
+
+
+def test_unknown_scope_raises(monkeypatch):
+    mod = _reload_scopes(monkeypatch, REDMINE_MCP_SCOPES="view_issues not_a_scope")
+    with pytest.raises(RuntimeError, match="not_a_scope"):
+        mod.configured_advertised_scopes()
+
+
+def test_write_scope_rejected_in_read_only_mode(monkeypatch):
+    mod = _reload_scopes(
+        monkeypatch,
+        REDMINE_MCP_READ_ONLY="true",
+        REDMINE_MCP_SCOPES="view_issues edit_issues",
+    )
+    with pytest.raises(RuntimeError, match="edit_issues"):
+        mod.configured_advertised_scopes()

--- a/tests/test_env_discovery_mode.py
+++ b/tests/test_env_discovery_mode.py
@@ -1,0 +1,26 @@
+"""Unit tests for REDMINE_OAUTH_DISCOVERY_AS parsing (#188)."""
+
+import pytest
+
+from redmine_mcp_server._env import _oauth_discovery_as
+
+
+def test_default_is_redmine(monkeypatch):
+    monkeypatch.delenv("REDMINE_OAUTH_DISCOVERY_AS", raising=False)
+    assert _oauth_discovery_as() == "redmine"
+
+
+def test_self_selected(monkeypatch):
+    monkeypatch.setenv("REDMINE_OAUTH_DISCOVERY_AS", "self")
+    assert _oauth_discovery_as() == "self"
+
+
+def test_case_and_whitespace_insensitive(monkeypatch):
+    monkeypatch.setenv("REDMINE_OAUTH_DISCOVERY_AS", "  SELF ")
+    assert _oauth_discovery_as() == "self"
+
+
+def test_invalid_value_raises(monkeypatch):
+    monkeypatch.setenv("REDMINE_OAUTH_DISCOVERY_AS", "proxy")
+    with pytest.raises(RuntimeError, match="REDMINE_OAUTH_DISCOVERY_AS"):
+        _oauth_discovery_as()

--- a/tests/test_oauth_discovery.py
+++ b/tests/test_oauth_discovery.py
@@ -262,3 +262,28 @@ async def test_redmine_mode_unchanged_regression(oauth_app):
         asm = (await client.get("/.well-known/oauth-authorization-server/mcp")).json()
     assert asm["issuer"] == "https://r.example.com/"
     assert asm["authorization_endpoint"] == "https://r.example.com/oauth/authorize"
+
+
+@pytest.mark.asyncio
+async def test_self_mode_serves_canonical_root_well_known(monkeypatch):
+    """Self mode serves AS metadata at the issuer's canonical root location."""
+    app = _build_self_mode_app(monkeypatch)  # base has no path -> root
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        root = await client.get("/.well-known/oauth-authorization-server")
+        suffixed = await client.get("/.well-known/oauth-authorization-server/mcp")
+
+    assert root.status_code == 200
+    assert suffixed.status_code == 200
+    assert root.json()["issuer"] == "http://localhost:3040/"
+
+
+@pytest.mark.asyncio
+async def test_redmine_mode_root_well_known_still_404(oauth_app):
+    """Default mode must NOT serve the root AS well-known (would break #140 clients)."""
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=oauth_app), base_url="http://test"
+    ) as client:
+        r = await client.get("/.well-known/oauth-authorization-server")
+    assert r.status_code == 404

--- a/tests/test_oauth_discovery.py
+++ b/tests/test_oauth_discovery.py
@@ -216,3 +216,49 @@ async def test_scopes_subset_narrows_both_documents(monkeypatch):
 
     assert pr["scopes_supported"] == ["view_project", "view_issues"]
     assert asm["scopes_supported"] == ["view_project", "view_issues"]
+
+
+def _build_self_mode_app(monkeypatch, base_url="http://localhost:3040"):
+    monkeypatch.setenv("REDMINE_URL", "https://r.example.com")
+    monkeypatch.setenv("REDMINE_MCP_BASE_URL", base_url)
+    monkeypatch.setenv("REDMINE_INTROSPECT_CLIENT_ID", "cid")
+    monkeypatch.setenv("REDMINE_INTROSPECT_CLIENT_SECRET", "csec")
+    monkeypatch.delenv("REDMINE_MCP_READ_ONLY", raising=False)
+    monkeypatch.delenv("REDMINE_MCP_SCOPES", raising=False)
+    monkeypatch.setenv("REDMINE_OAUTH_DISCOVERY_AS", "self")
+
+    from redmine_mcp_server import _auth, oauth_scopes
+
+    importlib.reload(oauth_scopes)
+    importlib.reload(_auth)
+
+    auth_provider = _auth.build_remote_auth()
+    return FastMCP("self_as_test", auth=auth_provider).http_app(stateless_http=True)
+
+
+@pytest.mark.asyncio
+async def test_self_mode_advertises_base_as_issuer_and_as(monkeypatch):
+    app = _build_self_mode_app(monkeypatch)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        pr = (await client.get("/.well-known/oauth-protected-resource/mcp")).json()
+        asm = (await client.get("/.well-known/oauth-authorization-server/mcp")).json()
+
+    # issuer + authorization_servers name the MCP base, not Redmine
+    assert asm["issuer"] == "http://localhost:3040/"
+    assert [str(u) for u in pr["authorization_servers"]] == ["http://localhost:3040/"]
+    # ...but authorize/token still point at Redmine /oauth/*
+    assert asm["authorization_endpoint"] == "https://r.example.com/oauth/authorize"
+    assert asm["token_endpoint"] == "https://r.example.com/oauth/token"
+
+
+@pytest.mark.asyncio
+async def test_redmine_mode_unchanged_regression(oauth_app):
+    """Default (redmine) mode still names Redmine as issuer + AS (preserves #140)."""
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=oauth_app), base_url="http://test"
+    ) as client:
+        asm = (await client.get("/.well-known/oauth-authorization-server/mcp")).json()
+    assert asm["issuer"] == "https://r.example.com/"
+    assert asm["authorization_endpoint"] == "https://r.example.com/oauth/authorize"

--- a/tests/test_oauth_discovery.py
+++ b/tests/test_oauth_discovery.py
@@ -188,3 +188,31 @@ async def test_authenticated_app_mounts_remote_auth_under_base_url_path(monkeypa
     assert asm.status_code == 200
     assert mounted_prm.status_code == 404
     assert mcp_get.status_code == 405
+
+
+@pytest.mark.asyncio
+async def test_scopes_subset_narrows_both_documents(monkeypatch):
+    """REDMINE_MCP_SCOPES restricts scopes_supported in both discovery docs."""
+    monkeypatch.setenv("REDMINE_URL", "https://r.example.com")
+    monkeypatch.setenv("REDMINE_MCP_BASE_URL", "http://localhost:3040")
+    monkeypatch.setenv("REDMINE_INTROSPECT_CLIENT_ID", "cid")
+    monkeypatch.setenv("REDMINE_INTROSPECT_CLIENT_SECRET", "csec")
+    monkeypatch.delenv("REDMINE_MCP_READ_ONLY", raising=False)
+    monkeypatch.setenv("REDMINE_MCP_SCOPES", "view_project view_issues")
+
+    from redmine_mcp_server import _auth, oauth_scopes
+
+    importlib.reload(oauth_scopes)
+    importlib.reload(_auth)
+
+    auth_provider = _auth.build_remote_auth()
+    app = FastMCP("scope_subset_test", auth=auth_provider).http_app(stateless_http=True)
+
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        pr = (await client.get("/.well-known/oauth-protected-resource/mcp")).json()
+        asm = (await client.get("/.well-known/oauth-authorization-server/mcp")).json()
+
+    assert pr["scopes_supported"] == ["view_project", "view_issues"]
+    assert asm["scopes_supported"] == ["view_project", "view_issues"]


### PR DESCRIPTION
Two opt-in OAuth discovery-advertising controls so narrow-scope MCP clients (Cursor and others that probe the authorization server's canonical well-known location) can complete OAuth against Redmine Doorkeeper in stock `oauth` mode. Both default off; token verification and #185 per-tool enforcement are untouched.

## #188: self-AS discovery profile
`REDMINE_OAUTH_DISCOVERY_AS=self` makes the server advertise itself as the authorization server (issuer = `REDMINE_MCP_BASE_URL`) and serve RFC 8414 metadata at that issuer's canonical well-known location, while `authorization_endpoint` / `token_endpoint` / `revocation_endpoint` still point at Redmine `/oauth/*`. The client keeps using its static confidential client registered in Redmine.

Root cause: stock `oauth` mode names Redmine as the authorization server, but no released Doorkeeper serves `/.well-known/oauth-authorization-server`, so clients that probe the issuer's canonical location fail discovery. The default `redmine` mode is unchanged and preserves the #140 fix (issuer == authorization_servers, both naming Redmine).

## #189: advertised-scope subsetting
`REDMINE_MCP_SCOPES` (space-separated) advertises only a subset of `scopes_supported`, validated as a subset of the current-mode advertised scopes, fail-fast at boot on an out-of-set scope. When a Redmine OAuth Application enables only a subset of permissions, this stops clients that request the full advertised list from failing consent with `invalid_scope`. Independent of #185 (which gates on token scopes).

## Testing
- Full unit suite green, including 16 new tests across scope subsetting, the discovery-mode selector, self-AS issuer/endpoint split, the canonical route, and a `redmine`-mode regression guard that locks the #140 behavior.
- flake8 + black clean.
- `REDMINE_OAUTH_DISCOVERY_AS` and `REDMINE_MCP_SCOPES` apply to `oauth` mode only (documented); `oauth-proxy` mode is unaffected.

Reporter verification requested on #188 and #189.
