### PR TITLE
feat(wiki): support file attachments on wiki pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `SECURITY.md` (private vulnerability reporting, deployment model, and threat
   model), and a pull request template. `docs/contributing.md` updated to
   reference them and to defer the release process to `scripts/release.py`.
+- `manage_redmine_wiki_page` now accepts an `uploads` parameter on `create` and
+  `update`, so files can be attached to wiki pages
+  ([#202](https://github.com/jztan/redmine-mcp-server/issues/202)). Entries take
+  the same shape as the issue tools: `file_path`, `source_url`, or
+  `content_base64`. Redmine rejects a wiki update with a blank body, so an
+  attachment-only update re-reads the page server-side and resends its text
+  unchanged, which avoids routing the body through the model and creates no new
+  revision. The request carries the version read during that fetch, so a
+  concurrent edit returns an edit conflict instead of reverting silently.
 
 ### Fixed
 - `show_project_dashboard` now shows the project name instead of the raw
@@ -59,6 +68,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   disabled-verification warning immediately followed by
   `certificate verify failed`
   ([#197](https://github.com/jztan/redmine-mcp-server/issues/197))
+- @goizper — reported the missing `uploads` parameter on wiki pages
+  ([#202](https://github.com/jztan/redmine-mcp-server/issues/202))
 
 ## [2.9.0] - 2026-08-01
 ### Added

--- a/docs/tool-reference.md
+++ b/docs/tool-reference.md
@@ -1772,10 +1772,18 @@ List, get, create, update, delete, or rename a Redmine wiki page. Replaces `list
 - `wiki_page_title` (string): Wiki page title. Required for all actions except `list`
 - `version` (integer, optional): Specific version number for `get` (default: latest)
 - `include_attachments` (boolean, optional): Include attachment metadata in `get` response. Default: `true`
-- `text` (string): Page content. Required for `create` and `update`
+- `text` (string): Page content. Required for `create`. Required for `update` unless `uploads` is provided, in which case the server reuses the page's current text
 - `comments` (string, optional): Change log comment for `create` and `update`
 - `new_title` (string): New title for `rename` (must differ from `wiki_page_title`)
 - `redirect_existing_links` (boolean, optional): When `true` (default), `rename` creates a `WikiRedirect` from the old title to the new title
+- `uploads` (list, optional): Files to attach to the page on `create` and `update`. Maximum 10 items. Each item is an object with:
+  - Exactly ONE source key:
+    - `file_path` (string): Absolute path to a file already on the server. Must be inside `ATTACHMENTS_DIR` or a directory listed in `REDMINE_MCP_UPLOAD_FILE_ROOTS`. Filename is derived from the path if omitted.
+    - `source_url` (string): HTTP(S) URL the server fetches. Filename is derived from the URL or `Content-Disposition` if omitted.
+    - `content_base64` (string): Raw file bytes encoded as base64. `filename` is required when using this source. Prefer `file_path` or `source_url` where possible: base64 sends the entire file through the model, while a path or URL costs a few tokens regardless of file size.
+  - `filename` (string, optional): Name the attachment will have in Redmine. Required for `content_base64`; derived for other sources when omitted.
+  - `content_type` (string, optional): MIME type override (e.g. `"application/xml"`).
+  - `description` (string, optional): Human-readable description for the attachment.
 
 **Returns:**
 - `list`: array of page metadata dicts (`title`, `version`, `parent_title` if present, `created_on`, `updated_on`) — no body text
@@ -1783,6 +1791,8 @@ List, get, create, update, delete, or rename a Redmine wiki page. Replaces `list
 - `delete`: `{"success": true, "title": ..., "message": ...}`
 - `rename`: `{"success": true, ...}` plus the renamed page's metadata
 - Error: `{"error": "..."}`
+
+**Attachment-only updates:** Redmine rejects a wiki update with a blank body (`422 Text field cannot be blank`), so when `uploads` is given without `text` the server re-reads the page and sends its current text back unchanged. The body is never routed through the model, and because the text is identical Redmine does not create a new revision. The request carries the version read during that fetch, so a concurrent edit returns an edit-conflict error rather than silently reverting the other author's work.
 
 **Examples:**
 
@@ -1829,6 +1839,28 @@ manage_redmine_wiki_page(
     project_id="my-project",
     wiki_page_title="Old_Title",
     new_title="New_Title",
+)
+
+# Attach a diagram and reference it with the draw.io macro in one call.
+# The macro accepts png, svg, xml, and drawio attachments.
+manage_redmine_wiki_page(
+    action="update",
+    project_id="my-project",
+    wiki_page_title="Architecture",
+    text="# Architecture\n\n{{drawio_attach(diagram.drawio)}}\n",
+    uploads=[{"file_path": "/srv/attachments/diagram.drawio"}],
+)
+```
+
+Note that the `redmine_drawio` plugin creates a new attachment every time a diagram is saved rather than replacing the previous one, so diagram attachments accumulate on the page and stale ones have to be deleted manually.
+
+```python
+# Attach a file without touching the page body.
+manage_redmine_wiki_page(
+    action="update",
+    project_id="my-project",
+    wiki_page_title="Architecture",
+    uploads=[{"source_url": "https://example.com/spec.pdf"}],
 )
 ```
 

--- a/docs/tool-reference.md
+++ b/docs/tool-reference.md
@@ -1776,7 +1776,7 @@ List, get, create, update, delete, or rename a Redmine wiki page. Replaces `list
 - `comments` (string, optional): Change log comment for `create` and `update`
 - `new_title` (string): New title for `rename` (must differ from `wiki_page_title`)
 - `redirect_existing_links` (boolean, optional): When `true` (default), `rename` creates a `WikiRedirect` from the old title to the new title
-- `uploads` (list, optional): Files to attach to the page on `create` and `update`. Maximum 10 items. Each item is an object with:
+- `uploads` (list, optional): Files to attach to the page on `create` and `update`. Requires the `edit_wiki_pages` permission on the project. Maximum 10 items. Each item is an object with:
   - Exactly ONE source key:
     - `file_path` (string): Absolute path to a file already on the server. Must be inside `ATTACHMENTS_DIR` or a directory listed in `REDMINE_MCP_UPLOAD_FILE_ROOTS`. Filename is derived from the path if omitted.
     - `source_url` (string): HTTP(S) URL the server fetches. Filename is derived from the URL or `Content-Disposition` if omitted.

--- a/src/redmine_mcp_server/_errors.py
+++ b/src/redmine_mcp_server/_errors.py
@@ -6,6 +6,7 @@ from typing import Any, Dict, Optional
 
 from redminelib.exceptions import (
     AuthError,
+    ConflictError,
     ForbiddenError,
     HTTPProtocolError,
     ResourceNotFoundError,
@@ -155,6 +156,16 @@ def _handle_redmine_error(
     if isinstance(e, ValidationError):
         logger.warning(f"Validation error during {operation}: {e}")
         return {"error": f"Validation failed: {_scrub_error_message(str(e))}"}
+
+    if isinstance(e, ConflictError):
+        resource_type = context.get("resource_type", "resource")
+        logger.warning(f"Edit conflict during {operation}: {e}")
+        return {
+            "error": (
+                f"Edit conflict: this {resource_type} changed on the server "
+                "since it was read. Re-read it and retry."
+            )
+        }
 
     if isinstance(e, VersionMismatchError):
         return {"error": _scrub_error_message(str(e))}

--- a/src/redmine_mcp_server/tools/files.py
+++ b/src/redmine_mcp_server/tools/files.py
@@ -185,16 +185,16 @@ async def _resolve_upload_content(
     return content_bytes, explicit, None
 
 
-async def _build_issue_uploads(
+async def _build_upload_descriptors(
     uploads: List[Dict[str, Any]],
 ) -> tuple[List[Dict[str, Any]], Optional[Dict[str, Any]]]:
     """Resolve and upload each entry, returning python-redmine upload descriptors.
 
-    Resolve and upload are interleaved per entry so peak memory stays bounded to
-    a single file. Returns ``(descriptors, None)`` on success or
-    ``([], {"error": ...})`` on the first failing entry, before any issue is
-    touched. Descriptor keys: token, filename, and optional content_type /
-    description.
+    Shared by issue and wiki write paths. Resolve and upload are interleaved per
+    entry so peak memory stays bounded to a single file. Returns
+    ``(descriptors, None)`` on success or ``([], {"error": ...})`` on the first
+    failing entry, before any resource is touched. Descriptor keys: token,
+    filename, and optional content_type / description.
     """
     if len(uploads) > _MAX_UPLOADS_PER_CALL:
         return [], {

--- a/src/redmine_mcp_server/tools/issues.py
+++ b/src/redmine_mcp_server/tools/issues.py
@@ -34,7 +34,7 @@ from .._serialization import (
 )
 from .._validation import _is_positive_int
 from ..server import mcp
-from .files import _build_issue_uploads
+from .files import _build_upload_descriptors
 
 _VALID_ISSUE_RELATION_TYPES: Set[str] = {
     "relates",
@@ -1339,7 +1339,7 @@ async def create_redmine_issue(
 
     upload_descriptors: List[Dict[str, Any]] = []
     if uploads:
-        upload_descriptors, upload_error = await _build_issue_uploads(uploads)
+        upload_descriptors, upload_error = await _build_upload_descriptors(uploads)
         if upload_error is not None:
             return upload_error
 
@@ -1522,7 +1522,7 @@ async def update_redmine_issue(
 
     upload_descriptors: List[Dict[str, Any]] = []
     if uploads:
-        upload_descriptors, upload_error = await _build_issue_uploads(uploads)
+        upload_descriptors, upload_error = await _build_upload_descriptors(uploads)
         if upload_error is not None:
             return upload_error
 

--- a/src/redmine_mcp_server/tools/wiki.py
+++ b/src/redmine_mcp_server/tools/wiki.py
@@ -182,6 +182,7 @@ async def _update_wiki_page_action(
     wiki_page_title: Optional[str] = None,
     text: Optional[str] = None,
     comments: Optional[str] = None,
+    uploads: Optional[List[Dict[str, Any]]] = None,
     **_: Any,
 ) -> Dict[str, Any]:
     title_error = _require_wiki_page_title("update", wiki_page_title)
@@ -190,16 +191,24 @@ async def _update_wiki_page_action(
     if text is None:
         return {"error": "text is required for action 'update'"}
 
+    upload_descriptors = None
+    if uploads:
+        upload_descriptors, upload_error = await _build_upload_descriptors(uploads)
+        if upload_error is not None:
+            return upload_error
+
+    update_kwargs: Dict[str, Any] = {
+        "project_id": project_id,
+        "text": text,
+        "comments": comments if comments else None,
+    }
+    if upload_descriptors:
+        update_kwargs["uploads"] = upload_descriptors
+
     try:
-        _get_redmine_client().wiki_page.update(
-            wiki_page_title,
-            project_id=project_id,
-            text=text,
-            comments=comments if comments else None,
-        )
-        wiki_page = _get_redmine_client().wiki_page.get(
-            wiki_page_title, project_id=project_id
-        )
+        client = _get_redmine_client()
+        client.wiki_page.update(wiki_page_title, **update_kwargs)
+        wiki_page = client.wiki_page.get(wiki_page_title, project_id=project_id)
         return _wiki_page_to_dict(wiki_page)
     except Exception as e:
         return _handle_redmine_error(

--- a/src/redmine_mcp_server/tools/wiki.py
+++ b/src/redmine_mcp_server/tools/wiki.py
@@ -188,8 +188,12 @@ async def _update_wiki_page_action(
     title_error = _require_wiki_page_title("update", wiki_page_title)
     if title_error is not None:
         return {"error": title_error}
-    if text is None:
-        return {"error": "text is required for action 'update'"}
+    if text is None and not uploads:
+        return {
+            "error": (
+                "text is required for action 'update' unless uploads is provided."
+            )
+        }
 
     upload_descriptors = None
     if uploads:
@@ -199,7 +203,6 @@ async def _update_wiki_page_action(
 
     update_kwargs: Dict[str, Any] = {
         "project_id": project_id,
-        "text": text,
         "comments": comments if comments else None,
     }
     if upload_descriptors:
@@ -207,6 +210,17 @@ async def _update_wiki_page_action(
 
     try:
         client = _get_redmine_client()
+        if text is None:
+            # Redmine rejects a wiki PUT with a blank body (422 "Text field
+            # cannot be blank"), so an attachment-only update re-reads the page
+            # and echoes its text back. Sending the version read here turns a
+            # concurrent edit into a 409 instead of a silent revert. Unchanged
+            # text does not create a new revision.
+            existing = client.wiki_page.get(wiki_page_title, project_id=project_id)
+            update_kwargs["text"] = existing.text
+            update_kwargs["version"] = existing.version
+        else:
+            update_kwargs["text"] = text
         client.wiki_page.update(wiki_page_title, **update_kwargs)
         wiki_page = client.wiki_page.get(wiki_page_title, project_id=project_id)
         return _wiki_page_to_dict(wiki_page)
@@ -336,7 +350,10 @@ async def manage_redmine_wiki_page(
         version: Specific version to retrieve (``get`` only, optional).
         include_attachments: Include attachment metadata in ``get``
             response. Default ``True``.
-        text: Page content. Required for ``create`` and ``update``.
+        text: Page content. Required for ``create``. Required for
+            ``update`` unless ``uploads`` is given, in which case the
+            server reuses the page's current text so an attachment-only
+            update does not have to resend the body.
         comments: Change log comment. Optional for ``create`` and
             ``update``.
         new_title: New title for the page (required for ``rename``).

--- a/src/redmine_mcp_server/tools/wiki.py
+++ b/src/redmine_mcp_server/tools/wiki.py
@@ -5,6 +5,7 @@ from typing import Any, Dict, List, Literal, Optional, Union
 from .._client import _get_redmine_client
 from .._decorators import ActionMode, action_dispatch
 from .._errors import _handle_redmine_error
+from .files import _build_upload_descriptors
 from .._serialization import (
     _attachment_to_dict,
     _iter_capped,
@@ -141,6 +142,7 @@ async def _create_wiki_page_action(
     wiki_page_title: Optional[str] = None,
     text: Optional[str] = None,
     comments: Optional[str] = None,
+    uploads: Optional[List[Dict[str, Any]]] = None,
     **_: Any,
 ) -> Dict[str, Any]:
     title_error = _require_wiki_page_title("create", wiki_page_title)
@@ -149,13 +151,23 @@ async def _create_wiki_page_action(
     if text is None:
         return {"error": "text is required for action 'create'"}
 
+    upload_descriptors = None
+    if uploads:
+        upload_descriptors, upload_error = await _build_upload_descriptors(uploads)
+        if upload_error is not None:
+            return upload_error
+
+    create_kwargs: Dict[str, Any] = {
+        "project_id": project_id,
+        "title": wiki_page_title,
+        "text": text,
+        "comments": comments if comments else None,
+    }
+    if upload_descriptors:
+        create_kwargs["uploads"] = upload_descriptors
+
     try:
-        wiki_page = _get_redmine_client().wiki_page.create(
-            project_id=project_id,
-            title=wiki_page_title,
-            text=text,
-            comments=comments if comments else None,
-        )
+        wiki_page = _get_redmine_client().wiki_page.create(**create_kwargs)
         return _wiki_page_to_dict(wiki_page)
     except Exception as e:
         return _handle_redmine_error(
@@ -302,6 +314,7 @@ async def manage_redmine_wiki_page(
     comments: Optional[str] = None,
     new_title: Optional[str] = None,
     redirect_existing_links: bool = True,
+    uploads: Optional[List[Dict[str, Any]]] = None,
 ) -> Union[List[Dict[str, Any]], Dict[str, Any]]:
     """List, get, create, update, delete, or rename a Redmine wiki page.
 
@@ -321,6 +334,15 @@ async def manage_redmine_wiki_page(
         redirect_existing_links: When ``True`` (default), the rename
             creates a redirect from ``wiki_page_title`` to ``new_title``.
             Passed to the API as ``"1"`` / ``"0"``.
+        uploads: Files to attach, for ``create`` and ``update`` only.
+            Maximum 10 items, 50 MiB each. Each item needs exactly ONE
+            source key: ``file_path`` (a path on the server, inside
+            ``REDMINE_MCP_UPLOAD_FILE_ROOTS``), ``source_url`` (an HTTP(S)
+            URL the server fetches), or ``content_base64``. Prefer
+            ``file_path`` or ``source_url``: ``content_base64`` sends the
+            whole file through the model. Optional per item: ``filename``
+            (required with ``content_base64``), ``content_type``,
+            ``description``. Ignored by the other actions.
 
     Returns:
         ``list``: list of page metadata dicts (no body text).

--- a/src/redmine_mcp_server/tools/wiki.py
+++ b/src/redmine_mcp_server/tools/wiki.py
@@ -195,6 +195,31 @@ async def _update_wiki_page_action(
             )
         }
 
+    existing_text = None
+    existing_version = None
+    if text is None:
+        # Redmine rejects a wiki PUT with a blank body (422 "Text field
+        # cannot be blank"), so an attachment-only update re-reads the page
+        # and echoes its text back. This read-back MUST happen before
+        # _build_upload_descriptors() below: that call already POSTs each
+        # file to /uploads.json, so if it ran first and the title/project
+        # turned out to be wrong, the read-back's 404 would strand those
+        # already-uploaded blobs on the server with nothing left to attach
+        # them to. Doing the cheap, most-likely-to-fail GET first avoids
+        # that. Do not reorder this back for "tidiness".
+        try:
+            existing = _get_redmine_client().wiki_page.get(
+                wiki_page_title, project_id=project_id
+            )
+        except Exception as e:
+            return _handle_redmine_error(
+                e,
+                f"updating wiki page '{wiki_page_title}' in project {project_id}",
+                {"resource_type": "wiki page", "resource_id": wiki_page_title},
+            )
+        existing_text = existing.text
+        existing_version = existing.version
+
     upload_descriptors = None
     if uploads:
         upload_descriptors, upload_error = await _build_upload_descriptors(uploads)
@@ -211,14 +236,11 @@ async def _update_wiki_page_action(
     try:
         client = _get_redmine_client()
         if text is None:
-            # Redmine rejects a wiki PUT with a blank body (422 "Text field
-            # cannot be blank"), so an attachment-only update re-reads the page
-            # and echoes its text back. Sending the version read here turns a
-            # concurrent edit into a 409 instead of a silent revert. Unchanged
-            # text does not create a new revision.
-            existing = client.wiki_page.get(wiki_page_title, project_id=project_id)
-            update_kwargs["text"] = existing.text
-            update_kwargs["version"] = existing.version
+            # Sending the version read above turns a concurrent edit into a
+            # 409 instead of a silent revert. Unchanged text does not create
+            # a new revision.
+            update_kwargs["text"] = existing_text
+            update_kwargs["version"] = existing_version
         else:
             update_kwargs["text"] = text
         client.wiki_page.update(wiki_page_title, **update_kwargs)
@@ -361,8 +383,10 @@ async def manage_redmine_wiki_page(
             creates a redirect from ``wiki_page_title`` to ``new_title``.
             Passed to the API as ``"1"`` / ``"0"``.
         uploads: Files to attach, for ``create`` and ``update`` only.
+            Requires the ``edit_wiki_pages`` permission on the project.
             Maximum 10 items, 50 MiB each. Each item needs exactly ONE
             source key: ``file_path`` (a path on the server, inside
+            ``ATTACHMENTS_DIR`` or a directory listed in
             ``REDMINE_MCP_UPLOAD_FILE_ROOTS``), ``source_url`` (an HTTP(S)
             URL the server fetches), or ``content_base64``. Prefer
             ``file_path`` or ``source_url``: ``content_base64`` sends the

--- a/src/redmine_mcp_server/tools/wiki.py
+++ b/src/redmine_mcp_server/tools/wiki.py
@@ -211,14 +211,14 @@ async def _update_wiki_page_action(
             existing = _get_redmine_client().wiki_page.get(
                 wiki_page_title, project_id=project_id
             )
+            existing_text = existing.text
+            existing_version = existing.version
         except Exception as e:
             return _handle_redmine_error(
                 e,
                 f"updating wiki page '{wiki_page_title}' in project {project_id}",
                 {"resource_type": "wiki page", "resource_id": wiki_page_title},
             )
-        existing_text = existing.text
-        existing_version = existing.version
 
     upload_descriptors = None
     if uploads:

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -5,6 +5,7 @@ This module contains integration tests that test the actual connection
 to Redmine and the overall functionality of the MCP server.
 """
 
+import base64
 import os
 import sys
 
@@ -2148,6 +2149,54 @@ class TestTagsPluginIntegration:
             assert {"mcp-verify-tag", "mcp-verify-two"} <= names
         finally:
             await delete_redmine_issue(issue_id, confirm_delete=True)
+
+
+@pytest.mark.skipif(not REDMINE_URL, reason="REDMINE_URL not configured")
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_wiki_upload_and_attachment_only_update():
+    """Attach on create, then attach again without resending the body."""
+    redmine = _get_redmine_or_none()
+    if redmine is None:
+        pytest.skip("Redmine client not initialized")
+
+    from redmine_mcp_server.tools.wiki import manage_redmine_wiki_page
+
+    title = "Integration_Upload_Probe"
+    project_id = os.getenv("REDMINE_TEST_PROJECT", "testing-project1")
+    payload = base64.b64encode(b"integration probe").decode("ascii")
+
+    created = await manage_redmine_wiki_page(
+        action="create",
+        project_id=project_id,
+        wiki_page_title=title,
+        text="# Probe\n\nbody",
+        uploads=[{"filename": "probe_one.txt", "content_base64": payload}],
+    )
+    assert "error" not in created, created
+
+    try:
+        fetched = await manage_redmine_wiki_page(
+            action="get", project_id=project_id, wiki_page_title=title
+        )
+        names = {a["filename"] for a in fetched["attachments"]}
+        assert "probe_one.txt" in names
+
+        # Attachment-only: no text passed, body must survive untouched.
+        updated = await manage_redmine_wiki_page(
+            action="update",
+            project_id=project_id,
+            wiki_page_title=title,
+            uploads=[{"filename": "probe_two.txt", "content_base64": payload}],
+        )
+        assert "error" not in updated, updated
+        assert "body" in updated["text"]
+        names = {a["filename"] for a in updated["attachments"]}
+        assert {"probe_one.txt", "probe_two.txt"} <= names
+    finally:
+        await manage_redmine_wiki_page(
+            action="delete", project_id=project_id, wiki_page_title=title
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -7,6 +7,7 @@ to Redmine and the overall functionality of the MCP server.
 
 import base64
 import os
+import re
 import sys
 
 import pytest
@@ -21,6 +22,23 @@ from redmine_mcp_server._client import (  # noqa: E402
 from redmine_mcp_server.tools.time_tracking import (  # noqa: E402
     list_time_entry_activities,
 )
+
+_INSECURE_CONTENT_PATTERN = re.compile(
+    r"^<insecure-content-([0-9a-f]{16})>\n(.*)\n</insecure-content-\1>$",
+    re.DOTALL,
+)
+
+
+def _unwrap_insecure_content(value):
+    """Strip the wrap_insecure_content() boundary tag, if present.
+
+    wrap_insecure_content() mints a fresh random nonce on every call, so
+    two separately-serialized responses carrying the same underlying text
+    will not be equal as raw strings. Compare the inner content instead.
+    Returns the value unchanged if it is not boundary-wrapped.
+    """
+    match = _INSECURE_CONTENT_PATTERN.match(value)
+    return match.group(2) if match else value
 
 
 def _get_redmine_or_none():
@@ -2190,7 +2208,9 @@ async def test_wiki_upload_and_attachment_only_update():
             uploads=[{"filename": "probe_two.txt", "content_base64": payload}],
         )
         assert "error" not in updated, updated
-        assert "body" in updated["text"]
+        assert _unwrap_insecure_content(updated["text"]) == _unwrap_insecure_content(
+            created["text"]
+        )
         names = {a["filename"] for a in updated["attachments"]}
         assert {"probe_one.txt", "probe_two.txt"} <= names
     finally:

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -2184,6 +2184,15 @@ async def test_wiki_upload_and_attachment_only_update():
     project_id = os.getenv("REDMINE_TEST_PROJECT", "testing-project1")
     payload = base64.b64encode(b"integration probe").decode("ascii")
 
+    # Best-effort cleanup of a page left behind by a previous crashed run.
+    # Wiki create is a PUT upsert: against an already-existing page it
+    # returns 204, which python-redmine surfaces as a ValidationError
+    # ("Resource already exists"). The result is ignored here, covering
+    # both the normal first run (page not found) and a stale leftover.
+    await manage_redmine_wiki_page(
+        action="delete", project_id=project_id, wiki_page_title=title
+    )
+
     created = await manage_redmine_wiki_page(
         action="create",
         project_id=project_id,

--- a/tests/test_upload_content_resolution.py
+++ b/tests/test_upload_content_resolution.py
@@ -200,7 +200,7 @@ async def test_resolve_source_url_uses_inferred_filename(monkeypatch):
     assert name == "inferred.png"
 
 
-from redmine_mcp_server.tools.files import _build_issue_uploads  # noqa: E402
+from redmine_mcp_server.tools.files import _build_upload_descriptors  # noqa: E402
 
 
 @pytest.mark.asyncio
@@ -208,7 +208,7 @@ from redmine_mcp_server.tools.files import _build_issue_uploads  # noqa: E402
 async def test_build_uploads_single_entry(mock_redmine):
     mock_redmine.upload.return_value = {"token": "tok-1"}
     b64 = _b64.b64encode(b"hi").decode("ascii")
-    descriptors, err = await _build_issue_uploads(
+    descriptors, err = await _build_upload_descriptors(
         [{"filename": "a.txt", "content_base64": b64}]
     )
     assert err is None
@@ -221,7 +221,7 @@ async def test_build_uploads_single_entry(mock_redmine):
 async def test_build_uploads_carries_content_type_and_description(mock_redmine):
     mock_redmine.upload.return_value = {"token": "t"}
     b64 = _b64.b64encode(b"hi").decode("ascii")
-    descriptors, err = await _build_issue_uploads(
+    descriptors, err = await _build_upload_descriptors(
         [
             {
                 "filename": "a.txt",
@@ -241,7 +241,7 @@ async def test_build_uploads_carries_content_type_and_description(mock_redmine):
 async def test_build_uploads_multi_entry(mock_redmine):
     mock_redmine.upload.side_effect = [{"token": "t1"}, {"token": "t2"}]
     b64 = _b64.b64encode(b"x").decode("ascii")
-    descriptors, err = await _build_issue_uploads(
+    descriptors, err = await _build_upload_descriptors(
         [
             {"filename": "a.txt", "content_base64": b64},
             {"filename": "b.txt", "content_base64": b64},
@@ -255,7 +255,7 @@ async def test_build_uploads_multi_entry(mock_redmine):
 @patch("redmine_mcp_server._client.redmine")
 async def test_build_uploads_aborts_before_upload_on_bad_entry(mock_redmine):
     b64 = _b64.b64encode(b"x").decode("ascii")
-    descriptors, err = await _build_issue_uploads(
+    descriptors, err = await _build_upload_descriptors(
         [
             {"filename": "a.txt", "content_base64": b64},
             {"content_base64": b64},  # missing filename -> abort
@@ -269,12 +269,12 @@ async def test_build_uploads_aborts_before_upload_on_bad_entry(mock_redmine):
 async def test_build_uploads_entry_count_cap():
     b64 = _b64.b64encode(b"x").decode("ascii")
     entries = [{"filename": f"f{i}.txt", "content_base64": b64} for i in range(11)]
-    descriptors, err = await _build_issue_uploads(entries)
+    descriptors, err = await _build_upload_descriptors(entries)
     assert err is not None
     assert "10" in err["error"]
 
 
 @pytest.mark.asyncio
 async def test_build_uploads_rejects_non_dict_entry():
-    descriptors, err = await _build_issue_uploads(["not-a-dict"])
+    descriptors, err = await _build_upload_descriptors(["not-a-dict"])
     assert err is not None

--- a/tests/test_wiki_conflict_errors.py
+++ b/tests/test_wiki_conflict_errors.py
@@ -1,0 +1,61 @@
+"""Conflict and validation error reporting for wiki writes."""
+
+import base64
+import os
+import sys
+from unittest.mock import Mock, patch
+
+import pytest
+from redminelib.exceptions import ConflictError, ValidationError
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from redmine_mcp_server.tools.wiki import manage_redmine_wiki_page  # noqa: E402
+
+B64 = base64.b64encode(b"bytes").decode("ascii")
+
+
+def _page(text="body", version=3):
+    page = Mock()
+    page.title = "Page"
+    page.text = text
+    page.version = version
+    page.created_on = "2026-08-08T10:00:00Z"
+    page.updated_on = "2026-08-08T10:00:00Z"
+    page.attachments = []
+    return page
+
+
+@pytest.mark.asyncio
+@patch("redmine_mcp_server._client.redmine")
+async def test_conflict_is_reported_as_edit_conflict(mock_redmine):
+    mock_redmine.upload.return_value = {"token": "t"}
+    mock_redmine.wiki_page.get.return_value = _page()
+    mock_redmine.wiki_page.update.side_effect = ConflictError()
+
+    result = await manage_redmine_wiki_page(
+        action="update",
+        project_id="proj",
+        wiki_page_title="Page",
+        uploads=[{"filename": "a.txt", "content_base64": B64}],
+    )
+
+    assert "Edit conflict" in result["error"]
+    assert "retry" in result["error"].lower()
+
+
+@pytest.mark.asyncio
+@patch("redmine_mcp_server._client.redmine")
+async def test_blank_text_validation_message_reaches_caller(mock_redmine):
+    mock_redmine.wiki_page.update.side_effect = ValidationError(
+        "Text field cannot be blank"
+    )
+
+    result = await manage_redmine_wiki_page(
+        action="update",
+        project_id="proj",
+        wiki_page_title="Page",
+        text="body",
+    )
+
+    assert "Text field cannot be blank" in result["error"]

--- a/tests/test_wiki_uploads.py
+++ b/tests/test_wiki_uploads.py
@@ -96,3 +96,60 @@ async def test_update_upload_failure_short_circuits(mock_redmine):
 
     assert "uploads[0]" in result["error"]
     mock_redmine.wiki_page.update.assert_not_called()
+
+
+@pytest.mark.asyncio
+@patch("redmine_mcp_server._client.redmine")
+async def test_attachment_only_update_reuses_fetched_text_and_version(mock_redmine):
+    mock_redmine.upload.return_value = {"token": "tok-3"}
+    mock_redmine.wiki_page.get.return_value = _make_wiki_page(
+        text="existing body", version=7
+    )
+
+    result = await manage_redmine_wiki_page(
+        action="update",
+        project_id="proj",
+        wiki_page_title="Page",
+        uploads=[{"filename": "diagram.drawio", "content_base64": B64}],
+    )
+
+    assert "error" not in result
+    _, kwargs = mock_redmine.wiki_page.update.call_args
+    # Body came from the server, never from the caller.
+    assert kwargs["text"] == "existing body"
+    # Version is echoed back so a concurrent edit 409s instead of reverting.
+    assert kwargs["version"] == 7
+    assert kwargs["uploads"] == [{"token": "tok-3", "filename": "diagram.drawio"}]
+
+
+@pytest.mark.asyncio
+@patch("redmine_mcp_server._client.redmine")
+async def test_update_without_text_or_uploads_is_rejected(mock_redmine):
+    result = await manage_redmine_wiki_page(
+        action="update",
+        project_id="proj",
+        wiki_page_title="Page",
+    )
+
+    assert "text is required" in result["error"]
+    mock_redmine.wiki_page.update.assert_not_called()
+
+
+@pytest.mark.asyncio
+@patch("redmine_mcp_server._client.redmine")
+async def test_attachment_only_update_skips_readback_when_text_given(mock_redmine):
+    mock_redmine.upload.return_value = {"token": "tok-4"}
+    mock_redmine.wiki_page.get.return_value = _make_wiki_page(text="server body")
+
+    await manage_redmine_wiki_page(
+        action="update",
+        project_id="proj",
+        wiki_page_title="Page",
+        text="caller body",
+        uploads=[{"filename": "a.txt", "content_base64": B64}],
+    )
+
+    _, kwargs = mock_redmine.wiki_page.update.call_args
+    assert kwargs["text"] == "caller body"
+    # Exactly one get(), the post-update re-fetch. No read-back happened.
+    assert mock_redmine.wiki_page.get.call_count == 1

--- a/tests/test_wiki_uploads.py
+++ b/tests/test_wiki_uploads.py
@@ -58,3 +58,41 @@ async def test_create_upload_failure_short_circuits(mock_redmine):
 
     assert "uploads[0]" in result["error"]
     mock_redmine.wiki_page.create.assert_not_called()
+
+
+@pytest.mark.asyncio
+@patch("redmine_mcp_server._client.redmine")
+async def test_update_with_text_passes_upload_descriptors(mock_redmine):
+    mock_redmine.upload.return_value = {"token": "tok-2"}
+    mock_redmine.wiki_page.get.return_value = _make_wiki_page(text="new body")
+
+    result = await manage_redmine_wiki_page(
+        action="update",
+        project_id="proj",
+        wiki_page_title="Page",
+        text="new body",
+        uploads=[{"filename": "a.txt", "content_base64": B64}],
+    )
+
+    assert "error" not in result
+    args, kwargs = mock_redmine.wiki_page.update.call_args
+    assert args[0] == "Page"
+    assert kwargs["text"] == "new body"
+    assert kwargs["uploads"] == [{"token": "tok-2", "filename": "a.txt"}]
+    # Explicit text means no read-back, so version is not sent.
+    assert "version" not in kwargs
+
+
+@pytest.mark.asyncio
+@patch("redmine_mcp_server._client.redmine")
+async def test_update_upload_failure_short_circuits(mock_redmine):
+    result = await manage_redmine_wiki_page(
+        action="update",
+        project_id="proj",
+        wiki_page_title="Page",
+        text="new body",
+        uploads=[{"content_base64": B64}],  # no filename -> resolver error
+    )
+
+    assert "uploads[0]" in result["error"]
+    mock_redmine.wiki_page.update.assert_not_called()

--- a/tests/test_wiki_uploads.py
+++ b/tests/test_wiki_uploads.py
@@ -1,0 +1,60 @@
+"""Unit tests for file uploads on wiki page create/update."""
+
+import base64
+import os
+import sys
+from unittest.mock import Mock, patch
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from redmine_mcp_server.tools.wiki import manage_redmine_wiki_page  # noqa: E402
+
+B64 = base64.b64encode(b"diagram-bytes").decode("ascii")
+
+
+def _make_wiki_page(title="Page", text="Body", version=1):
+    page = Mock()
+    page.title = title
+    page.text = text
+    page.version = version
+    page.created_on = "2026-08-08T10:00:00Z"
+    page.updated_on = "2026-08-08T10:00:00Z"
+    page.attachments = []
+    return page
+
+
+@pytest.mark.asyncio
+@patch("redmine_mcp_server._client.redmine")
+async def test_create_passes_upload_descriptors(mock_redmine):
+    mock_redmine.upload.return_value = {"token": "tok-1"}
+    mock_redmine.wiki_page.create.return_value = _make_wiki_page()
+
+    result = await manage_redmine_wiki_page(
+        action="create",
+        project_id="proj",
+        wiki_page_title="Page",
+        text="# Body",
+        uploads=[{"filename": "diagram.drawio", "content_base64": B64}],
+    )
+
+    assert "error" not in result
+    _, kwargs = mock_redmine.wiki_page.create.call_args
+    assert kwargs["uploads"] == [{"token": "tok-1", "filename": "diagram.drawio"}]
+    assert kwargs["text"] == "# Body"
+
+
+@pytest.mark.asyncio
+@patch("redmine_mcp_server._client.redmine")
+async def test_create_upload_failure_short_circuits(mock_redmine):
+    result = await manage_redmine_wiki_page(
+        action="create",
+        project_id="proj",
+        wiki_page_title="Page",
+        text="# Body",
+        uploads=[{"content_base64": B64}],  # no filename -> resolver error
+    )
+
+    assert "uploads[0]" in result["error"]
+    mock_redmine.wiki_page.create.assert_not_called()


### PR DESCRIPTION
Closes #202.

`manage_redmine_wiki_page` gains an `uploads` parameter, honored on `create` and `update`, so files can finally be attached to wiki pages. Entries take the same shape as the issue tools (`file_path`, `source_url`, or `content_base64`), and the descriptor builder is shared rather than duplicated.

## The wrinkle

Redmine rejects a wiki `PUT` that carries `uploads` but no `text`:

```
422 {"errors":["Text field cannot be blank"]}
```

So an attachment-only call is not expressible in the API as-is. Making the caller resend the page body would work, but for an MCP server that means pulling the whole page through the model just to keep it unchanged.

Instead, when `uploads` is given and `text` is omitted, the server re-reads the page and echoes its existing text back in the same request. Two things make that safe, both verified against live 6.1.1 and 7.0.0 servers:

- Redmine creates no new revision when the text is unchanged, so attaching does not churn the version history.
- The request carries the `version` read during that fetch, so a concurrent edit returns `409` (surfaced as an edit-conflict error) instead of silently reverting the other author.

## Changes

- `uploads` on `manage_redmine_wiki_page` for `create` and `update`, ignored by the other actions
- `_build_issue_uploads` renamed to `_build_upload_descriptors`, since nothing in it was issue-specific, so wiki and issues share one implementation of the 50 MiB and 10-entry caps and the `uploads[i]: ...` error prefixes
- Attachment-only updates via the server-side read-back described above
- A `ConflictError` branch in `_errors.py`, replacing a raw library string that leaked through the generic fallback. This improves the message for every tool, not just wiki
- Upload resolution runs before any write, and the read-back GET runs before uploads are POSTed, so a wrong page title cannot strand uploaded blobs on the server

## Verification

- Unit suite 1562 to 1571 passed, no failures
- Integration tests pass against both Redmine 6.1.1 and 7.0.0, which matters because 7.0 returns a wiki page `project` ref that 6.x omits
- Attaching was confirmed to require `edit_wiki_pages`, by stripping that permission from the sandbox role and watching the attach fail. `oauth_scopes.py` already gated on it, so no scope change was needed
- End to end with the `redmine_drawio` plugin on 6.1.1: a single call carrying both the `{{drawio_attach(diagram.drawio)}}` macro text and the `.drawio` upload renders the real diagram, not the plugin's default-diagram fallback. Raw `.drawio` works, with no PNG or SVG export needed

## Notes

`rename` has a similar read-back that does not send a version, so it still has the lost-update window this PR closes for `update`. Left out deliberately: fixing it makes `rename` able to return a conflict error, which is a user-visible change deserving its own entry.
