### PR TITLE
fix(wiki): serialize the dict-shaped project ref added in Redmine 7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   that replaces the row. Only a missing row (HTTP 404) takes the create path;
   any other error is surfaced, so a transient failure cannot null the agile
   fields it was unable to read.
+- `manage_redmine_wiki_page` no longer fails against Redmine 7.0 with
+  `'dict' object has no attribute 'id'`. Redmine 7.0 added a `project` ref to
+  the wiki page API response
+  ([Redmine #43569](https://www.redmine.org/issues/43569)), and python-redmine
+  hands that field over as a plain dict rather than a resource object, so
+  serializing it raised. This broke `get`, `create`, `update`, and `rename` —
+  the write actions changed the page and only then failed, reporting an error
+  for a change that had in fact been applied. The ref is now read in either
+  shape and those actions return the page again. `list` and `delete` were
+  unaffected, as are Redmine versions before 7.0, which omit the field.
 
 ### Contributors
 - @knasiotis — reported the dropped `agile_sprint_id` write and implemented

--- a/docs/tool-reference.md
+++ b/docs/tool-reference.md
@@ -1779,7 +1779,7 @@ List, get, create, update, delete, or rename a Redmine wiki page. Replaces `list
 
 **Returns:**
 - `list`: array of page metadata dicts (`title`, `version`, `parent_title` if present, `created_on`, `updated_on`) — no body text
-- `get`/`create`/`update`: full wiki page dict (`title`, `text`, `version`, `created_on`, `updated_on`, `author`, `project`, `attachments` when applicable). `project` is only returned by Redmine 7.0+ ([#43569](https://www.redmine.org/issues/43569)); earlier versions omit the key
+- `get`/`create`/`update`: full wiki page dict (`title`, `text`, `version`, `created_on`, `updated_on`, `author`, `project`, `attachments` when applicable). `project` is only returned by Redmine 7.0+; earlier versions omit the key
 - `delete`: `{"success": true, "title": ..., "message": ...}`
 - `rename`: `{"success": true, ...}` plus the renamed page's metadata
 - Error: `{"error": "..."}`

--- a/docs/tool-reference.md
+++ b/docs/tool-reference.md
@@ -1779,7 +1779,7 @@ List, get, create, update, delete, or rename a Redmine wiki page. Replaces `list
 
 **Returns:**
 - `list`: array of page metadata dicts (`title`, `version`, `parent_title` if present, `created_on`, `updated_on`) — no body text
-- `get`/`create`/`update`: full wiki page dict (`title`, `text`, `version`, `created_on`, `updated_on`, `author`, `project`, `attachments` when applicable)
+- `get`/`create`/`update`: full wiki page dict (`title`, `text`, `version`, `created_on`, `updated_on`, `author`, `project`, `attachments` when applicable). `project` is only returned by Redmine 7.0+ ([#43569](https://www.redmine.org/issues/43569)); earlier versions omit the key
 - `delete`: `{"success": true, "title": ..., "message": ...}`
 - `rename`: `{"success": true, ...}` plus the renamed page's metadata
 - Error: `{"error": "..."}`

--- a/src/redmine_mcp_server/_serialization.py
+++ b/src/redmine_mcp_server/_serialization.py
@@ -180,10 +180,21 @@ def _named_ref(obj: Any) -> Optional[Dict[str, Any]]:
 
     See issue #109 for the policy decision.
 
+    Refs arrive as plain dicts when python-redmine does not list the
+    key in the parent's ``_resource_map`` -- as with ``project`` on a
+    wiki page, added by Redmine 7.0 (Redmine #43569). ``getattr`` on a
+    dict would silently return ``{'id': None, 'name': ''}``, so dicts
+    are read with ``.get()``.
+
     Returns ``None`` when ``obj`` is ``None``.
     """
     if obj is None:
         return None
+    if isinstance(obj, dict):
+        return {
+            "id": obj.get("id"),
+            "name": obj.get("name", ""),
+        }
     return {
         "id": getattr(obj, "id", None),
         "name": getattr(obj, "name", ""),

--- a/src/redmine_mcp_server/tools/wiki.py
+++ b/src/redmine_mcp_server/tools/wiki.py
@@ -8,6 +8,7 @@ from .._errors import _handle_redmine_error
 from .._serialization import (
     _attachment_to_dict,
     _iter_capped,
+    _named_ref,
     _safe_isoformat,
     wrap_insecure_content,
 )
@@ -49,17 +50,13 @@ def _wiki_page_to_dict(
 
     # Add author info
     if hasattr(wiki_page, "author"):
-        result["author"] = {
-            "id": wiki_page.author.id,
-            "name": wiki_page.author.name,
-        }
+        result["author"] = _named_ref(wiki_page.author)
 
-    # Add project info
+    # Add project info. Only Redmine 7.0+ returns this field (Redmine
+    # #43569); on older versions the hasattr guard omits the key. It
+    # arrives as a plain dict rather than a resource -- see _named_ref.
     if hasattr(wiki_page, "project"):
-        result["project"] = {
-            "id": wiki_page.project.id,
-            "name": wiki_page.project.name,
-        }
+        result["project"] = _named_ref(wiki_page.project)
 
     # Process attachments if requested. Routes through the shared
     # _attachment_to_dict helper so wiki and issue attachments produce

--- a/tests/test_global_search.py
+++ b/tests/test_global_search.py
@@ -385,6 +385,28 @@ class TestManageRedmineWikiPageGet:
     @pytest.mark.asyncio
     @patch("redmine_mcp_server._client.redmine")
     @patch("redmine_mcp_server._cleanup._ensure_cleanup_started")
+    async def test_wiki_page_project_as_dict(
+        self, mock_cleanup, mock_redmine, mock_wiki_page
+    ):
+        """Redmine 7.0 returns project as a plain dict (Redmine #43569).
+
+        python-redmine leaves it unwrapped because WikiPage._resource_map
+        does not list it, so the serializer must read it as a dict.
+        """
+        from redmine_mcp_server.tools.wiki import manage_redmine_wiki_page
+
+        mock_wiki_page.project = {"id": 1, "name": "Platform Test"}
+        mock_redmine.wiki_page.get.return_value = mock_wiki_page
+
+        result = await manage_redmine_wiki_page(
+            action="get", project_id="platform-test", wiki_page_title="TestPage"
+        )
+
+        assert result["project"] == {"id": 1, "name": "Platform Test"}
+
+    @pytest.mark.asyncio
+    @patch("redmine_mcp_server._client.redmine")
+    @patch("redmine_mcp_server._cleanup._ensure_cleanup_started")
     async def test_wiki_page_not_found(self, mock_cleanup, mock_redmine):
         """Test handling of non-existent wiki page."""
         from redmine_mcp_server.tools.wiki import manage_redmine_wiki_page

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -502,6 +502,15 @@ class TestRedmineIntegration:
             assert "Updated" in update_result["text"]
             assert update_result["version"] >= 2  # Version should increment
 
+            # Redmine 7.0+ returns a project ref (Redmine #43569); older
+            # versions omit the key. Where present it must carry the real
+            # id/name rather than being blanked out during serialization.
+            for result in (create_result, read_result, update_result):
+                project = result.get("project")
+                if project is not None:
+                    assert project["id"], f"project id missing: {project}"
+                    assert project["name"], f"project name missing: {project}"
+
             # 4. Delete the wiki page
             delete_result = await manage_redmine_wiki_page(
                 action="delete",

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -452,6 +452,7 @@ class TestRedmineIntegration:
 
         project_id = projects[0].identifier
         wiki_title = "Integration_Test_Wiki_Page"
+        renamed_title = "Integration_Test_Wiki_Page_Renamed"
 
         try:
             # 1. Create a new wiki page
@@ -502,33 +503,48 @@ class TestRedmineIntegration:
             assert "Updated" in update_result["text"]
             assert update_result["version"] >= 2  # Version should increment
 
+            # 4. Rename the wiki page
+            rename_result = await manage_redmine_wiki_page(
+                action="rename",
+                project_id=project_id,
+                wiki_page_title=wiki_title,
+                new_title=renamed_title,
+            )
+
+            if "error" in rename_result:
+                pytest.fail(f"Failed to rename wiki page: {rename_result['error']}")
+
+            assert rename_result["success"] is True
+            assert rename_result["title"] == renamed_title
+
             # Redmine 7.0+ returns a project ref (Redmine #43569); older
             # versions omit the key. Where present it must carry the real
             # id/name rather than being blanked out during serialization.
-            for result in (create_result, read_result, update_result):
+            # Covers every action that serializes a page.
+            for result in (create_result, read_result, update_result, rename_result):
                 project = result.get("project")
                 if project is not None:
                     assert project["id"], f"project id missing: {project}"
                     assert project["name"], f"project name missing: {project}"
 
-            # 4. Delete the wiki page
+            # 5. Delete the wiki page
             delete_result = await manage_redmine_wiki_page(
                 action="delete",
                 project_id=project_id,
-                wiki_page_title=wiki_title,
+                wiki_page_title=renamed_title,
             )
 
             if "error" in delete_result:
                 pytest.fail(f"Failed to delete wiki page: {delete_result['error']}")
 
             assert delete_result["success"] is True
-            assert delete_result["title"] == wiki_title
+            assert delete_result["title"] == renamed_title
 
-            # 5. Verify the page was deleted
+            # 6. Verify the page was deleted
             verify_result = await manage_redmine_wiki_page(
                 action="get",
                 project_id=project_id,
-                wiki_page_title=wiki_title,
+                wiki_page_title=renamed_title,
             )
             assert "error" in verify_result
             assert "not found" in verify_result["error"].lower()
@@ -536,15 +552,17 @@ class TestRedmineIntegration:
         except Exception as e:
             pytest.fail(f"Integration test failed: {e}")
         finally:
-            # Clean up: attempt to delete the wiki page if it still exists
-            try:
-                await manage_redmine_wiki_page(
-                    action="delete",
-                    project_id=project_id,
-                    wiki_page_title=wiki_title,
-                )
-            except Exception:
-                pass  # Best effort cleanup
+            # Clean up: attempt to delete either title if it still exists
+            # (which of the two survives depends on where the test failed).
+            for title in (wiki_title, renamed_title):
+                try:
+                    await manage_redmine_wiki_page(
+                        action="delete",
+                        project_id=project_id,
+                        wiki_page_title=title,
+                    )
+                except Exception:
+                    pass  # Best effort cleanup
 
     @pytest.mark.skipif(not REDMINE_URL, reason="REDMINE_URL not configured")
     @pytest.mark.integration

--- a/tests/test_named_ref_dict_shape.py
+++ b/tests/test_named_ref_dict_shape.py
@@ -1,0 +1,40 @@
+"""
+Test cases for the _named_ref helper with dict-shaped refs.
+
+python-redmine only wraps a nested key as a Resource when the parent
+resource lists it in its ``_resource_map``; anything else arrives as a
+plain dict.  Redmine 7.0 adding ``project`` to the wiki page API
+response (Redmine #43569) is the concrete case.  These tests pin the
+dict path so it returns the real id/name instead of silently yielding
+``{'id': None, 'name': ''}``.
+"""
+
+from unittest.mock import Mock
+
+from redmine_mcp_server._serialization import _named_ref  # noqa: E402
+
+
+class TestNamedRefDictShape:
+    """Unit tests for _named_ref against dict-shaped refs."""
+
+    def test_dict_returns_id_and_name(self):
+        ref = {"id": 1, "name": "Platform Test"}
+        assert _named_ref(ref) == {"id": 1, "name": "Platform Test"}
+
+    def test_dict_missing_name_falls_back_to_empty_string(self):
+        assert _named_ref({"id": 7}) == {"id": 7, "name": ""}
+
+    def test_dict_missing_id_returns_none_id(self):
+        assert _named_ref({"name": "No Id"}) == {"id": None, "name": "No Id"}
+
+
+class TestNamedRefExistingShapes:
+    """The None and Resource-like paths are unchanged."""
+
+    def test_none_returns_none(self):
+        assert _named_ref(None) is None
+
+    def test_resource_like_object_returns_id_and_name(self):
+        obj = Mock(id=42)
+        obj.name = "Some User"
+        assert _named_ref(obj) == {"id": 42, "name": "Some User"}


### PR DESCRIPTION
## Summary

`manage_redmine_wiki_page` crashes against Redmine 7.0 with `An unexpected error occurred while fetching wiki page '<title>' in project <project>: 'dict' object has no attribute 'id'`.

Redmine 7.0 added a `project` ref to the wiki page API response ([Redmine #43569](https://www.redmine.org/issues/43569), one added line in `app/views/wiki/show.api.rsb`). python-redmine only wraps a nested key as a `Resource` when the parent lists it in its `_resource_map`, and `WikiPage._resource_map` is `{'author': 'User'}` — no `project`. So `project` arrives as a plain `dict`, and `_wiki_page_to_dict`'s `wiki_page.project.id` raises. The `AttributeError` is caught by the same handler that wraps the network call, which is why a serialization bug reads as a Redmine API failure.

This affects `get`, `create`, `update`, and `rename` (all serialize a page); `list` and `delete` are unaffected. The write actions are the nastier case — they applied the change and *then* failed, reporting an error for a write that had already succeeded. Redmine 6.1 and earlier are unaffected: they don't send the field.

Not fixable by a dependency bump — python-redmine 2.5.0 is the latest release and the pin is already `>=2.5.0,<3`.

Existing tests missed this because the fixtures build `project` as a `Mock()` with `.id`/`.name`, which behaves like a `Resource`.

## Changes

- `_named_ref` (`_serialization.py`) reads dict-shaped refs via `.get()` instead of `getattr`. It previously returned `{"id": None, "name": ""}` for a dict — silent data loss — so this also repairs six other call sites that pass potentially-dict refs (`tools/gantt.py`, `tools/files.py`, `tools/time_tracking.py`, `tools/projects.py`, `tools/issues.py`, and `_attachment_to_dict`).
- `_wiki_page_to_dict` (`tools/wiki.py`) routes both `author` and `project` through `_named_ref` instead of hand-rolled ref dicts. The `hasattr` guards are kept — they're what omits the keys entirely on pre-7.0 servers.
- Unit tests: new `tests/test_named_ref_dict_shape.py` for the helper; a dict-`project` regression test beside the existing wiki `get` tests in `tests/test_global_search.py`.
- Integration test: the wiki lifecycle test asserts that when `project` is present it carries a real id/name, and now also exercises `rename` — the fourth affected action, which previously had no integration coverage at all. The assertion is version-agnostic, so it passes on both 6.1 (key absent) and 7.0 (key present).
- `CHANGELOG.md` and `docs/tool-reference.md` (the `project` field is documented as Redmine 7.0+; it was previously listed unconditionally).

## Testing

The integration tests skip entirely unless `REDMINE_URL` is set, so reproducing this needs a `.env` pointing at a live Redmine. Run against containerized **7.0.0** (where the bug appears) and **6.1.2** (where the field is absent), identical results on both:

```
$ python tests/run_tests.py --all
  unit:        1539 passed, 87 deselected
  integration: 76 passed, 11 skipped   # skips = optional plugins + live OAuth

$ uv run black --check src/ --line-length=88     # clean
$ uv run flake8 src/ --max-line-length=88        # clean
```

The new unit tests and the wiki lifecycle integration test both fail before the fix and pass after. Live, all four affected actions (`create`, `get`, `update`, `rename`) return `project: {id, name}` on 7.0.0 and omit the key on 6.1.2 — the version-agnostic assertion holds in both directions.

Note: run `tests/fixtures/ssl/generate-test-certs.sh` first — the certs aren't in the repo (removed in 1d17604, generated in CI), so `test_ssl_cert_file_exists` fails without them. Unrelated to this change.

## Checklist

- [x] `python tests/run_tests.py --all` passes (activate `.venv` first), with a live Redmine configured — verified on 7.0.0 and 6.1.2
- [x] `uv run black --check src/` and `uv run flake8 src/ --max-line-length=88` are clean
- [x] `CHANGELOG.md` [Unreleased] has a bullet for user-facing changes
- [x] No manual version bumps: `pyproject.toml`, `server.json`, and CHANGELOG version headers are managed by the release script
- [x] Docs updated where behavior changed: README stays concise, details go to `docs/tool-reference.md`
- [x] Change works with both local (`uv run python -m redmine_mcp_server.main`) and Docker (`docker-compose up`) deployments
