### PR TITLE
feat: add MCP tool annotations so clients can distinguish read-only tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- MCP tool annotations on every tool, so clients can tell read-only queries
+  from writes. Read tools now advertise `readOnlyHint`, which lets annotation
+  aware clients skip write-operation approval prompts for ordinary Redmine
+  queries. Additive tools advertise `destructiveHint=false`. Annotations are
+  advisory client metadata: OAuth scope enforcement and
+  `REDMINE_MCP_READ_ONLY` remain the server-side controls. ([#204](https://github.com/jztan/redmine-mcp-server/issues/204))
 
 ## [2.12.0] - 2026-08-22
 ### Added

--- a/src/redmine_mcp_server/_annotations.py
+++ b/src/redmine_mcp_server/_annotations.py
@@ -1,0 +1,140 @@
+"""MCP ToolAnnotations classification for every registered tool (#204).
+
+This module is the single source of truth for the behavior hints returned
+in ``tools/list``. It deliberately mirrors the shape of ``oauth_scopes.py``:
+one central per-tool table plus an anti-drift test.
+
+Annotations are advisory client metadata. Per the MCP specification they are
+hints only, and "clients MUST consider tool annotations to be untrusted
+unless they come from trusted servers". Authorization is still enforced by
+the OAuth scope middleware and by ``REDMINE_MCP_READ_ONLY``.
+
+Only non-default values are emitted. The MCP schema defaults are
+``readOnlyHint=false``, ``destructiveHint=true``, ``idempotentHint=false``.
+
+Maintenance:
+    1. When adding a new MCP tool, add it here with the kind that matches
+       what it can actually do.
+    2. Classification is by effect on Redmine state. A tool that only reads
+       Redmine is READ even if it writes an ephemeral local cache file.
+    3. Mixed ``manage_X(action=...)`` tools take the conservative union of
+       their actions. Annotations cannot vary by the ``action`` argument.
+    4. Never infer the kind from ``TOOL_SCOPES``. An empty scope set can mean
+       either a read or a mutating plugin/local operation.
+"""
+
+import enum
+from typing import Dict, Optional
+
+from mcp.types import ToolAnnotations
+
+
+class ToolKind(enum.Enum):
+    """Behavior class of a tool, independent of deployment configuration."""
+
+    READ = "read"
+    WRITE_ADDITIVE = "write_additive"
+    WRITE_DESTRUCTIVE = "write_destructive"
+    WRITE_DESTRUCTIVE_IDEMPOTENT = "write_destructive_idempotent"
+
+
+# destructiveHint on a READ tool is formally redundant (the field is
+# meaningful only when readOnlyHint == false), but it is emitted anyway to
+# guard against a naive client that reads destructiveHint without first
+# checking readOnlyHint.
+_BY_KIND: Dict[ToolKind, ToolAnnotations] = {
+    ToolKind.READ: ToolAnnotations(readOnlyHint=True, destructiveHint=False),
+    ToolKind.WRITE_ADDITIVE: ToolAnnotations(readOnlyHint=False, destructiveHint=False),
+    ToolKind.WRITE_DESTRUCTIVE: ToolAnnotations(readOnlyHint=False),
+    ToolKind.WRITE_DESTRUCTIVE_IDEMPOTENT: ToolAnnotations(
+        readOnlyHint=False, idempotentHint=True
+    ),
+}
+
+TOOL_KINDS: Dict[str, ToolKind] = {
+    # --- projects ---
+    "list_redmine_projects": ToolKind.READ,
+    "get_project_modules": ToolKind.READ,
+    "list_project_trackers": ToolKind.READ,
+    "summarize_project_status": ToolKind.READ,
+    "list_project_members": ToolKind.READ,
+    "manage_project_member": ToolKind.WRITE_DESTRUCTIVE,  # add/update/remove
+    "list_redmine_versions": ToolKind.READ,
+    "manage_redmine_version": ToolKind.WRITE_DESTRUCTIVE,  # create/update/delete
+    # --- issues ---
+    "list_redmine_issues": ToolKind.READ,
+    "get_redmine_issue": ToolKind.READ,
+    "list_subtasks": ToolKind.READ,
+    "list_redmine_queries": ToolKind.READ,
+    "get_gantt_chart": ToolKind.READ,
+    "search_redmine_issues": ToolKind.READ,
+    "get_private_notes": ToolKind.READ,
+    "create_redmine_issue": ToolKind.WRITE_ADDITIVE,
+    "copy_issue": ToolKind.WRITE_ADDITIVE,
+    # Not idempotent: the notes-only carve-out (oauth_scopes.py) means a
+    # repeat call appends a second journal note.
+    "update_redmine_issue": ToolKind.WRITE_DESTRUCTIVE,
+    "delete_redmine_issue": ToolKind.WRITE_DESTRUCTIVE_IDEMPOTENT,
+    "manage_issue_relation": ToolKind.WRITE_DESTRUCTIVE,
+    # add/remove are arguably set-semantics and therefore idempotent, but the
+    # conservative-union rule for mixed tools applies. A wrong idempotent=true
+    # is the more expensive error.
+    "manage_issue_watcher": ToolKind.WRITE_DESTRUCTIVE,
+    "manage_issue_note": ToolKind.WRITE_DESTRUCTIVE,
+    "manage_issue_category": ToolKind.WRITE_DESTRUCTIVE,
+    # --- checklists (plugin) ---
+    "get_checklist": ToolKind.READ,
+    "create_checklist_item": ToolKind.WRITE_ADDITIVE,
+    "update_checklist_item": ToolKind.WRITE_DESTRUCTIVE_IDEMPOTENT,
+    # --- wiki ---
+    "manage_redmine_wiki_page": ToolKind.WRITE_DESTRUCTIVE,
+    # --- documents ---
+    "manage_document": ToolKind.WRITE_DESTRUCTIVE,
+    # --- time tracking ---
+    "list_time_entries": ToolKind.READ,
+    "list_time_entry_activities": ToolKind.READ,
+    "manage_time_entry": ToolKind.WRITE_DESTRUCTIVE,
+    "import_time_entries": ToolKind.WRITE_ADDITIVE,
+    # --- files and attachments ---
+    # READ: does not touch Redmine state. It writes an ephemeral file into
+    # ATTACHMENTS_DIR that the background cleanup manager expires.
+    "get_redmine_attachment": ToolKind.READ,
+    "list_files": ToolKind.READ,
+    "upload_file": ToolKind.WRITE_ADDITIVE,
+    "delete_file": ToolKind.WRITE_DESTRUCTIVE_IDEMPOTENT,
+    # Empty scope set like list_redmine_roles, but it deletes files. This is
+    # why annotations cannot be inferred from scope membership.
+    "cleanup_attachment_files": ToolKind.WRITE_DESTRUCTIVE_IDEMPOTENT,
+    # --- search ---
+    "search_entire_redmine": ToolKind.READ,
+    # --- enumeration ---
+    "list_redmine_roles": ToolKind.READ,
+    "list_project_issue_custom_fields": ToolKind.READ,
+    "list_redmine_trackers": ToolKind.READ,
+    "list_redmine_issue_statuses": ToolKind.READ,
+    "list_redmine_issue_priorities": ToolKind.READ,
+    "list_redmine_users": ToolKind.READ,
+    # --- meta ---
+    "get_current_user": ToolKind.READ,
+    "get_mcp_server_info": ToolKind.READ,
+    # --- RedmineUP plugins ---
+    # Empty scope sets, but both are mixed read/write dispatchers.
+    "manage_product": ToolKind.WRITE_DESTRUCTIVE,
+    "manage_contact": ToolKind.WRITE_DESTRUCTIVE,
+    # --- MCP Apps ---
+    "show_triage_board": ToolKind.READ,
+    "get_triage_board_data": ToolKind.READ,
+    "show_project_dashboard": ToolKind.READ,
+    "get_project_dashboard_data": ToolKind.READ,
+}
+
+
+def annotations_for(tool_name: str) -> Optional[ToolAnnotations]:
+    """Return a fresh ToolAnnotations for a tool, or None if unclassified.
+
+    Returns a copy: ToolAnnotations is a mutable pydantic model, so handing
+    out the shared per-kind instance would let one caller's mutation leak
+    into every other tool of the same kind.
+    """
+    kind = TOOL_KINDS.get(tool_name)
+    return _BY_KIND[kind].model_copy() if kind else None

--- a/src/redmine_mcp_server/_annotations.py
+++ b/src/redmine_mcp_server/_annotations.py
@@ -118,9 +118,10 @@ TOOL_KINDS: Dict[str, ToolKind] = {
     "get_current_user": ToolKind.READ,
     "get_mcp_server_info": ToolKind.READ,
     # --- RedmineUP plugins ---
-    # Empty scope sets, but both are mixed read/write dispatchers.
+    # Empty scope sets, but all four are mixed read/write dispatchers.
     "manage_product": ToolKind.WRITE_DESTRUCTIVE,
     "manage_contact": ToolKind.WRITE_DESTRUCTIVE,
+    "manage_deal": ToolKind.WRITE_DESTRUCTIVE,
     # --- MCP Apps ---
     "show_triage_board": ToolKind.READ,
     "get_triage_board_data": ToolKind.READ,

--- a/src/redmine_mcp_server/_decorators.py
+++ b/src/redmine_mcp_server/_decorators.py
@@ -27,6 +27,20 @@ class ActionMode(enum.Enum):
     WRITE = "write"
 
 
+# Per-tool action specs, recorded at decoration time so tests can cross-check
+# the ToolAnnotations classification (#204) against what each action really
+# does. Keyed by tool name: contacts, products and documents wrap their
+# dispatch in a separate _manage_X_dispatch helper, so that suffix is
+# normalized away.
+ACTION_SPECS: Dict[str, Dict[str, "ActionMode"]] = {}
+
+
+def _tool_name_for(func_name: str) -> str:
+    if func_name.startswith("_") and func_name.endswith("_dispatch"):
+        return func_name[1 : -len("_dispatch")]
+    return func_name
+
+
 def action_dispatch(spec: Dict[str, ActionMode]):
     """See module docstring for usage."""
 
@@ -50,6 +64,7 @@ def action_dispatch(spec: Dict[str, ActionMode]):
                 handlers = await handlers
             return await handlers[action](**kwargs)
 
+        ACTION_SPECS[_tool_name_for(handler_map_fn.__name__)] = dict(spec)
         return wrapper
 
     return decorator

--- a/src/redmine_mcp_server/server.py
+++ b/src/redmine_mcp_server/server.py
@@ -88,7 +88,7 @@ class _AnnotatingFastMCP(FastMCP):
     """
 
     def tool(self, name_or_fn=None, **kwargs):
-        if name_or_fn is not None or kwargs.get("name") or kwargs.get("annotations"):
+        if name_or_fn is not None or kwargs.get("name") or "annotations" in kwargs:
             return super().tool(name_or_fn, **kwargs)
         register = super().tool
 

--- a/src/redmine_mcp_server/server.py
+++ b/src/redmine_mcp_server/server.py
@@ -20,6 +20,7 @@ import os
 
 from fastmcp import FastMCP
 
+from ._annotations import annotations_for
 from ._env import _is_scope_enforcement_enabled
 from ._tool_error_middleware import CleanValidationErrorMiddleware
 
@@ -71,5 +72,31 @@ def _register_middlewares(mcp_instance, auth_provider) -> None:
 
 AUTH_PROVIDER = _select_auth_provider(REDMINE_AUTH_MODE)
 
-mcp = FastMCP("redmine_mcp_tools", auth=AUTH_PROVIDER)
+
+class _AnnotatingFastMCP(FastMCP):
+    """FastMCP that injects ToolAnnotations from the central table.
+
+    Every tool in this server registers with the deferred decorator form
+    (``@mcp.tool()`` or ``@mcp.tool(app=...)``), with no positional name and
+    no ``name=``, so the tool name is always ``fn.__name__``. A caller that
+    passes ``annotations=`` or a custom name bypasses the table rather than
+    fighting it.
+
+    An unclassified tool yields ``annotations=None``, which is exactly the
+    pre-#204 behavior. That fails safe: clients already treat an unannotated
+    tool as potentially destructive. The anti-drift test is what catches it.
+    """
+
+    def tool(self, name_or_fn=None, **kwargs):
+        if name_or_fn is not None or kwargs.get("name") or kwargs.get("annotations"):
+            return super().tool(name_or_fn, **kwargs)
+        register = super().tool
+
+        def decorator(fn):
+            return register(annotations=annotations_for(fn.__name__), **kwargs)(fn)
+
+        return decorator
+
+
+mcp = _AnnotatingFastMCP("redmine_mcp_tools", auth=AUTH_PROVIDER)
 _register_middlewares(mcp, AUTH_PROVIDER)

--- a/tests/test_tool_annotations.py
+++ b/tests/test_tool_annotations.py
@@ -53,20 +53,20 @@ class TestAnnotationsTable:
         assert annotations_for("list_redmine_projects").readOnlyHint is True
 
     def test_table_size_and_kind_counts(self):
-        assert len(TOOL_KINDS) == 52
+        assert len(TOOL_KINDS) == 53
         counts = {kind: 0 for kind in ToolKind}
         for kind in TOOL_KINDS.values():
             counts[kind] += 1
         assert counts[ToolKind.READ] == 31
         assert counts[ToolKind.WRITE_ADDITIVE] == 5
-        assert counts[ToolKind.WRITE_DESTRUCTIVE] == 12
+        assert counts[ToolKind.WRITE_DESTRUCTIVE] == 13
         assert counts[ToolKind.WRITE_DESTRUCTIVE_IDEMPOTENT] == 4
 
 
 async def _registered_tools():
     """Enumerate tools exactly as the server does.
 
-    Importing only ``tools`` sees 47 of the 51; ``apps`` registers 4 more.
+    Importing only ``tools`` sees 48 of the 52; ``apps`` registers 4 more.
     """
     from redmine_mcp_server.server import mcp
     import redmine_mcp_server.tools  # noqa: F401  triggers registration
@@ -114,8 +114,8 @@ class TestRegisteredToolAnnotations:
         assert by_name["delete_redmine_issue"].annotations.readOnlyHint is False
 
 
-# The 11 tools whose TOOL_SCOPES entry is empty. Scope membership cannot
-# classify these, so each one is a reviewed, hand-made decision. Three of
+# The 12 tools whose TOOL_SCOPES entry is empty. Scope membership cannot
+# classify these, so each one is a reviewed, hand-made decision. Four of
 # them mutate state despite looking exactly like the eight pure reads.
 _EMPTY_SCOPE_KINDS = {
     "cleanup_attachment_files": ToolKind.WRITE_DESTRUCTIVE_IDEMPOTENT,
@@ -128,6 +128,7 @@ _EMPTY_SCOPE_KINDS = {
     "list_redmine_trackers": ToolKind.READ,
     "list_redmine_users": ToolKind.READ,
     "manage_contact": ToolKind.WRITE_DESTRUCTIVE,
+    "manage_deal": ToolKind.WRITE_DESTRUCTIVE,
     "manage_product": ToolKind.WRITE_DESTRUCTIVE,
 }
 

--- a/tests/test_tool_annotations.py
+++ b/tests/test_tool_annotations.py
@@ -1,5 +1,7 @@
 """Tests for MCP ToolAnnotations classification (#204)."""
 
+import pytest
+
 from redmine_mcp_server._annotations import (
     TOOL_KINDS,
     ToolKind,
@@ -50,3 +52,54 @@ class TestAnnotationsTable:
         assert counts[ToolKind.WRITE_ADDITIVE] == 5
         assert counts[ToolKind.WRITE_DESTRUCTIVE] == 12
         assert counts[ToolKind.WRITE_DESTRUCTIVE_IDEMPOTENT] == 4
+
+
+async def _registered_tools():
+    """Enumerate tools exactly as the server does.
+
+    Importing only ``tools`` sees 47 of the 51; ``apps`` registers 4 more.
+    """
+    from redmine_mcp_server.server import mcp
+    import redmine_mcp_server.tools  # noqa: F401  triggers registration
+    import redmine_mcp_server.apps  # noqa: F401  triggers registration
+
+    return await mcp.list_tools()
+
+
+class TestRegisteredToolAnnotations:
+    @pytest.mark.asyncio
+    async def test_every_registered_tool_is_classified(self):
+        """Anti-drift: a new @mcp.tool() must get a TOOL_KINDS entry."""
+        registered = {tool.name for tool in await _registered_tools()}
+        classified = set(TOOL_KINDS)
+        assert (
+            registered <= classified
+        ), f"tools missing from TOOL_KINDS: {registered - classified}"
+        # cleanup_attachment_files registers only when
+        # REDMINE_MCP_EXPOSE_ADMIN_TOOLS is truthy; it must still be mapped.
+        conditional = {"cleanup_attachment_files"}
+        stale = classified - registered - conditional
+        assert not stale, f"stale TOOL_KINDS entries: {stale}"
+
+    @pytest.mark.asyncio
+    async def test_emitted_annotations_match_table(self):
+        """The wire output must match the table, not merely exist.
+
+        Table membership alone would not catch a tool registered under an
+        explicit name= that never received its annotation.
+        """
+        for tool in await _registered_tools():
+            expected = annotations_for(tool.name)
+            assert expected is not None, f"{tool.name} is unclassified"
+            assert tool.annotations is not None, f"{tool.name} has no annotations"
+            assert tool.annotations.model_dump(
+                exclude_none=True
+            ) == expected.model_dump(exclude_none=True), tool.name
+
+    @pytest.mark.asyncio
+    async def test_read_tools_are_advertised_read_only(self):
+        by_name = {tool.name: tool for tool in await _registered_tools()}
+        assert by_name["list_redmine_projects"].annotations.readOnlyHint is True
+        assert by_name["get_redmine_issue"].annotations.readOnlyHint is True
+        assert by_name["search_entire_redmine"].annotations.readOnlyHint is True
+        assert by_name["delete_redmine_issue"].annotations.readOnlyHint is False

--- a/tests/test_tool_annotations.py
+++ b/tests/test_tool_annotations.py
@@ -1,0 +1,52 @@
+"""Tests for MCP ToolAnnotations classification (#204)."""
+
+from redmine_mcp_server._annotations import (
+    TOOL_KINDS,
+    ToolKind,
+    annotations_for,
+)
+
+
+class TestAnnotationsTable:
+    def test_read_tool_is_read_only(self):
+        ann = annotations_for("list_redmine_projects")
+        assert ann.readOnlyHint is True
+        assert ann.destructiveHint is False
+
+    def test_additive_write_is_not_destructive(self):
+        ann = annotations_for("create_redmine_issue")
+        assert ann.readOnlyHint is False
+        assert ann.destructiveHint is False
+
+    def test_destructive_write_omits_spec_defaults(self):
+        # destructiveHint defaults to true and idempotentHint to false in the
+        # MCP schema, so a destructive tool only needs readOnlyHint.
+        ann = annotations_for("manage_redmine_wiki_page")
+        assert ann.readOnlyHint is False
+        assert ann.destructiveHint is None
+        assert ann.idempotentHint is None
+
+    def test_idempotent_destructive_write(self):
+        ann = annotations_for("delete_redmine_issue")
+        assert ann.readOnlyHint is False
+        assert ann.idempotentHint is True
+
+    def test_unknown_tool_returns_none(self):
+        assert annotations_for("no_such_tool_exists") is None
+
+    def test_returns_independent_copies(self):
+        # ToolAnnotations is a mutable pydantic model. Handing the same
+        # instance to 31 tools would let one mutation leak across all of them.
+        first = annotations_for("list_redmine_projects")
+        first.readOnlyHint = False
+        assert annotations_for("list_redmine_projects").readOnlyHint is True
+
+    def test_table_size_and_kind_counts(self):
+        assert len(TOOL_KINDS) == 52
+        counts = {kind: 0 for kind in ToolKind}
+        for kind in TOOL_KINDS.values():
+            counts[kind] += 1
+        assert counts[ToolKind.READ] == 31
+        assert counts[ToolKind.WRITE_ADDITIVE] == 5
+        assert counts[ToolKind.WRITE_DESTRUCTIVE] == 12
+        assert counts[ToolKind.WRITE_DESTRUCTIVE_IDEMPOTENT] == 4

--- a/tests/test_tool_annotations.py
+++ b/tests/test_tool_annotations.py
@@ -7,6 +7,12 @@ from redmine_mcp_server._annotations import (
     ToolKind,
     annotations_for,
 )
+from redmine_mcp_server._decorators import ACTION_SPECS, ActionMode
+from redmine_mcp_server.oauth_scopes import (
+    READ_SCOPES,
+    TOOL_SCOPES,
+    WRITE_SCOPES,
+)
 
 
 class TestAnnotationsTable:
@@ -103,3 +109,98 @@ class TestRegisteredToolAnnotations:
         assert by_name["get_redmine_issue"].annotations.readOnlyHint is True
         assert by_name["search_entire_redmine"].annotations.readOnlyHint is True
         assert by_name["delete_redmine_issue"].annotations.readOnlyHint is False
+
+
+# The 11 tools whose TOOL_SCOPES entry is empty. Scope membership cannot
+# classify these, so each one is a reviewed, hand-made decision. Three of
+# them mutate state despite looking exactly like the eight pure reads.
+_EMPTY_SCOPE_KINDS = {
+    "cleanup_attachment_files": ToolKind.WRITE_DESTRUCTIVE_IDEMPOTENT,
+    "get_current_user": ToolKind.READ,
+    "get_mcp_server_info": ToolKind.READ,
+    "list_project_issue_custom_fields": ToolKind.READ,
+    "list_redmine_issue_priorities": ToolKind.READ,
+    "list_redmine_issue_statuses": ToolKind.READ,
+    "list_redmine_roles": ToolKind.READ,
+    "list_redmine_trackers": ToolKind.READ,
+    "list_redmine_users": ToolKind.READ,
+    "manage_contact": ToolKind.WRITE_DESTRUCTIVE,
+    "manage_product": ToolKind.WRITE_DESTRUCTIVE,
+}
+
+
+def _required_scopes(entry) -> set:
+    """Flatten a TOOL_SCOPES entry to the set of scopes it can demand."""
+    if isinstance(entry, dict):
+        required: set = set()
+        for scopes in entry.values():
+            required |= scopes
+        return required
+    return set(entry or ())
+
+
+class TestClassificationCrossChecks:
+    def test_write_scoped_tools_are_never_read_only(self):
+        writes = set(WRITE_SCOPES)
+        for name, entry in TOOL_SCOPES.items():
+            if _required_scopes(entry) & writes:
+                assert (
+                    TOOL_KINDS[name] is not ToolKind.READ
+                ), f"{name} needs a write scope but is classified READ"
+
+    def test_read_scoped_tools_are_read_only(self):
+        reads = set(READ_SCOPES)
+        for name, entry in TOOL_SCOPES.items():
+            required = _required_scopes(entry)
+            if required and required <= reads:
+                assert (
+                    TOOL_KINDS[name] is ToolKind.READ
+                ), f"{name} needs only read scopes but is not classified READ"
+
+    def test_mixed_action_tools_are_not_read_only(self):
+        for name, spec in ACTION_SPECS.items():
+            # Skip test artifacts from other test modules that may pollute
+            # ACTION_SPECS during test runs (e.g., dispatcher in test_decorators.py).
+            if name not in TOOL_KINDS:
+                continue
+            if ActionMode.WRITE in spec.values():
+                assert (
+                    TOOL_KINDS[name] is not ToolKind.READ
+                ), f"{name} has WRITE actions but is classified READ"
+
+    def test_all_mixed_tools_are_covered(self):
+        """Guard against a rename silently dropping cross-check coverage.
+
+        contacts, products and documents route through a separate
+        _manage_X_dispatch helper rather than stacking the decorator under
+        @mcp.tool(), so they are the ones a naive lookup would miss.
+        """
+        expected = {
+            "manage_contact",
+            "manage_document",
+            "manage_issue_category",
+            "manage_issue_note",
+            "manage_issue_relation",
+            "manage_issue_watcher",
+            "manage_product",
+            "manage_project_member",
+            "manage_redmine_version",
+            "manage_redmine_wiki_page",
+            "manage_time_entry",
+        }
+        assert expected <= set(ACTION_SPECS), (
+            f"mixed tools missing from ACTION_SPECS: " f"{expected - set(ACTION_SPECS)}"
+        )
+
+    def test_empty_scope_tools_match_reviewed_map(self):
+        actual = {
+            name
+            for name, entry in TOOL_SCOPES.items()
+            if not isinstance(entry, dict) and not entry
+        }
+        assert actual == set(_EMPTY_SCOPE_KINDS), (
+            "the set of empty-scope tools changed; each one needs a reviewed "
+            "annotation decision"
+        )
+        for name, kind in _EMPTY_SCOPE_KINDS.items():
+            assert TOOL_KINDS[name] is kind, name

--- a/tests/test_tool_annotations.py
+++ b/tests/test_tool_annotations.py
@@ -1,7 +1,10 @@
 """Tests for MCP ToolAnnotations classification (#204)."""
 
+from types import SimpleNamespace
+
 import pytest
 
+import redmine_mcp_server._scope_middleware as scope_mw
 from redmine_mcp_server._annotations import (
     TOOL_KINDS,
     ToolKind,
@@ -159,8 +162,13 @@ class TestClassificationCrossChecks:
 
     def test_mixed_action_tools_are_not_read_only(self):
         for name, spec in ACTION_SPECS.items():
-            # Skip test artifacts from other test modules that may pollute
-            # ACTION_SPECS during test runs (e.g., dispatcher in test_decorators.py).
+            # A name missing from TOOL_KINDS can only be a synthetic
+            # artifact from tests/test_decorators.py polluting the shared
+            # ACTION_SPECS registry: test_every_registered_tool_is_classified
+            # bounds every registered tool into TOOL_KINDS, and
+            # test_all_mixed_tools_are_covered pins the 11 real mixed tools
+            # into ACTION_SPECS, so no genuine mixed tool can reach this
+            # branch.
             if name not in TOOL_KINDS:
                 continue
             if ActionMode.WRITE in spec.values():
@@ -189,7 +197,7 @@ class TestClassificationCrossChecks:
             "manage_time_entry",
         }
         assert expected <= set(ACTION_SPECS), (
-            f"mixed tools missing from ACTION_SPECS: " f"{expected - set(ACTION_SPECS)}"
+            "mixed tools missing from ACTION_SPECS: " f"{expected - set(ACTION_SPECS)}"
         )
 
     def test_empty_scope_tools_match_reviewed_map(self):
@@ -242,6 +250,30 @@ class TestAnnotationInteractions:
         assert annotations.destructiveHint is False
 
     @pytest.mark.asyncio
+    async def test_explicit_annotations_none_is_honored_not_raised(self):
+        """An explicit ``annotations=None`` must degrade safely, not raise.
+
+        ``kwargs.get("annotations")`` treats an explicit ``None`` the same
+        as an absent key, so it used to fall into the deferred branch and
+        then pass ``annotations=`` a second time on top of the one already
+        in ``**kwargs``, raising ``TypeError: got multiple values for
+        keyword argument 'annotations'``. The guard must instead test for
+        key presence so a caller's explicit override is delegated to
+        ``super().tool(...)`` untouched.
+        """
+        from redmine_mcp_server.server import _AnnotatingFastMCP
+
+        probe = _AnnotatingFastMCP("probe-explicit-none")
+
+        @probe.tool(annotations=None)
+        async def some_probe_tool() -> dict:
+            """Probe registered with an explicit annotations=None."""
+            return {}
+
+        registered = {t.name: t for t in await probe.list_tools()}
+        assert registered["some_probe_tool"].annotations is None
+
+    @pytest.mark.asyncio
     async def test_scope_middleware_preserves_annotations(self):
         """The scope filter must not strip or rebuild annotations."""
         from redmine_mcp_server._scope_middleware import (
@@ -259,3 +291,47 @@ class TestAnnotationInteractions:
         by_name = {tool.name: tool for tool in result}
         assert by_name["list_redmine_projects"].annotations.readOnlyHint is True
         assert by_name["delete_redmine_issue"].annotations.readOnlyHint is False
+
+    @pytest.mark.asyncio
+    async def test_scope_middleware_filters_and_preserves_annotations(
+        self, monkeypatch
+    ):
+        """The filtering branch (a real token) must not touch annotations.
+
+        Unlike the no-token test above, this exercises the loop in
+        ``on_list_tools`` that actually walks and rebuilds the tool list,
+        which is the code path that could plausibly drop or rebuild
+        annotations. ``view_project`` grants ``list_redmine_projects`` but
+        not ``delete_redmine_issue`` (which needs ``delete_issues``), so the
+        token both admits a tool and filters one out.
+        """
+        from redmine_mcp_server._scope_middleware import (
+            ScopeEnforcementMiddleware,
+        )
+
+        tools = await _registered_tools()
+        middleware = ScopeEnforcementMiddleware()
+
+        async def call_next(_context):
+            return tools
+
+        monkeypatch.setattr(
+            scope_mw,
+            "get_access_token",
+            lambda: SimpleNamespace(token="t", scopes=["view_project"]),
+        )
+
+        result = await middleware.on_list_tools(None, call_next)
+        by_name = {tool.name: tool for tool in result}
+
+        # The filter actually ran: the unscoped tool was dropped.
+        assert "delete_redmine_issue" not in by_name
+        assert len(result) < len(tools)
+
+        # The survivor kept its correct annotations, unmodified.
+        assert "list_redmine_projects" in by_name
+        assert by_name["list_redmine_projects"].annotations.readOnlyHint is True
+        expected = annotations_for("list_redmine_projects")
+        assert by_name["list_redmine_projects"].annotations.model_dump(
+            exclude_none=True
+        ) == expected.model_dump(exclude_none=True)

--- a/tests/test_tool_annotations.py
+++ b/tests/test_tool_annotations.py
@@ -214,18 +214,32 @@ class TestAnnotationInteractions:
         Flipping write tools to readOnlyHint=true when writes are disabled
         would be technically true but would corrupt an agent's planning: it
         would fold a "safe" create into a plan that can only ever error.
+
+        Annotations are computed once at decoration time, inside
+        ``_AnnotatingFastMCP.tool``, when a tool module is first imported.
+        By the time this test runs, `redmine_mcp_server.tools` and `.apps`
+        are already imported and cached in ``sys.modules``, so re-reading
+        the already-registered tools after monkeypatching the environment
+        would prove nothing: registration already happened and will not
+        re-run. The only way to actually exercise the decoration-time
+        decision under read-only mode is to set the env var first, then
+        register a fresh probe tool on a brand new ``_AnnotatingFastMCP``
+        instance, so the decorator runs while the env var is in effect.
         """
-        baseline = {
-            tool.name: tool.annotations.model_dump(exclude_none=True)
-            for tool in await _registered_tools()
-        }
+        from redmine_mcp_server.server import _AnnotatingFastMCP
+
         monkeypatch.setenv("REDMINE_MCP_READ_ONLY", "true")
-        after = {
-            tool.name: tool.annotations.model_dump(exclude_none=True)
-            for tool in await _registered_tools()
-        }
-        assert after == baseline
-        assert baseline["create_redmine_issue"]["readOnlyHint"] is False
+        probe = _AnnotatingFastMCP("probe")
+
+        @probe.tool()
+        async def create_redmine_issue(project_id: int) -> dict:
+            """Probe registered while read-only mode is active."""
+            return {}
+
+        registered = {t.name: t for t in await probe.list_tools()}
+        annotations = registered["create_redmine_issue"].annotations
+        assert annotations.readOnlyHint is False
+        assert annotations.destructiveHint is False
 
     @pytest.mark.asyncio
     async def test_scope_middleware_preserves_annotations(self):

--- a/tests/test_tool_annotations.py
+++ b/tests/test_tool_annotations.py
@@ -204,3 +204,44 @@ class TestClassificationCrossChecks:
         )
         for name, kind in _EMPTY_SCOPE_KINDS.items():
             assert TOOL_KINDS[name] is kind, name
+
+
+class TestAnnotationInteractions:
+    @pytest.mark.asyncio
+    async def test_annotations_stable_in_read_only_mode(self, monkeypatch):
+        """Classification describes the tool, not the deployment's policy.
+
+        Flipping write tools to readOnlyHint=true when writes are disabled
+        would be technically true but would corrupt an agent's planning: it
+        would fold a "safe" create into a plan that can only ever error.
+        """
+        baseline = {
+            tool.name: tool.annotations.model_dump(exclude_none=True)
+            for tool in await _registered_tools()
+        }
+        monkeypatch.setenv("REDMINE_MCP_READ_ONLY", "true")
+        after = {
+            tool.name: tool.annotations.model_dump(exclude_none=True)
+            for tool in await _registered_tools()
+        }
+        assert after == baseline
+        assert baseline["create_redmine_issue"]["readOnlyHint"] is False
+
+    @pytest.mark.asyncio
+    async def test_scope_middleware_preserves_annotations(self):
+        """The scope filter must not strip or rebuild annotations."""
+        from redmine_mcp_server._scope_middleware import (
+            ScopeEnforcementMiddleware,
+        )
+
+        tools = await _registered_tools()
+        middleware = ScopeEnforcementMiddleware()
+
+        async def call_next(_context):
+            return tools
+
+        # No access token in context: the middleware returns tools untouched.
+        result = await middleware.on_list_tools(None, call_next)
+        by_name = {tool.name: tool for tool in result}
+        assert by_name["list_redmine_projects"].annotations.readOnlyHint is True
+        assert by_name["delete_redmine_issue"].annotations.readOnlyHint is False


### PR DESCRIPTION
Closes #204.

Every tool now advertises an explicit MCP `ToolAnnotations` classification, so clients can tell a read-only query from a write instead of treating all 51 tools as potentially destructive.

## What changed

- **`_annotations.py`** (new): a `ToolKind` enum and a 52-entry `TOOL_KINDS` table, deliberately shaped like `oauth_scopes.py` so the two tables sit side by side.
- **`_AnnotatingFastMCP`** in `server.py`: injects annotations at registration by tool name. No module under `tools/` or `apps/` changed.
- **`ACTION_SPECS`** in `_decorators.py`: exposes the per-action `ActionMode` specs so tests can cross-check the classification.
- 19 tests in `tests/test_tool_annotations.py`.

## Classification

| Kind | Emitted | Count |
|---|---|---|
| READ | `readOnlyHint=true, destructiveHint=false` | 31 |
| WRITE_ADDITIVE | `readOnlyHint=false, destructiveHint=false` | 5 |
| WRITE_DESTRUCTIVE | `readOnlyHint=false` | 12 |
| WRITE_DESTRUCTIVE_IDEMPOTENT | `readOnlyHint=false, idempotentHint=true` | 4 |

Only non-default values are emitted, since the MCP schema already defaults writes to `readOnlyHint=false, destructiveHint=true`. `openWorldHint` is skipped: every tool reaches an external Redmine, so the `true` default is already right.

Mixed `manage_*` tools take the conservative union of their actions, since annotations cannot vary by the `action` argument.

## Why the classification is not inferred from scopes

As @aadnehovda pointed out in the issue, scope membership cannot decide this. 11 tools resolve to an empty scope set, and 3 of them mutate (`cleanup_attachment_files`, `manage_product`, `manage_contact`) while looking identical to pure reads like `get_current_user`. Those 11 are hand-classified and pinned in their own test.

Two cross-check tests catch the rest automatically: no tool needing a write scope may be classified READ, and no tool needing only read scopes may be anything else. Together they pin 41 of 52 against sources that already exist, so a wrong classification fails CI rather than reaching a client.

## Annotations do not change authorization

The MCP spec treats annotations as untrusted hints. OAuth scope enforcement and `REDMINE_MCP_READ_ONLY` remain the only server-side controls, and nothing in this branch touches them. Classification is static by design: it describes the tool, not the deployment, so `REDMINE_MCP_READ_ONLY=true` does not flip a create tool to read-only. Telling an agent a create is safe would corrupt its planning, not just its prompting.

## Verification

Full unit suite passes, flake8 and black clean. Verified live over the real HTTP transport against a 6.1 sandbox: 51 tools all annotated (52 with `REDMINE_MCP_EXPOSE_ADMIN_TOOLS`), plus a read-only-mode run and a 7.0 smoke test.

Not verified here: whether a given client actually suppresses its approval prompt. That needs a real annotation-aware client.
