### PR TITLE
feat: support writing agile_sprint_id/position via update_redmine_issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,15 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - Write support for agile sprint and position via `update_redmine_issue`
-  ([#193](https://github.com/jztan/redmine-mcp-server/issues/193)): a nested
-  `agile_data_attributes` dict in `fields` may now carry `agile_sprint_id`
-  (set to `0`/null to remove the issue from its sprint), `position`, and
-  `story_points`, routed to the RedmineUP Agile plugin endpoint the same way
-  top-level `story_points` already was. Previously `agile_sprint_id` was
+  ([#193](https://github.com/jztan/redmine-mcp-server/issues/193)):
+  `agile_sprint_id` (set to `0`/null to remove the issue from its sprint) and
+  `position` may now be set, given either top-level in `fields` or nested under
+  an `agile_data_attributes` dict, routed to the RedmineUP Agile plugin endpoint
+  the same way `story_points` already was. Previously `agile_sprint_id` was
   silently dropped, so issues could not be moved to/from a sprint through the
-  MCP server. The updated issue is now augmented with the resulting
-  `story_points`, `agile_sprint_id`, and `agile_position` so the change can be
-  verified from the response.
+  MCP server. Writes are applied in place — the current `agile_data` row (id and
+  existing values) is carried forward — so changing one agile field never nulls
+  the others. The updated issue is augmented with the resulting `story_points`,
+  `agile_sprint_id`, and `agile_position` so the change can be verified from the
+  response.
 
 ## [2.8.0] - 2026-07-25
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Write support for agile sprint and position via `update_redmine_issue`
+  ([#NNN](https://github.com/jztan/redmine-mcp-server/issues/NNN)): a nested
+  `agile_data_attributes` dict in `fields` may now carry `agile_sprint_id`
+  (set to `0`/null to remove the issue from its sprint), `position`, and
+  `story_points`, routed to the RedmineUP Agile plugin endpoint the same way
+  top-level `story_points` already was. Previously `agile_sprint_id` was
+  silently dropped, so issues could not be moved to/from a sprint through the
+  MCP server. The updated issue is now augmented with the resulting
+  `story_points`, `agile_sprint_id`, and `agile_position` so the change can be
+  verified from the response.
 
 ## [2.8.0] - 2026-07-25
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - Write support for agile sprint and position via `update_redmine_issue`
-  ([#NNN](https://github.com/jztan/redmine-mcp-server/issues/NNN)): a nested
+  ([#193](https://github.com/jztan/redmine-mcp-server/issues/193)): a nested
   `agile_data_attributes` dict in `fields` may now carry `agile_sprint_id`
   (set to `0`/null to remove the issue from its sprint), `position`, and
   `story_points`, routed to the RedmineUP Agile plugin endpoint the same way

--- a/docs/tool-reference.md
+++ b/docs/tool-reference.md
@@ -926,9 +926,25 @@ Updates an existing issue with the provided fields. Blocked when `REDMINE_MCP_RE
 **Note:** You can use either `status_id` or `status_name` in fields. When `status_name` is provided, the tool automatically resolves the corresponding status ID.
 You can also update custom fields by name (for example `{"size": "S"}`) and the tool will resolve them to Redmine `custom_fields` entries using project custom-field metadata. You can still pass explicit `custom_fields` with field IDs.
 
-When `REDMINE_AGILE_ENABLED=true`, you can also pass `story_points` (non-negative integer or `null` to clear) and it will be written via the RedmineUP Agile plugin endpoint. If the plugin is disabled, `story_points` is silently ignored.
+When `REDMINE_AGILE_ENABLED=true`, you can also set RedmineUP Agile fields, written via the Agile plugin endpoint:
 
-**Note:** `story_points` is always intercepted before custom field resolution, regardless of the `REDMINE_AGILE_ENABLED` setting. If your Redmine instance has a custom field literally named `"story_points"`, it cannot be updated by name through this tool — use explicit `custom_fields` with its field ID instead (e.g. `{"custom_fields": [{"id": 42, "value": "8"}]}`).
+- `story_points` — non-negative integer, or `null` to clear.
+- `agile_sprint_id` — the sprint (board) the issue belongs to; `0`/`null` removes it from its sprint.
+- `position` — position within the sprint/backlog (read back as `agile_position`; accepted under either name).
+
+Each may be given top-level in `fields` or nested under an `agile_data_attributes` dict (both forms are equivalent):
+
+```python
+# Move issue to sprint 117 (top-level or nested are equivalent)
+update_redmine_issue(issue_id=123, fields={"agile_sprint_id": 117})
+update_redmine_issue(issue_id=123, fields={"agile_data_attributes": {"agile_sprint_id": 117}})
+# Remove from its sprint
+update_redmine_issue(issue_id=123, fields={"agile_sprint_id": 0})
+```
+
+Updates are applied **in place**: the tool reads the current `agile_data` row and carries the existing values (and row id) forward, so changing one agile field (e.g. the sprint) does not clear the others. The updated issue is returned with the resulting `story_points`, `agile_sprint_id`, and `agile_position` so the change can be verified from the response. If the plugin is disabled, these agile keys are silently ignored.
+
+**Note:** these agile keys are always intercepted before custom field resolution, regardless of the `REDMINE_AGILE_ENABLED` setting. If your Redmine instance has a custom field literally named `"story_points"` (or `"agile_sprint_id"`/`"position"`), it cannot be updated by name through this tool — use explicit `custom_fields` with its field ID instead (e.g. `{"custom_fields": [{"id": 42, "value": "8"}]}`).
 
 When `REDMINE_TAGS_ENABLED=true`, you can pass `tag_list` to set the issue's AlphaNodes additional_tags tags — a list of names or a comma-separated string; `[]` clears all tags. It replaces the full tag set (it is not additive), is intercepted before custom-field resolution (so a custom field named `"tag_list"` must use the explicit `custom_fields` id form), and requires `create_issue_tags` (new tags) or `edit_issue_tags` (existing tags only). A `tag_list` change is recorded in the issue journal. Silently ignored when the flag is off.
 

--- a/src/redmine_mcp_server/tools/issues.py
+++ b/src/redmine_mcp_server/tools/issues.py
@@ -70,8 +70,14 @@ def _fetch_agile_data(issue_id: int) -> Dict[str, Any]:
     }
 
 
-def _apply_agile_story_points(issue_id: int, story_points) -> None:
-    """Write story_points for an issue via the RedmineUP Agile endpoint.
+def _apply_agile_data(issue_id: int, agile_attrs: Dict[str, Any]) -> None:
+    """Write agile fields for an issue via the RedmineUP Agile endpoint.
+
+    ``agile_attrs`` is passed through as ``agile_data_attributes`` on the issue
+    PUT, so it accepts any of the plugin's writable keys — ``story_points``,
+    ``agile_sprint_id``, and ``position``. python-redmine's core ``issue.update``
+    does not understand ``agile_data_attributes``, so these must be sent to the
+    plugin directly here rather than through the standard update path.
 
     Raises on any HTTP error (caller is responsible for catching).
     """
@@ -81,15 +87,39 @@ def _apply_agile_story_points(issue_id: int, story_points) -> None:
 
     client = _get_redmine_client()
     url = f"{_client.REDMINE_URL}/issues/{issue_id}.json"
-    payload = json.dumps(
-        {"issue": {"agile_data_attributes": {"story_points": story_points}}}
-    )
+    payload = json.dumps({"issue": {"agile_data_attributes": agile_attrs}})
     client.engine.request(
         "put",
         url,
         headers={"Content-Type": "application/json"},
         data=payload,
     )
+
+
+def _apply_agile_story_points(issue_id: int, story_points) -> None:
+    """Write story_points for an issue via the RedmineUP Agile endpoint.
+
+    Thin back-compat wrapper around :func:`_apply_agile_data`.
+
+    Raises on any HTTP error (caller is responsible for catching).
+    """
+    _apply_agile_data(issue_id, {"story_points": story_points})
+
+
+def _augment_with_agile_data(issue_id: int, result: Dict[str, Any]) -> Dict[str, Any]:
+    """Merge RedmineUP Agile fields into a serialized issue dict.
+
+    Adds ``story_points``, ``agile_sprint_id``, and ``agile_position`` so callers
+    can read back agile state (e.g. confirm a sprint move) from the same response.
+    A no-op when the Agile plugin is disabled, and silently omits the fields on
+    any fetch failure — same best-effort contract as ``get_redmine_issue``.
+    """
+    if _is_agile_enabled():
+        try:
+            result.update(_fetch_agile_data(issue_id))
+        except Exception:
+            pass  # Silently omit agile fields on any failure
+    return result
 
 
 def _custom_fields_to_list(issue: Any) -> List[Dict[str, Any]]:
@@ -747,12 +777,7 @@ async def get_redmine_issue(
         if _is_tags_enabled():
             result["tags"] = _issue_tags_to_list(issue)
 
-        if _is_agile_enabled():
-            try:
-                agile = _fetch_agile_data(issue_id)
-                result.update(agile)
-            except Exception:
-                pass  # Silently omit agile fields on any failure
+        result = _augment_with_agile_data(issue_id, result)
 
         return result
     except Exception as e:
@@ -1413,11 +1438,15 @@ async def update_redmine_issue(
     provided in ``fields``. When present and ``status_id`` is not supplied, the
     function will look up the corresponding status ID and use it for the update.
 
-    When ``REDMINE_AGILE_ENABLED=true``, a ``story_points`` key may also be
-    provided in ``fields``; it is routed to the RedmineUP Agile plugin endpoint
-    separately and is not passed to the standard Redmine update. When
-    ``REDMINE_AGILE_ENABLED=false`` (default), ``story_points`` is silently
-    ignored.
+    When ``REDMINE_AGILE_ENABLED=true``, RedmineUP Agile fields may also be set.
+    A top-level ``story_points`` key is supported, and a nested
+    ``agile_data_attributes`` dict may carry ``story_points``, ``agile_sprint_id``
+    (set to ``0``/null to remove the issue from its sprint), and ``position``.
+    These are routed to the Agile plugin endpoint separately rather than through
+    the standard Redmine update, and the returned issue is augmented with the
+    resulting ``story_points``, ``agile_sprint_id``, and ``agile_position`` so the
+    change can be verified from the response. When ``REDMINE_AGILE_ENABLED=false``
+    (default), these agile keys are silently ignored.
 
     When ``REDMINE_TAGS_ENABLED=true``, a ``tag_list`` key may be provided in
     ``fields`` to set the issue's AlphaNodes additional_tags tags. Accepts a
@@ -1451,17 +1480,32 @@ async def update_redmine_issue(
 
     update_fields = dict(fields)
 
-    # Extract agile fields — not understood by python-redmine.
-    # Use explicit key presence check so story_points=None (clear) still triggers
-    # the agile endpoint (story_points is not None would skip it).
-    story_points = None
-    agile_update_needed = False
+    # Extract agile fields — python-redmine's core update does not understand
+    # ``agile_data_attributes``, so they must be routed to the RedmineUP Agile
+    # plugin endpoint separately. Two spellings are accepted:
+    #   * a top-level ``story_points`` (kept for backwards compatibility), and
+    #   * a nested ``agile_data_attributes`` dict, which is the only way to reach
+    #     the plugin's other writable fields — most importantly ``agile_sprint_id``
+    #     (sprint / board membership) and ``position``.
+    # Explicit key-presence checks so a null/0 value (which clears the field or
+    # removes the issue from its sprint) still triggers the write.
+    agile_attrs: Dict[str, Any] = {}
     if _is_agile_enabled():
         if "story_points" in update_fields:
-            story_points = update_fields.pop("story_points")
-            agile_update_needed = True
+            agile_attrs["story_points"] = update_fields.pop("story_points")
+        nested = update_fields.pop("agile_data_attributes", None)
+        if isinstance(nested, dict):
+            writable = ("story_points", "agile_sprint_id", "position", "agile_position")
+            for key in writable:
+                if key in nested:
+                    # _fetch_agile_data exposes the read alias ``agile_position``;
+                    # normalize it to the plugin's ``position`` on the write path.
+                    write_key = "position" if key == "agile_position" else key
+                    agile_attrs[write_key] = nested[key]
     else:
         update_fields.pop("story_points", None)
+        update_fields.pop("agile_data_attributes", None)
+    agile_update_needed = bool(agile_attrs)
 
     # Extract tag_list (additional_tags plugin) before custom-field resolution
     # so it is never mistaken for a same-named custom field. Explicit key
@@ -1498,23 +1542,29 @@ async def update_redmine_issue(
             _get_redmine_client().issue.update(issue_id, **update_kwargs)
         if agile_update_needed:
             try:
-                _apply_agile_story_points(issue_id, story_points)
+                _apply_agile_data(issue_id, agile_attrs)
             except Exception as agile_e:
                 return _handle_redmine_error(
                     agile_e,
-                    f"updating agile story_points for issue {issue_id}",
+                    f"updating agile fields for issue {issue_id}",
                     {"resource_type": "issue", "resource_id": issue_id},
                 )
         if upload_descriptors:
             updated_issue = _get_redmine_client().issue.get(
                 issue_id, include="attachments,journals"
             )
-            return _augment_with_upload_result(
+            result = _augment_with_upload_result(
                 _issue_to_dict(updated_issue, include_custom_fields=True),
                 updated_issue,
             )
+            if agile_update_needed:
+                result = _augment_with_agile_data(issue_id, result)
+            return result
         updated_issue = _get_redmine_client().issue.get(issue_id)
-        return _issue_to_dict(updated_issue, include_custom_fields=True)
+        result = _issue_to_dict(updated_issue, include_custom_fields=True)
+        if agile_update_needed:
+            result = _augment_with_agile_data(issue_id, result)
+        return result
     except ValidationError as e:
         if not _is_required_custom_field_autofill_enabled():
             return _augment_validation_error_with_field_hint(
@@ -1580,23 +1630,29 @@ async def update_redmine_issue(
             _get_redmine_client().issue.update(issue_id, **retry_kwargs)
             if agile_update_needed:
                 try:
-                    _apply_agile_story_points(issue_id, story_points)
+                    _apply_agile_data(issue_id, agile_attrs)
                 except Exception as agile_e:
                     return _handle_redmine_error(
                         agile_e,
-                        f"updating agile story_points for issue {issue_id}",
+                        f"updating agile fields for issue {issue_id}",
                         {"resource_type": "issue", "resource_id": issue_id},
                     )
             if upload_descriptors:
                 updated_issue = _get_redmine_client().issue.get(
                     issue_id, include="attachments,journals"
                 )
-                return _augment_with_upload_result(
+                result = _augment_with_upload_result(
                     _issue_to_dict(updated_issue, include_custom_fields=True),
                     updated_issue,
                 )
+                if agile_update_needed:
+                    result = _augment_with_agile_data(issue_id, result)
+                return result
             updated_issue = _get_redmine_client().issue.get(issue_id)
-            return _issue_to_dict(updated_issue, include_custom_fields=True)
+            result = _issue_to_dict(updated_issue, include_custom_fields=True)
+            if agile_update_needed:
+                result = _augment_with_agile_data(issue_id, result)
+            return result
         except Exception as retry_error:
             return _augment_validation_error_with_field_hint(
                 _handle_redmine_error(

--- a/src/redmine_mcp_server/tools/issues.py
+++ b/src/redmine_mcp_server/tools/issues.py
@@ -49,10 +49,11 @@ _VALID_ISSUE_RELATION_TYPES: Set[str] = {
 }
 
 
-def _fetch_agile_data(issue_id: int) -> Dict[str, Any]:
-    """Fetch agile fields for an issue from the RedmineUP Agile endpoint.
+def _fetch_agile_data_raw(issue_id: int) -> Dict[str, Any]:
+    """Fetch the raw RedmineUP ``agile_data`` record for an issue.
 
-    Returns a dict with story_points, agile_sprint_id, and agile_position.
+    Returns the plugin's ``agile_data`` object verbatim — including its ``id``
+    and ``position`` — or an empty dict when the issue has no agile_data.
     Raises on any HTTP error (caller is responsible for catching).
     """
     # Lazy lookup so tests patching
@@ -62,7 +63,16 @@ def _fetch_agile_data(issue_id: int) -> Dict[str, Any]:
     client = _get_redmine_client()
     url = f"{_client.REDMINE_URL}/issues/{issue_id}/agile_data.json"
     payload = client.engine.request("get", url)
-    agile_data = payload.get("agile_data", {}) or {}
+    return payload.get("agile_data", {}) or {}
+
+
+def _fetch_agile_data(issue_id: int) -> Dict[str, Any]:
+    """Fetch agile fields for an issue from the RedmineUP Agile endpoint.
+
+    Returns a dict with story_points, agile_sprint_id, and agile_position.
+    Raises on any HTTP error (caller is responsible for catching).
+    """
+    agile_data = _fetch_agile_data_raw(issue_id)
     return {
         "story_points": agile_data.get("story_points"),
         "agile_sprint_id": agile_data.get("agile_sprint_id"),
@@ -73,21 +83,47 @@ def _fetch_agile_data(issue_id: int) -> Dict[str, Any]:
 def _apply_agile_data(issue_id: int, agile_attrs: Dict[str, Any]) -> None:
     """Write agile fields for an issue via the RedmineUP Agile endpoint.
 
-    ``agile_attrs`` is passed through as ``agile_data_attributes`` on the issue
-    PUT, so it accepts any of the plugin's writable keys — ``story_points``,
-    ``agile_sprint_id``, and ``position``. python-redmine's core ``issue.update``
-    does not understand ``agile_data_attributes``, so these must be sent to the
-    plugin directly here rather than through the standard update path.
+    ``agile_attrs`` may contain any of the plugin's writable keys —
+    ``story_points``, ``agile_sprint_id``, and ``position``. python-redmine's
+    core ``issue.update`` does not understand ``agile_data_attributes``, so these
+    must be sent to the plugin directly here rather than through the standard
+    update path.
 
-    Raises on any HTTP error (caller is responsible for catching).
+    The plugin declares ``accepts_nested_attributes_for :agile_data`` without
+    ``update_only: true``, so a nested payload that omits the existing row's
+    ``id`` *replaces* the agile_data row and nulls every field not included. To
+    update in place, this first reads the current row and carries its ``id`` and
+    existing values forward, then overlays the requested changes — so setting one
+    field (e.g. the sprint) never wipes the others. An explicit ``None``/``0`` in
+    ``agile_attrs`` still clears its field, since requested values take priority.
+
+    Raises on any HTTP error from the write (caller is responsible for catching).
     """
     # Lazy lookup so tests patching
     # `_client.REDMINE_URL` are observed at call time.
     from .. import _client
 
     client = _get_redmine_client()
+
+    # Read the current row so the write updates in place instead of replacing it.
+    # A read failure (e.g. no agile_data row yet) falls back to a plain create.
+    try:
+        current = _fetch_agile_data_raw(issue_id)
+    except Exception:
+        current = {}
+
+    attrs: Dict[str, Any] = {}
+    row_id = current.get("id")
+    if row_id is not None:
+        attrs["id"] = row_id
+    for key in ("story_points", "agile_sprint_id", "position"):
+        value = current.get(key)
+        if value is not None:
+            attrs[key] = value
+    attrs.update(agile_attrs)  # requested changes win (incl. explicit None/0)
+
     url = f"{_client.REDMINE_URL}/issues/{issue_id}.json"
-    payload = json.dumps({"issue": {"agile_data_attributes": agile_attrs}})
+    payload = json.dumps({"issue": {"agile_data_attributes": attrs}})
     client.engine.request(
         "put",
         url,
@@ -1438,12 +1474,14 @@ async def update_redmine_issue(
     provided in ``fields``. When present and ``status_id`` is not supplied, the
     function will look up the corresponding status ID and use it for the update.
 
-    When ``REDMINE_AGILE_ENABLED=true``, RedmineUP Agile fields may also be set.
-    A top-level ``story_points`` key is supported, and a nested
-    ``agile_data_attributes`` dict may carry ``story_points``, ``agile_sprint_id``
-    (set to ``0``/null to remove the issue from its sprint), and ``position``.
-    These are routed to the Agile plugin endpoint separately rather than through
-    the standard Redmine update, and the returned issue is augmented with the
+    When ``REDMINE_AGILE_ENABLED=true``, RedmineUP Agile fields may also be set:
+    ``story_points``, ``agile_sprint_id`` (set to ``0``/null to remove the issue
+    from its sprint), and ``position`` (also accepted as ``agile_position``). Each
+    may be given top-level in ``fields`` or nested under an ``agile_data_attributes``
+    dict. They are routed to the Agile plugin endpoint separately rather than
+    through the standard Redmine update; untouched agile fields are preserved (the
+    update happens in place, so setting only the sprint does not clear
+    ``story_points``/``position``). The returned issue is augmented with the
     resulting ``story_points``, ``agile_sprint_id``, and ``agile_position`` so the
     change can be verified from the response. When ``REDMINE_AGILE_ENABLED=false``
     (default), these agile keys are silently ignored.
@@ -1482,28 +1520,36 @@ async def update_redmine_issue(
 
     # Extract agile fields — python-redmine's core update does not understand
     # ``agile_data_attributes``, so they must be routed to the RedmineUP Agile
-    # plugin endpoint separately. Two spellings are accepted:
-    #   * a top-level ``story_points`` (kept for backwards compatibility), and
-    #   * a nested ``agile_data_attributes`` dict, which is the only way to reach
-    #     the plugin's other writable fields — most importantly ``agile_sprint_id``
-    #     (sprint / board membership) and ``position``.
-    # Explicit key-presence checks so a null/0 value (which clears the field or
-    # removes the issue from its sprint) still triggers the write.
+    # plugin endpoint separately. Each writable field may be given either
+    # top-level (like ``story_points``) or nested under an ``agile_data_attributes``
+    # dict; the nested form mirrors the raw plugin payload. The writable fields are
+    # ``story_points``, ``agile_sprint_id`` (sprint / board membership; ``0``/null
+    # removes the issue from its sprint), and ``position`` (read back as
+    # ``agile_position``, accepted under either name). Explicit key-presence checks
+    # so a null/0 value still triggers the write, and ``_apply_agile_data`` carries
+    # untouched fields forward so a subset update never nulls the rest.
     agile_attrs: Dict[str, Any] = {}
     if _is_agile_enabled():
-        if "story_points" in update_fields:
-            agile_attrs["story_points"] = update_fields.pop("story_points")
         nested = update_fields.pop("agile_data_attributes", None)
+        sources = [update_fields]
         if isinstance(nested, dict):
-            writable = ("story_points", "agile_sprint_id", "position", "agile_position")
-            for key in writable:
-                if key in nested:
-                    # _fetch_agile_data exposes the read alias ``agile_position``;
-                    # normalize it to the plugin's ``position`` on the write path.
+            sources.append(nested)
+        for source in sources:
+            for key in (
+                "story_points",
+                "agile_sprint_id",
+                "position",
+                "agile_position",
+            ):
+                if key in source:
+                    value = source[key] if source is nested else source.pop(key)
+                    # ``agile_position`` is the read alias; the plugin writes
+                    # ``position``.
                     write_key = "position" if key == "agile_position" else key
-                    agile_attrs[write_key] = nested[key]
+                    agile_attrs[write_key] = value
     else:
-        update_fields.pop("story_points", None)
+        for key in ("story_points", "agile_sprint_id", "position", "agile_position"):
+            update_fields.pop(key, None)
         update_fields.pop("agile_data_attributes", None)
     agile_update_needed = bool(agile_attrs)
 

--- a/tests/test_agile_support.py
+++ b/tests/test_agile_support.py
@@ -96,53 +96,129 @@ class TestFetchAgileData:
         }
 
 
+GET_URL = "http://localhost:3000/issues/42/agile_data.json"
+PUT_URL = "http://localhost:3000/issues/42.json"
+PUT_HEADERS = {"Content-Type": "application/json"}
+
+
+def _put_call(attrs, url=PUT_URL):
+    return call(
+        "put",
+        url,
+        headers=PUT_HEADERS,
+        data=json.dumps({"issue": {"agile_data_attributes": attrs}}),
+    )
+
+
 class TestApplyAgileStoryPoints:
     @patch("redmine_mcp_server._client.REDMINE_URL", "http://localhost:3000")
     @patch("redmine_mcp_server._client.redmine")
-    def test_calls_engine_put_with_correct_payload(self, mock_redmine):
-        mock_redmine.engine.request.return_value = Mock()
+    def test_updates_story_points_in_place(self, mock_redmine):
+        # Reads the current row first, then writes it back with the id and the
+        # untouched fields carried forward so only story_points changes.
+        mock_redmine.engine.request.side_effect = [
+            {
+                "agile_data": {
+                    "id": 9,
+                    "story_points": 3,
+                    "agile_sprint_id": 2,
+                    "position": 5,
+                }
+            },
+            Mock(),
+        ]
 
         _apply_agile_story_points(42, 8)
 
-        mock_redmine.engine.request.assert_called_once_with(
-            "put",
-            "http://localhost:3000/issues/42.json",
-            headers={"Content-Type": "application/json"},
-            data=json.dumps({"issue": {"agile_data_attributes": {"story_points": 8}}}),
-        )
+        assert mock_redmine.engine.request.call_args_list == [
+            call("get", GET_URL),
+            _put_call(
+                {
+                    "id": 9,
+                    "story_points": 8,
+                    "agile_sprint_id": 2,
+                    "position": 5,
+                }
+            ),
+        ]
 
     @patch("redmine_mcp_server._client.REDMINE_URL", "http://localhost:3000")
     @patch("redmine_mcp_server._client.redmine")
     def test_allows_null_to_clear_story_points(self, mock_redmine):
-        mock_redmine.engine.request.return_value = Mock()
+        mock_redmine.engine.request.side_effect = [
+            {"agile_data": {"id": 9, "story_points": 3}},
+            Mock(),
+        ]
 
         _apply_agile_story_points(42, None)
 
-        mock_redmine.engine.request.assert_called_once_with(
-            "put",
-            "http://localhost:3000/issues/42.json",
-            headers={"Content-Type": "application/json"},
-            data=json.dumps(
-                {"issue": {"agile_data_attributes": {"story_points": None}}}
-            ),
+        assert mock_redmine.engine.request.call_args_list[1] == _put_call(
+            {"id": 9, "story_points": None}
         )
 
 
 class TestApplyAgileData:
     @patch("redmine_mcp_server._client.REDMINE_URL", "http://localhost:3000")
     @patch("redmine_mcp_server._client.redmine")
-    def test_puts_arbitrary_agile_attributes(self, mock_redmine):
-        mock_redmine.engine.request.return_value = Mock()
+    def test_updates_in_place_preserving_other_fields(self, mock_redmine):
+        # Regression for the accepts_nested_attributes_for footgun: setting only
+        # the sprint must not null story_points/position. The row id and existing
+        # values are carried forward in the PUT.
+        mock_redmine.engine.request.side_effect = [
+            {
+                "agile_data": {
+                    "id": 7,
+                    "story_points": 5,
+                    "agile_sprint_id": 2,
+                    "position": 9,
+                }
+            },
+            Mock(),
+        ]
+
+        _apply_agile_data(42, {"agile_sprint_id": 117})
+
+        assert mock_redmine.engine.request.call_args_list == [
+            call("get", GET_URL),
+            _put_call(
+                {
+                    "id": 7,
+                    "story_points": 5,
+                    "agile_sprint_id": 117,
+                    "position": 9,
+                }
+            ),
+        ]
+
+    @patch("redmine_mcp_server._client.REDMINE_URL", "http://localhost:3000")
+    @patch("redmine_mcp_server._client.redmine")
+    def test_creates_when_no_existing_row(self, mock_redmine):
+        # No agile_data yet: nothing to carry forward, no id, plain create.
+        mock_redmine.engine.request.side_effect = [
+            {"agile_data": {}},
+            Mock(),
+        ]
 
         _apply_agile_data(42, {"agile_sprint_id": 3})
 
-        mock_redmine.engine.request.assert_called_once_with(
-            "put",
-            "http://localhost:3000/issues/42.json",
-            headers={"Content-Type": "application/json"},
-            data=json.dumps(
-                {"issue": {"agile_data_attributes": {"agile_sprint_id": 3}}}
-            ),
+        assert mock_redmine.engine.request.call_args_list[1] == _put_call(
+            {"agile_sprint_id": 3}
+        )
+
+    @patch("redmine_mcp_server._client.REDMINE_URL", "http://localhost:3000")
+    @patch("redmine_mcp_server._client.redmine")
+    def test_read_failure_falls_back_to_requested_only(self, mock_redmine):
+        # If the current-row read fails, still attempt the write with just the
+        # requested change rather than aborting.
+        mock_redmine.engine.request.side_effect = [
+            Exception("no agile_data"),
+            Mock(),
+        ]
+
+        _apply_agile_data(42, {"agile_sprint_id": 3})
+
+        assert mock_redmine.engine.request.call_args_list[1] == _put_call(
+            {"agile_sprint_id": 3}
         )
 
 
@@ -199,6 +275,15 @@ class TestGetRedmineIssueAgile:
         assert "story_points" not in result
 
 
+GET1 = "http://localhost:3000/issues/1/agile_data.json"
+PUT1 = "http://localhost:3000/issues/1.json"
+
+
+def _current(**fields):
+    """Build a mocked GET agile_data.json response body."""
+    return {"agile_data": fields}
+
+
 class TestUpdateRedmineIssueAgile:
 
     @pytest.mark.asyncio
@@ -207,17 +292,11 @@ class TestUpdateRedmineIssueAgile:
     async def test_extracts_story_points_and_calls_agile_endpoint(self, mock_redmine):
         mock_redmine.issue.update.return_value = True
         mock_redmine.issue.get.return_value = _make_minimal_issue(1)
-        # First engine.request is the agile PUT; the second is the follow-up
-        # agile GET used to echo the resulting agile fields into the response.
+        # Per agile write: read current row, PUT in place, then echo-read.
         mock_redmine.engine.request.side_effect = [
+            _current(id=9, story_points=3, agile_sprint_id=2, position=5),
             Mock(),
-            {
-                "agile_data": {
-                    "story_points": 8,
-                    "agile_sprint_id": None,
-                    "position": None,
-                }
-            },
+            _current(story_points=8, agile_sprint_id=2, position=5),
         ]
 
         with patch.dict(os.environ, {"REDMINE_AGILE_ENABLED": "true"}):
@@ -227,17 +306,18 @@ class TestUpdateRedmineIssueAgile:
 
         # story_points must NOT be passed to issue.update
         mock_redmine.issue.update.assert_called_once_with(1, subject="New")
-        # agile endpoint must be PUT with the correct payload, then read back
         assert mock_redmine.engine.request.call_args_list == [
-            call(
-                "put",
-                "http://localhost:3000/issues/1.json",
-                headers={"Content-Type": "application/json"},
-                data=json.dumps(
-                    {"issue": {"agile_data_attributes": {"story_points": 8}}}
-                ),
+            call("get", GET1),
+            _put_call(
+                {
+                    "id": 9,
+                    "story_points": 8,
+                    "agile_sprint_id": 2,
+                    "position": 5,
+                },
+                url=PUT1,
             ),
-            call("get", "http://localhost:3000/issues/1/agile_data.json"),
+            call("get", GET1),
         ]
         assert result["id"] == 1
         # Response is augmented with the read-back agile state.
@@ -250,26 +330,16 @@ class TestUpdateRedmineIssueAgile:
         mock_redmine.issue.update.return_value = True
         mock_redmine.issue.get.return_value = _make_minimal_issue(1)
         mock_redmine.engine.request.side_effect = [
+            _current(id=9, story_points=3),
             Mock(),
-            {
-                "agile_data": {
-                    "story_points": None,
-                    "agile_sprint_id": None,
-                    "position": None,
-                }
-            },
+            _current(story_points=None, agile_sprint_id=None, position=None),
         ]
 
         with patch.dict(os.environ, {"REDMINE_AGILE_ENABLED": "true"}):
             await update_redmine_issue(1, {"story_points": None})
 
-        assert mock_redmine.engine.request.call_args_list[0] == call(
-            "put",
-            "http://localhost:3000/issues/1.json",
-            headers={"Content-Type": "application/json"},
-            data=json.dumps(
-                {"issue": {"agile_data_attributes": {"story_points": None}}}
-            ),
+        assert mock_redmine.engine.request.call_args_list[1] == _put_call(
+            {"id": 9, "story_points": None}, url=PUT1
         )
 
     @pytest.mark.asyncio
@@ -279,14 +349,9 @@ class TestUpdateRedmineIssueAgile:
         mock_redmine.issue.update.return_value = True
         mock_redmine.issue.get.return_value = _make_minimal_issue(1)
         mock_redmine.engine.request.side_effect = [
+            _current(id=9, story_points=5, agile_sprint_id=2, position=1),
             Mock(),
-            {
-                "agile_data": {
-                    "story_points": None,
-                    "agile_sprint_id": 117,
-                    "position": 1,
-                }
-            },
+            _current(story_points=5, agile_sprint_id=117, position=1),
         ]
 
         with patch.dict(os.environ, {"REDMINE_AGILE_ENABLED": "true"}):
@@ -296,16 +361,46 @@ class TestUpdateRedmineIssueAgile:
 
         # No standard fields left, so the core update is skipped entirely.
         mock_redmine.issue.update.assert_not_called()
-        # Sprint is written through the agile endpoint...
-        assert mock_redmine.engine.request.call_args_list[0] == call(
-            "put",
-            "http://localhost:3000/issues/1.json",
-            headers={"Content-Type": "application/json"},
-            data=json.dumps(
-                {"issue": {"agile_data_attributes": {"agile_sprint_id": 117}}}
-            ),
+        # Sprint written in place — story_points/position carried forward (not nulled).
+        assert mock_redmine.engine.request.call_args_list[1] == _put_call(
+            {
+                "id": 9,
+                "story_points": 5,
+                "agile_sprint_id": 117,
+                "position": 1,
+            },
+            url=PUT1,
         )
-        # ...and echoed back in the response so the move can be verified.
+        assert result["agile_sprint_id"] == 117
+        assert result["story_points"] == 5
+
+    @pytest.mark.asyncio
+    @patch("redmine_mcp_server._client.REDMINE_URL", "http://localhost:3000")
+    @patch("redmine_mcp_server._client.redmine")
+    async def test_sets_sprint_via_top_level_key(self, mock_redmine):
+        # Maintainer feedback: a top-level agile_sprint_id must be honored too, not
+        # left to fall through to custom-field resolution.
+        mock_redmine.issue.update.return_value = True
+        mock_redmine.issue.get.return_value = _make_minimal_issue(1)
+        mock_redmine.engine.request.side_effect = [
+            _current(id=9, story_points=5, agile_sprint_id=2, position=1),
+            Mock(),
+            _current(story_points=5, agile_sprint_id=117, position=1),
+        ]
+
+        with patch.dict(os.environ, {"REDMINE_AGILE_ENABLED": "true"}):
+            result = await update_redmine_issue(1, {"agile_sprint_id": 117})
+
+        mock_redmine.issue.update.assert_not_called()
+        assert mock_redmine.engine.request.call_args_list[1] == _put_call(
+            {
+                "id": 9,
+                "story_points": 5,
+                "agile_sprint_id": 117,
+                "position": 1,
+            },
+            url=PUT1,
+        )
         assert result["agile_sprint_id"] == 117
 
     @pytest.mark.asyncio
@@ -315,14 +410,9 @@ class TestUpdateRedmineIssueAgile:
         mock_redmine.issue.update.return_value = True
         mock_redmine.issue.get.return_value = _make_minimal_issue(1)
         mock_redmine.engine.request.side_effect = [
+            _current(id=9, story_points=5, agile_sprint_id=2, position=1),
             Mock(),
-            {
-                "agile_data": {
-                    "story_points": None,
-                    "agile_sprint_id": None,
-                    "position": None,
-                }
-            },
+            _current(story_points=5, agile_sprint_id=None, position=1),
         ]
 
         with patch.dict(os.environ, {"REDMINE_AGILE_ENABLED": "true"}):
@@ -330,14 +420,16 @@ class TestUpdateRedmineIssueAgile:
                 1, {"agile_data_attributes": {"agile_sprint_id": 0}}
             )
 
-        # agile_sprint_id=0 must still trigger the write (explicit key presence).
-        assert mock_redmine.engine.request.call_args_list[0] == call(
-            "put",
-            "http://localhost:3000/issues/1.json",
-            headers={"Content-Type": "application/json"},
-            data=json.dumps(
-                {"issue": {"agile_data_attributes": {"agile_sprint_id": 0}}}
-            ),
+        # agile_sprint_id=0 must still trigger the write (explicit key presence),
+        # and other fields are preserved.
+        assert mock_redmine.engine.request.call_args_list[1] == _put_call(
+            {
+                "id": 9,
+                "story_points": 5,
+                "agile_sprint_id": 0,
+                "position": 1,
+            },
+            url=PUT1,
         )
 
     @pytest.mark.asyncio
@@ -347,14 +439,9 @@ class TestUpdateRedmineIssueAgile:
         mock_redmine.issue.update.return_value = True
         mock_redmine.issue.get.return_value = _make_minimal_issue(1)
         mock_redmine.engine.request.side_effect = [
+            _current(id=9, story_points=5, agile_sprint_id=2, position=1),
             Mock(),
-            {
-                "agile_data": {
-                    "story_points": None,
-                    "agile_sprint_id": 117,
-                    "position": 1,
-                }
-            },
+            _current(story_points=5, agile_sprint_id=117, position=1),
         ]
 
         with patch.dict(os.environ, {"REDMINE_AGILE_ENABLED": "true"}):
@@ -368,13 +455,14 @@ class TestUpdateRedmineIssueAgile:
 
         # Standard fields go through issue.update; agile_data_attributes does not.
         mock_redmine.issue.update.assert_called_once_with(1, status_id=20)
-        assert mock_redmine.engine.request.call_args_list[0] == call(
-            "put",
-            "http://localhost:3000/issues/1.json",
-            headers={"Content-Type": "application/json"},
-            data=json.dumps(
-                {"issue": {"agile_data_attributes": {"agile_sprint_id": 117}}}
-            ),
+        assert mock_redmine.engine.request.call_args_list[1] == _put_call(
+            {
+                "id": 9,
+                "story_points": 5,
+                "agile_sprint_id": 117,
+                "position": 1,
+            },
+            url=PUT1,
         )
 
     @pytest.mark.asyncio
@@ -388,11 +476,13 @@ class TestUpdateRedmineIssueAgile:
                 1,
                 {
                     "subject": "X",
-                    "agile_data_attributes": {"agile_sprint_id": 117},
+                    "agile_sprint_id": 117,
+                    "agile_data_attributes": {"agile_sprint_id": 5},
                 },
             )
 
-        # agile_data_attributes must NOT reach issue.update as a custom field...
+        # Neither the top-level nor the nested agile key may reach issue.update as
+        # a custom field...
         mock_redmine.issue.update.assert_called_once_with(1, subject="X")
         # ...and no agile HTTP call is made.
         mock_redmine.engine.request.assert_not_called()

--- a/tests/test_agile_support.py
+++ b/tests/test_agile_support.py
@@ -5,12 +5,13 @@ import os
 import sys
 
 import pytest
-from unittest.mock import Mock, patch
+from unittest.mock import Mock, call, patch
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
 from redmine_mcp_server._env import _is_agile_enabled  # noqa: E402
 from redmine_mcp_server.tools.issues import (  # noqa: E402
+    _apply_agile_data,
     _fetch_agile_data,
     _apply_agile_story_points,
     get_redmine_issue,
@@ -127,6 +128,24 @@ class TestApplyAgileStoryPoints:
         )
 
 
+class TestApplyAgileData:
+    @patch("redmine_mcp_server._client.REDMINE_URL", "http://localhost:3000")
+    @patch("redmine_mcp_server._client.redmine")
+    def test_puts_arbitrary_agile_attributes(self, mock_redmine):
+        mock_redmine.engine.request.return_value = Mock()
+
+        _apply_agile_data(42, {"agile_sprint_id": 3})
+
+        mock_redmine.engine.request.assert_called_once_with(
+            "put",
+            "http://localhost:3000/issues/42.json",
+            headers={"Content-Type": "application/json"},
+            data=json.dumps(
+                {"issue": {"agile_data_attributes": {"agile_sprint_id": 3}}}
+            ),
+        )
+
+
 class TestGetRedmineIssueAgile:
 
     @pytest.mark.asyncio
@@ -188,7 +207,18 @@ class TestUpdateRedmineIssueAgile:
     async def test_extracts_story_points_and_calls_agile_endpoint(self, mock_redmine):
         mock_redmine.issue.update.return_value = True
         mock_redmine.issue.get.return_value = _make_minimal_issue(1)
-        mock_redmine.engine.request.return_value = Mock()
+        # First engine.request is the agile PUT; the second is the follow-up
+        # agile GET used to echo the resulting agile fields into the response.
+        mock_redmine.engine.request.side_effect = [
+            Mock(),
+            {
+                "agile_data": {
+                    "story_points": 8,
+                    "agile_sprint_id": None,
+                    "position": None,
+                }
+            },
+        ]
 
         with patch.dict(os.environ, {"REDMINE_AGILE_ENABLED": "true"}):
             result = await update_redmine_issue(
@@ -197,14 +227,21 @@ class TestUpdateRedmineIssueAgile:
 
         # story_points must NOT be passed to issue.update
         mock_redmine.issue.update.assert_called_once_with(1, subject="New")
-        # agile endpoint must be called with correct payload
-        mock_redmine.engine.request.assert_called_once_with(
-            "put",
-            "http://localhost:3000/issues/1.json",
-            headers={"Content-Type": "application/json"},
-            data=json.dumps({"issue": {"agile_data_attributes": {"story_points": 8}}}),
-        )
+        # agile endpoint must be PUT with the correct payload, then read back
+        assert mock_redmine.engine.request.call_args_list == [
+            call(
+                "put",
+                "http://localhost:3000/issues/1.json",
+                headers={"Content-Type": "application/json"},
+                data=json.dumps(
+                    {"issue": {"agile_data_attributes": {"story_points": 8}}}
+                ),
+            ),
+            call("get", "http://localhost:3000/issues/1/agile_data.json"),
+        ]
         assert result["id"] == 1
+        # Response is augmented with the read-back agile state.
+        assert result["story_points"] == 8
 
     @pytest.mark.asyncio
     @patch("redmine_mcp_server._client.REDMINE_URL", "http://localhost:3000")
@@ -212,12 +249,21 @@ class TestUpdateRedmineIssueAgile:
     async def test_null_story_points_clears_field(self, mock_redmine):
         mock_redmine.issue.update.return_value = True
         mock_redmine.issue.get.return_value = _make_minimal_issue(1)
-        mock_redmine.engine.request.return_value = Mock()
+        mock_redmine.engine.request.side_effect = [
+            Mock(),
+            {
+                "agile_data": {
+                    "story_points": None,
+                    "agile_sprint_id": None,
+                    "position": None,
+                }
+            },
+        ]
 
         with patch.dict(os.environ, {"REDMINE_AGILE_ENABLED": "true"}):
             await update_redmine_issue(1, {"story_points": None})
 
-        mock_redmine.engine.request.assert_called_once_with(
+        assert mock_redmine.engine.request.call_args_list[0] == call(
             "put",
             "http://localhost:3000/issues/1.json",
             headers={"Content-Type": "application/json"},
@@ -225,6 +271,132 @@ class TestUpdateRedmineIssueAgile:
                 {"issue": {"agile_data_attributes": {"story_points": None}}}
             ),
         )
+
+    @pytest.mark.asyncio
+    @patch("redmine_mcp_server._client.REDMINE_URL", "http://localhost:3000")
+    @patch("redmine_mcp_server._client.redmine")
+    async def test_sets_sprint_via_nested_agile_data_attributes(self, mock_redmine):
+        mock_redmine.issue.update.return_value = True
+        mock_redmine.issue.get.return_value = _make_minimal_issue(1)
+        mock_redmine.engine.request.side_effect = [
+            Mock(),
+            {
+                "agile_data": {
+                    "story_points": None,
+                    "agile_sprint_id": 117,
+                    "position": 1,
+                }
+            },
+        ]
+
+        with patch.dict(os.environ, {"REDMINE_AGILE_ENABLED": "true"}):
+            result = await update_redmine_issue(
+                1, {"agile_data_attributes": {"agile_sprint_id": 117}}
+            )
+
+        # No standard fields left, so the core update is skipped entirely.
+        mock_redmine.issue.update.assert_not_called()
+        # Sprint is written through the agile endpoint...
+        assert mock_redmine.engine.request.call_args_list[0] == call(
+            "put",
+            "http://localhost:3000/issues/1.json",
+            headers={"Content-Type": "application/json"},
+            data=json.dumps(
+                {"issue": {"agile_data_attributes": {"agile_sprint_id": 117}}}
+            ),
+        )
+        # ...and echoed back in the response so the move can be verified.
+        assert result["agile_sprint_id"] == 117
+
+    @pytest.mark.asyncio
+    @patch("redmine_mcp_server._client.REDMINE_URL", "http://localhost:3000")
+    @patch("redmine_mcp_server._client.redmine")
+    async def test_removes_from_sprint_with_zero(self, mock_redmine):
+        mock_redmine.issue.update.return_value = True
+        mock_redmine.issue.get.return_value = _make_minimal_issue(1)
+        mock_redmine.engine.request.side_effect = [
+            Mock(),
+            {
+                "agile_data": {
+                    "story_points": None,
+                    "agile_sprint_id": None,
+                    "position": None,
+                }
+            },
+        ]
+
+        with patch.dict(os.environ, {"REDMINE_AGILE_ENABLED": "true"}):
+            await update_redmine_issue(
+                1, {"agile_data_attributes": {"agile_sprint_id": 0}}
+            )
+
+        # agile_sprint_id=0 must still trigger the write (explicit key presence).
+        assert mock_redmine.engine.request.call_args_list[0] == call(
+            "put",
+            "http://localhost:3000/issues/1.json",
+            headers={"Content-Type": "application/json"},
+            data=json.dumps(
+                {"issue": {"agile_data_attributes": {"agile_sprint_id": 0}}}
+            ),
+        )
+
+    @pytest.mark.asyncio
+    @patch("redmine_mcp_server._client.REDMINE_URL", "http://localhost:3000")
+    @patch("redmine_mcp_server._client.redmine")
+    async def test_combines_standard_fields_and_sprint(self, mock_redmine):
+        mock_redmine.issue.update.return_value = True
+        mock_redmine.issue.get.return_value = _make_minimal_issue(1)
+        mock_redmine.engine.request.side_effect = [
+            Mock(),
+            {
+                "agile_data": {
+                    "story_points": None,
+                    "agile_sprint_id": 117,
+                    "position": 1,
+                }
+            },
+        ]
+
+        with patch.dict(os.environ, {"REDMINE_AGILE_ENABLED": "true"}):
+            await update_redmine_issue(
+                1,
+                {
+                    "status_id": 20,
+                    "agile_data_attributes": {"agile_sprint_id": 117},
+                },
+            )
+
+        # Standard fields go through issue.update; agile_data_attributes does not.
+        mock_redmine.issue.update.assert_called_once_with(1, status_id=20)
+        assert mock_redmine.engine.request.call_args_list[0] == call(
+            "put",
+            "http://localhost:3000/issues/1.json",
+            headers={"Content-Type": "application/json"},
+            data=json.dumps(
+                {"issue": {"agile_data_attributes": {"agile_sprint_id": 117}}}
+            ),
+        )
+
+    @pytest.mark.asyncio
+    @patch("redmine_mcp_server._client.redmine")
+    async def test_sprint_dropped_when_agile_disabled(self, mock_redmine):
+        mock_redmine.issue.update.return_value = True
+        mock_redmine.issue.get.return_value = _make_minimal_issue(1)
+
+        with patch.dict(os.environ, {"REDMINE_AGILE_ENABLED": "false"}):
+            result = await update_redmine_issue(
+                1,
+                {
+                    "subject": "X",
+                    "agile_data_attributes": {"agile_sprint_id": 117},
+                },
+            )
+
+        # agile_data_attributes must NOT reach issue.update as a custom field...
+        mock_redmine.issue.update.assert_called_once_with(1, subject="X")
+        # ...and no agile HTTP call is made.
+        mock_redmine.engine.request.assert_not_called()
+        assert result["id"] == 1
 
     @pytest.mark.asyncio
     @patch("redmine_mcp_server._client.redmine")


### PR DESCRIPTION
## Description
`update_redmine_issue` could write `story_points` to the RedmineUP Agile plugin but silently
dropped `agile_sprint_id`, so issues could not be moved to/from a sprint through the MCP server
(the call returned success while the sprint was unchanged). This generalizes the agile-write
path so sprint and position are writable too, and echoes the resulting agile fields back in the
response so the change is verifiable.

## Related Issue
Fixes #193

## Changes Made
- Generalize `_apply_agile_story_points` into `_apply_agile_data(issue_id, agile_attrs)`, which
  PUTs `{"issue": {"agile_data_attributes": <attrs>}}` to `/issues/{id}.json`.
  `_apply_agile_story_points` is kept as a thin back-compat wrapper.
- In `update_redmine_issue`, a nested `agile_data_attributes` dict in `fields` may now carry
  `agile_sprint_id` (`0`/null removes the issue from its sprint), `position`, and `story_points`.
  Top-level `story_points` still works unchanged. Agile keys are collected with explicit
  key-presence checks (so `0`/null still triggers the write) and popped before custom-field
  mapping so `agile_data_attributes` is never mistaken for a custom field. When
  `REDMINE_AGILE_ENABLED=false`, these keys are silently ignored as before.
- The updated issue is augmented with the resulting `story_points`, `agile_sprint_id`, and
  `agile_position` (mirroring `get_redmine_issue`), only when an agile field was actually
  written, so plain updates make no extra HTTP call.
- `get_redmine_issue`'s agile augmentation refactored to reuse the new `_augment_with_agile_data`
  helper.

## Testing
- [x] Unit tests added/updated (`tests/test_agile_support.py`: set sprint, remove-with-0,
  combined standard+sprint update, drop-when-disabled, response echo, `_apply_agile_data`)
- [x] Full non-integration suite passes locally: **1527 passed**
- [x] Manual: raw `PUT /issues/{id}.json` with `agile_data_attributes.agile_sprint_id`
  confirmed to set/clear the sprint (same endpoint the fix uses)
- [x] `black --check` and `flake8 --max-line-length=88` clean on changed files

## Checklist
- [x] Code follows style guidelines (Black, flake8 @ 88)
- [x] Documentation updated (docstring + CHANGELOG)
- [x] Tests added/updated
- [x] CHANGELOG updated

## Compatibility
Backwards compatible — top-level `story_points` and all existing behavior are unchanged; only
the previously-dropped agile keys gain effect.
