### PR TITLE
fix: add REDMINE_TIMEOUT so a hung Redmine cannot hang a request forever

### DIFF
--- a/.env.docker.example
+++ b/.env.docker.example
@@ -111,6 +111,12 @@ ATTACHMENT_EXPIRES_MINUTES=60
 # REDMINE_PER_USER_TRUST_PROXY=true
 # REDMINE_PER_USER_AUDIT_IDENTITY=false
 
+# Request timeout (optional)
+# Seconds to wait for a Redmine HTTP response before failing the call.
+# Applied as connect timeout min(10, value) plus read timeout of the value.
+# 0 or a negative value disables it, restoring the old hang-forever behavior.
+# REDMINE_TIMEOUT=30
+
 # SSL options (optional)
 # REDMINE_SSL_VERIFY=true
 # REDMINE_SSL_CERT=/path/to/ca-bundle.crt

--- a/.env.docker.example
+++ b/.env.docker.example
@@ -112,9 +112,10 @@ ATTACHMENT_EXPIRES_MINUTES=60
 # REDMINE_PER_USER_AUDIT_IDENTITY=false
 
 # Request timeout (optional)
-# Seconds to wait for a Redmine HTTP response before failing the call.
+# Whole seconds to wait for a Redmine HTTP response before failing the call.
 # Applied as connect timeout min(10, value) plus read timeout of the value.
-# 0 or a negative value disables it, restoring the old hang-forever behavior.
+# 0 or a negative value disables it: an unresponsive Redmine will hang the
+# request.
 # REDMINE_TIMEOUT=30
 
 # SSL options (optional)

--- a/.env.example
+++ b/.env.example
@@ -189,6 +189,13 @@ REDMINE_MCP_UPLOAD_FILE_ROOTS=
 # REDMINE_PER_USER_TRUST_PROXY=true
 # REDMINE_PER_USER_AUDIT_IDENTITY=false
 
+# Request Timeout (Optional)
+# Seconds to wait for a response from Redmine before failing the call.
+# Applied as connect timeout min(10, value) plus read timeout of the value.
+# Set to 0 to wait forever (not recommended: an unresponsive Redmine will
+# hang the request).
+REDMINE_TIMEOUT=30
+
 # SSL Certificate Configuration (Optional)
 # Enable/disable SSL certificate verification (default: true)
 # WARNING: Only set to false for development/testing environments!

--- a/.env.example
+++ b/.env.example
@@ -190,10 +190,10 @@ REDMINE_MCP_UPLOAD_FILE_ROOTS=
 # REDMINE_PER_USER_AUDIT_IDENTITY=false
 
 # Request Timeout (Optional)
-# Seconds to wait for a response from Redmine before failing the call.
+# Whole seconds to wait for a response from Redmine before failing the call.
 # Applied as connect timeout min(10, value) plus read timeout of the value.
-# Set to 0 to wait forever (not recommended: an unresponsive Redmine will
-# hang the request).
+# 0 or a negative value disables it: an unresponsive Redmine will hang the
+# request.
 REDMINE_TIMEOUT=30
 
 # SSL Certificate Configuration (Optional)

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -14,6 +14,7 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     strategy:
       matrix:
         python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -19,6 +19,7 @@ env:
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     strategy:
       matrix:
         python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Redmine HTTP calls now carry a timeout, configurable with `REDMINE_TIMEOUT`
+  (default 30 seconds, `0` disables). Previously no timeout was applied
+  anywhere: python-redmine accepts a `requests={"timeout": ...}` setting but
+  never passes it to `requests`, so a Redmine that accepted a connection and
+  never answered would hang the call indefinitely ([#214](https://github.com/jztan/redmine-mcp-server/issues/214), reported by @Bricklou).
+  Connect timeouts are also no longer misreported as connection errors, which
+  had blamed the configured URL for an unresponsive server.
+  Note that a hung call can still stall other requests for the duration of the
+  timeout, including `/health`; moving the blocking calls off the event loop
+  is tracked separately.
+
 ### Changed
 - The README Contributors list is now generated from the `### Contributors`
   credits in this changelog rather than maintained by hand, which had drifted:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   never passes it to `requests`, so a Redmine that accepted a connection and
   never answered would hang the call indefinitely ([#214](https://github.com/jztan/redmine-mcp-server/issues/214), reported by @Bricklou).
   Connect timeouts are also no longer misreported as connection errors, which
-  had blamed the configured URL for an unresponsive server.
+  had blamed the configured URL for an unresponsive server. The same fix
+  covers a stalled attachment download: a Redmine that starts sending an
+  attachment and then goes silent is now reported as a timeout instead of a
+  connection error.
   Note that a hung call can still stall other requests for the duration of the
   timeout, including `/health`; moving the blocking calls off the event loop
   is tracked separately.

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ The server runs on `http://localhost:8000` with the MCP endpoint at `/mcp`, heal
 | `REDMINE_SSL_VERIFY` | No | `true` | Enable/disable SSL certificate verification |
 | `REDMINE_SSL_CERT` | No | – | Path to custom CA certificate file |
 | `REDMINE_SSL_CLIENT_CERT` | No | – | Path to client certificate for mutual TLS |
-| `REDMINE_TIMEOUT` | No | `30` | Seconds to wait for a Redmine HTTP response before failing the call. Applied as a connect timeout of at most 10s plus a read timeout of the full value. Set to `0` to wait indefinitely, which restores the pre-2.10 behavior and can hang the request. |
+| `REDMINE_TIMEOUT` | No | `30` | Whole seconds to wait for a Redmine HTTP response before failing the call. Applied as a connect timeout of at most 10s plus a read timeout of the full value. Set to `0` to wait indefinitely, which restores the previous behavior and can hang the request. |
 | `REDMINE_MCP_READ_ONLY` | No | `false` | Block all write operations (create/update/delete) when set to `true` |
 | `REDMINE_OAUTH_SCOPE_ENFORCEMENT` | No | `on` | OAuth modes only: deny tool calls whose access token lacks the tool's Redmine permission scopes, and filter `tools/list` accordingly. Set to `off` temporarily while re-consenting older tokens ([details](docs/oauth-setup.md#scope-enforcement)) |
 | `REDMINE_OAUTH_DISCOVERY_AS` | No | `redmine` | OAuth modes only: which authorization server discovery advertises. `redmine` names your Redmine; `self` advertises this server (issuer = `REDMINE_MCP_BASE_URL`) and serves RFC 8414 metadata at its own canonical well-known location, which clients that probe there need, Cursor among them ([details](docs/oauth-setup.md#cursor-and-self-as-discovery)) |

--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ The server runs on `http://localhost:8000` with the MCP endpoint at `/mcp`, heal
 | `REDMINE_SSL_VERIFY` | No | `true` | Enable/disable SSL certificate verification |
 | `REDMINE_SSL_CERT` | No | – | Path to custom CA certificate file |
 | `REDMINE_SSL_CLIENT_CERT` | No | – | Path to client certificate for mutual TLS |
+| `REDMINE_TIMEOUT` | No | `30` | Seconds to wait for a Redmine HTTP response before failing the call. Applied as a connect timeout of at most 10s plus a read timeout of the full value. Set to `0` to wait indefinitely, which restores the pre-2.10 behavior and can hang the request. |
 | `REDMINE_MCP_READ_ONLY` | No | `false` | Block all write operations (create/update/delete) when set to `true` |
 | `REDMINE_OAUTH_SCOPE_ENFORCEMENT` | No | `on` | OAuth modes only: deny tool calls whose access token lacks the tool's Redmine permission scopes, and filter `tools/list` accordingly. Set to `off` temporarily while re-consenting older tokens ([details](docs/oauth-setup.md#scope-enforcement)) |
 | `REDMINE_OAUTH_DISCOVERY_AS` | No | `redmine` | OAuth modes only: which authorization server discovery advertises. `redmine` names your Redmine; `self` advertises this server (issuer = `REDMINE_MCP_BASE_URL`) and serves RFC 8414 metadata at its own canonical well-known location, which clients that probe there need, Cursor among them ([details](docs/oauth-setup.md#cursor-and-self-as-discovery)) |

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -61,7 +61,10 @@ This guide covers common issues and solutions for the Redmine MCP Server.
 
 **Note on large attachments:** the read timeout measures the gap between
 bytes, not total transfer time, so a slow but steady download is not cut off
-by it.
+by it. An upload works the other way: after the file body is sent, the
+client still waits under the same read timeout for Redmine's response, so a
+large upload to a busy instance may need a higher `REDMINE_TIMEOUT` even
+though the transfer itself completed.
 
 ### SSL Certificate Errors
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -34,18 +34,34 @@ This guide covers common issues and solutions for the Redmine MCP Server.
 ### Network Timeout Errors
 
 **Symptoms:**
-- Requests timing out
-- "Connection timeout" errors
+- "Redmine at ... did not respond in time"
+- "Timed out connecting to Redmine at ..."
 
 **Solutions:**
 
-1. **Increase Timeout Settings**
-   - Add longer timeout values in your configuration
-   - Check if Redmine server is slow or overloaded
+1. **Distinguish the two messages**
+   - "Timed out connecting" means the host or port never accepted the
+     connection. Check the URL, DNS, and any firewall or proxy in between.
+   - "did not respond in time" means Redmine accepted the connection but sent
+     no response within the read budget. The server is reachable but slow or
+     stuck.
 
-2. **Check Network Speed**
-   - Test your internet connection
-   - Consider using local network if possible
+2. **Raise the Limit for a Slow Redmine**
+   - `REDMINE_TIMEOUT` defaults to 30 seconds. Large queries against a busy
+     instance may legitimately need more: `REDMINE_TIMEOUT=120`.
+   - Setting `REDMINE_TIMEOUT=0` disables the timeout entirely. Avoid it: a
+     Redmine that accepts a connection and never answers will hang the
+     request forever.
+
+3. **Reduce the Work per Call**
+   - Lower `limit` on list tools, or use the `fields` parameter of
+     `list_redmine_issues` to return fewer fields.
+   - Use `journal_limit` on `get_redmine_issue` for issues with long
+     comment histories.
+
+**Note on large attachments:** the read timeout measures the gap between
+bytes, not total transfer time, so a slow but steady download is not cut off
+by it.
 
 ### SSL Certificate Errors
 

--- a/src/redmine_mcp_server/_client.py
+++ b/src/redmine_mcp_server/_client.py
@@ -25,6 +25,9 @@ from urllib.parse import urlparse
 from dotenv import load_dotenv
 from fastmcp.server.dependencies import get_access_token, get_http_request
 from redminelib import Redmine
+from redminelib.engines import SyncEngine
+
+from ._env import get_redmine_timeout
 
 logger = logging.getLogger("redmine_mcp_server")
 
@@ -173,6 +176,56 @@ def _build_requests_config() -> dict:
     return requests_config
 
 
+class TimeoutSyncEngine(SyncEngine):
+    """SyncEngine that puts REDMINE_TIMEOUT on every request.
+
+    redminelib drops a ``requests={"timeout": ...}`` config on the floor:
+    ``SyncEngine.create_session()`` setattr()s it onto a ``requests.Session``,
+    which has no ``timeout`` attribute that is read at request time, and
+    ``BaseEngine.construct_request_kwargs()`` never builds one. Without this
+    class a Redmine that accepts the connection and never answers hangs the
+    call forever (issue #214).
+
+    Injecting here rather than monkeypatching ``session.request`` matters:
+    ``Redmine.session()`` re-instantiates ``engine.__class__``, and
+    ``Redmine.download()`` uses that context manager, so a patched method
+    would be silently dropped for attachment downloads. A subclass survives.
+
+    The timeout is read per request, not captured at construction, so the
+    cached legacy client picks up an env change without being rebuilt.
+    """
+
+    @staticmethod
+    def construct_request_kwargs(method, headers, params, data):
+        kwargs = SyncEngine.construct_request_kwargs(method, headers, params, data)
+        timeout = get_redmine_timeout()
+        if timeout is not None:
+            kwargs.setdefault("timeout", timeout)
+        return kwargs
+
+
+def _new_client(**kwargs) -> Redmine:
+    """Build a Redmine client with this server's connection-level defaults.
+
+    Every client must carry ``engine=TimeoutSyncEngine`` and the SSL/proxy
+    config from ``_build_requests_config()``. Routing all construction through
+    here keeps that true for auth modes added later; the previous shape
+    repeated each branch with and without a ``requests=`` config, so a new
+    connection setting could reach half the call sites.
+
+    A caller-supplied ``requests`` dict (the OAuth Authorization header) is
+    merged on top of the shared config rather than replacing it.
+    """
+    g = globals()
+    requests_config = _build_requests_config()
+    caller_requests = kwargs.pop("requests", None)
+    if caller_requests:
+        requests_config = {**requests_config, **caller_requests}
+    if requests_config:
+        kwargs["requests"] = requests_config
+    return g["Redmine"](g["REDMINE_URL"], engine=TimeoutSyncEngine, **kwargs)
+
+
 def httpx_ssl_kwargs(url: Optional[str] = None) -> dict:
     """Return `verify`/`cert` kwargs for an httpx client talking to Redmine.
 
@@ -256,25 +309,10 @@ def _build_legacy_client() -> Redmine:
     # Read attributes via globals() so tests using patch.object(_client, ...)
     # observe the override at call time.
     g = globals()
-    requests_config = _build_requests_config()
     if g["REDMINE_API_KEY"]:
-        if requests_config:
-            return g["Redmine"](
-                g["REDMINE_URL"],
-                key=g["REDMINE_API_KEY"],
-                requests=requests_config,
-            )
-        return g["Redmine"](g["REDMINE_URL"], key=g["REDMINE_API_KEY"])
+        return _new_client(key=g["REDMINE_API_KEY"])
     elif g["REDMINE_USERNAME"] and g["REDMINE_PASSWORD"]:
-        if requests_config:
-            return g["Redmine"](
-                g["REDMINE_URL"],
-                username=g["REDMINE_USERNAME"],
-                password=g["REDMINE_PASSWORD"],
-                requests=requests_config,
-            )
-        return g["Redmine"](
-            g["REDMINE_URL"],
+        return _new_client(
             username=g["REDMINE_USERNAME"],
             password=g["REDMINE_PASSWORD"],
         )
@@ -303,14 +341,8 @@ def _get_redmine_client() -> Redmine:
     access_token = get_access_token()
     if access_token is not None and access_token.token:
         # Per-request client with Bearer token (cannot be cached)
-        requests_config = _build_requests_config()
         headers = {"Authorization": f"Bearer {access_token.token}"}
-        if requests_config:
-            return g["Redmine"](
-                g["REDMINE_URL"],
-                requests={"headers": headers, **requests_config},
-            )
-        return g["Redmine"](g["REDMINE_URL"], requests={"headers": headers})
+        return _new_client(requests={"headers": headers})
 
     # legacy-per-user mode: per-request key from the X-Redmine-API-Key header.
     if g["REDMINE_AUTH_MODE"] == "legacy-per-user":
@@ -321,11 +353,7 @@ def _get_redmine_client() -> Redmine:
         except RuntimeError:
             request = None
         key = resolve_per_user_key(request)  # raises PerUserAuthError
-        requests_config = _build_requests_config()
-        if requests_config:
-            client = g["Redmine"](g["REDMINE_URL"], key=key, requests=requests_config)
-        else:
-            client = g["Redmine"](g["REDMINE_URL"], key=key)
+        client = _new_client(key=key)
         maybe_log_identity(client, key)
         return client
 

--- a/src/redmine_mcp_server/_env.py
+++ b/src/redmine_mcp_server/_env.py
@@ -92,6 +92,29 @@ def _get_int_env(var_name: str, default: int) -> int:
         return default
 
 
+def get_redmine_timeout() -> tuple[float, float] | None:
+    """Return the ``(connect, read)`` timeout for Redmine HTTP calls.
+
+    ``REDMINE_TIMEOUT`` is a single seconds value (default 30). It is applied
+    as a connect timeout of at most 10s plus a read timeout of the full value,
+    which is the shape ``requests`` expects.
+
+    Returns ``None`` when set to 0 or less, which restores the pre-#214
+    behavior of waiting forever. That escape hatch exists for genuinely slow
+    Redmine instances; it also reintroduces the hang, so it is not a default.
+
+    Two properties of the requests timeout are worth knowing when tuning it:
+    the read timeout is the gap between bytes, not a cap on total transfer
+    time, so it does not limit large attachment downloads; and the connect
+    timeout applies per IP address, so an unresponsive dual-stack host can
+    take twice the connect budget before failing.
+    """
+    seconds = _get_int_env("REDMINE_TIMEOUT", 30)
+    if seconds <= 0:
+        return None
+    return (min(10.0, float(seconds)), float(seconds))
+
+
 def _get_upload_file_roots() -> list[str]:
     """Return realpath-resolved directory roots allowed as ``file_path`` upload
     sources.

--- a/src/redmine_mcp_server/_errors.py
+++ b/src/redmine_mcp_server/_errors.py
@@ -21,6 +21,7 @@ from requests.exceptions import (
     SSLError as RequestsSSLError,
     Timeout as RequestsTimeout,
 )
+from urllib3.exceptions import TimeoutError as Urllib3TimeoutError
 
 logger = logging.getLogger("redmine_mcp_server")
 
@@ -82,6 +83,18 @@ def _timeout_budget_hint() -> str:
     return f"REDMINE_TIMEOUT: connect {connect:g}s, read {read:g}s"
 
 
+def _read_timeout_error(redmine_url: str) -> Dict[str, Any]:
+    """Build the "did not respond in time" error dict for a read timeout."""
+    return {
+        "error": (
+            f"Redmine at {redmine_url} did not respond in time "
+            f"({_timeout_budget_hint()}). The server may be overloaded or "
+            "the request too large. Raise or disable the limit with "
+            "REDMINE_TIMEOUT."
+        )
+    }
+
+
 def _handle_redmine_error(
     e: Exception, operation: str, context: Optional[Dict[str, Any]] = None
 ) -> Dict[str, Any]:
@@ -123,14 +136,24 @@ def _handle_redmine_error(
                     "2) No firewall or proxy is dropping the connection"
                 )
             }
-        return {
-            "error": (
-                f"Redmine at {redmine_url} did not respond in time "
-                f"({_timeout_budget_hint()}). The server may be overloaded or "
-                "the request too large. Raise or disable the limit with "
-                "REDMINE_TIMEOUT."
-            )
-        }
+        return _read_timeout_error(redmine_url)
+
+    # A stalled streaming download (e.g. get_redmine_attachment) does NOT
+    # raise ReadTimeout: requests' iter_content() catches urllib3's
+    # ReadTimeoutError and re-raises it wrapped in a plain ConnectionError
+    # (see requests/models.py). Left unhandled, that would fall into the
+    # ConnectionError branch below and blame the URL for a server that
+    # started answering and then went silent mid-body (#214). Detect the
+    # wrapped urllib3 timeout here so it gets the read-timeout message
+    # instead. A genuine ConnectionError (refused, DNS failure) has no such
+    # wrapped cause and still falls through unchanged.
+    if (
+        isinstance(e, RequestsConnectionError)
+        and e.args
+        and isinstance(e.args[0], Urllib3TimeoutError)
+    ):
+        logger.error(f"Streaming read timeout during {operation}: {e}")
+        return _read_timeout_error(redmine_url)
 
     # Connection-level errors (from requests library)
     if isinstance(e, RequestsConnectionError):

--- a/src/redmine_mcp_server/_errors.py
+++ b/src/redmine_mcp_server/_errors.py
@@ -17,6 +17,7 @@ from redminelib.exceptions import (
 )
 from requests.exceptions import (
     ConnectionError as RequestsConnectionError,
+    ConnectTimeout as RequestsConnectTimeout,
     SSLError as RequestsSSLError,
     Timeout as RequestsTimeout,
 )
@@ -70,6 +71,17 @@ def _scrub_error_message(message: str) -> str:
     return scrubbed
 
 
+def _timeout_budget_hint() -> str:
+    """Describe the configured timeout for inclusion in an error message."""
+    from ._env import get_redmine_timeout  # lazy import avoids circular
+
+    timeout = get_redmine_timeout()
+    if timeout is None:
+        return "REDMINE_TIMEOUT is disabled"
+    connect, read = timeout
+    return f"REDMINE_TIMEOUT: connect {connect:g}s, read {read:g}s"
+
+
 def _handle_redmine_error(
     e: Exception, operation: str, context: Optional[Dict[str, Any]] = None
 ) -> Dict[str, Any]:
@@ -97,6 +109,29 @@ def _handle_redmine_error(
             )
         }
 
+    # Check Timeout BEFORE ConnectionError: ConnectTimeout inherits from both,
+    # so the ConnectionError branch would otherwise swallow it and blame the
+    # URL when the real cause is a server that stopped answering (#214).
+    if isinstance(e, RequestsTimeout):
+        logger.error(f"Timeout during {operation}: {e}")
+        if isinstance(e, RequestsConnectTimeout):
+            return {
+                "error": (
+                    f"Timed out connecting to Redmine at {redmine_url} "
+                    f"({_timeout_budget_hint()}). Please check: "
+                    "1) The host and port are reachable, "
+                    "2) No firewall or proxy is dropping the connection"
+                )
+            }
+        return {
+            "error": (
+                f"Redmine at {redmine_url} did not respond in time "
+                f"({_timeout_budget_hint()}). The server may be overloaded or "
+                "the request too large. Raise or disable the limit with "
+                "REDMINE_TIMEOUT."
+            )
+        }
+
     # Connection-level errors (from requests library)
     if isinstance(e, RequestsConnectionError):
         logger.error(f"Connection error during {operation}: {e}")
@@ -105,15 +140,6 @@ def _handle_redmine_error(
                 f"Cannot connect to Redmine at {redmine_url}. "
                 "Please check: 1) URL is correct, 2) Network is accessible, "
                 "3) Redmine server is running"
-            )
-        }
-
-    if isinstance(e, RequestsTimeout):
-        logger.error(f"Timeout during {operation}: {e}")
-        return {
-            "error": (
-                f"Connection to Redmine at {redmine_url} timed out. "
-                "Please check: 1) Network connectivity, 2) Redmine server load"
             )
         }
 

--- a/tests/test_client_timeout.py
+++ b/tests/test_client_timeout.py
@@ -1,0 +1,35 @@
+"""Tests for the Redmine request timeout (issue #214).
+
+redminelib never passes a timeout to requests, so before this change a Redmine
+that accepted a connection and never answered hung the call forever. These
+tests lock in that every client carries a timeout and that the resulting
+errors are distinguishable.
+"""
+
+from redmine_mcp_server._env import get_redmine_timeout
+
+
+class TestGetRedmineTimeout:
+    def test_default_is_10_connect_30_read(self, monkeypatch):
+        monkeypatch.delenv("REDMINE_TIMEOUT", raising=False)
+        assert get_redmine_timeout() == (10.0, 30.0)
+
+    def test_connect_never_exceeds_read(self, monkeypatch):
+        monkeypatch.setenv("REDMINE_TIMEOUT", "5")
+        assert get_redmine_timeout() == (5.0, 5.0)
+
+    def test_large_value_keeps_connect_at_10(self, monkeypatch):
+        monkeypatch.setenv("REDMINE_TIMEOUT", "300")
+        assert get_redmine_timeout() == (10.0, 300.0)
+
+    def test_zero_disables(self, monkeypatch):
+        monkeypatch.setenv("REDMINE_TIMEOUT", "0")
+        assert get_redmine_timeout() is None
+
+    def test_negative_disables(self, monkeypatch):
+        monkeypatch.setenv("REDMINE_TIMEOUT", "-1")
+        assert get_redmine_timeout() is None
+
+    def test_garbage_falls_back_to_default(self, monkeypatch):
+        monkeypatch.setenv("REDMINE_TIMEOUT", "soon")
+        assert get_redmine_timeout() == (10.0, 30.0)

--- a/tests/test_client_timeout.py
+++ b/tests/test_client_timeout.py
@@ -19,6 +19,7 @@ from requests.exceptions import (
     ReadTimeout,
 )
 from requests.exceptions import Timeout as RequestsTimeoutExc
+from urllib3.exceptions import ReadTimeoutError
 
 from redmine_mcp_server import _client
 from redmine_mcp_server._client import TimeoutSyncEngine
@@ -153,6 +154,24 @@ class TestEveryBuildPathIsTimed:
         assert fake.call_args.kwargs["requests"]["verify"] is False
         assert fake.call_args.kwargs["engine"] is TimeoutSyncEngine
 
+    def test_oauth_bearer_path_merges_with_ssl_config(self, monkeypatch):
+        """_new_client merges {**requests_config, **caller_requests}: prove
+        both survive when both dicts are non-empty, not just whichever one
+        happens to win a key collision."""
+        fake = self._fake_redmine()
+        monkeypatch.setattr(_client, "Redmine", fake)
+        monkeypatch.setattr(_client, "redmine", None)
+        monkeypatch.setattr(_client, "REDMINE_URL", "https://redmine.example.com")
+        monkeypatch.setattr(_client, "REDMINE_SSL_VERIFY", False)
+        token = MagicMock()
+        token.token = "bearer-token"
+        with patch.object(_client, "get_access_token", return_value=token):
+            _client._get_redmine_client()
+        requests_kwargs = fake.call_args.kwargs["requests"]
+        assert requests_kwargs["headers"]["Authorization"] == "Bearer bearer-token"
+        assert requests_kwargs["verify"] is False
+        assert fake.call_args.kwargs["engine"] is TimeoutSyncEngine
+
 
 class TestTimeoutErrorMessages:
     def test_read_timeout_says_the_server_did_not_respond(self, monkeypatch):
@@ -170,6 +189,19 @@ class TestTimeoutErrorMessages:
     def test_plain_connection_error_still_reported_as_such(self):
         result = _handle_redmine_error(RequestsConnectionError("refused"), "get_issue")
         assert "Cannot connect to Redmine" in result["error"]
+
+    def test_stalled_stream_reported_as_timeout_not_connection_error(self):
+        """requests' iter_content() re-raises a socket read timeout as a
+        plain ConnectionError wrapping urllib3's ReadTimeoutError (see
+        requests/models.py). get_redmine_attachment streams via
+        iter_content, so a Redmine that starts an attachment and then goes
+        silent must be reported as a timeout, not blamed on the URL."""
+        wrapped = ReadTimeoutError(None, None, "Read timed out.")
+        result = _handle_redmine_error(
+            RequestsConnectionError(wrapped), "get_attachment"
+        )
+        assert "did not respond in time" in result["error"]
+        assert "URL is correct" not in result["error"]
 
     def test_message_reports_the_configured_budget(self, monkeypatch):
         monkeypatch.setenv("REDMINE_TIMEOUT", "45")
@@ -231,9 +263,3 @@ class TestTimeoutReachesTheWire:
             client.issue.get(1)
         elapsed = time.monotonic() - started
         assert elapsed < 5, f"timeout did not fire promptly ({elapsed:.1f}s)"
-
-    def test_disabling_the_timeout_is_honored(self, black_hole_server, monkeypatch):
-        """REDMINE_TIMEOUT=0 must not smuggle in a default."""
-        monkeypatch.setenv("REDMINE_TIMEOUT", "0")
-        kwargs = TimeoutSyncEngine.construct_request_kwargs("get", {}, {}, None)
-        assert "timeout" not in kwargs

--- a/tests/test_client_timeout.py
+++ b/tests/test_client_timeout.py
@@ -6,6 +6,10 @@ tests lock in that every client carries a timeout and that the resulting
 errors are distinguishable.
 """
 
+from unittest.mock import MagicMock, patch
+
+from redmine_mcp_server import _client
+from redmine_mcp_server._client import TimeoutSyncEngine
 from redmine_mcp_server._env import get_redmine_timeout
 
 
@@ -33,3 +37,105 @@ class TestGetRedmineTimeout:
     def test_garbage_falls_back_to_default(self, monkeypatch):
         monkeypatch.setenv("REDMINE_TIMEOUT", "soon")
         assert get_redmine_timeout() == (10.0, 30.0)
+
+
+class TestTimeoutSyncEngine:
+    def test_injects_timeout_kwarg(self, monkeypatch):
+        monkeypatch.delenv("REDMINE_TIMEOUT", raising=False)
+        kwargs = TimeoutSyncEngine.construct_request_kwargs("get", {}, {}, None)
+        assert kwargs["timeout"] == (10.0, 30.0)
+
+    def test_keeps_base_kwargs(self, monkeypatch):
+        monkeypatch.delenv("REDMINE_TIMEOUT", raising=False)
+        kwargs = TimeoutSyncEngine.construct_request_kwargs(
+            "get", {"X-Test": "1"}, {"limit": 5}, None
+        )
+        assert kwargs["headers"] == {"X-Test": "1"}
+        assert kwargs["params"] == {"limit": 5}
+
+    def test_omits_timeout_when_disabled(self, monkeypatch):
+        monkeypatch.setenv("REDMINE_TIMEOUT", "0")
+        kwargs = TimeoutSyncEngine.construct_request_kwargs("get", {}, {}, None)
+        assert "timeout" not in kwargs
+
+    def test_read_at_request_time_not_build_time(self, monkeypatch):
+        """The cached legacy client must see an env change without a rebuild."""
+        monkeypatch.setenv("REDMINE_TIMEOUT", "7")
+        assert TimeoutSyncEngine.construct_request_kwargs("get", {}, {}, None)[
+            "timeout"
+        ] == (7.0, 7.0)
+        monkeypatch.setenv("REDMINE_TIMEOUT", "99")
+        assert TimeoutSyncEngine.construct_request_kwargs("get", {}, {}, None)[
+            "timeout"
+        ] == (10.0, 99.0)
+
+
+class TestEveryBuildPathIsTimed:
+    """Every construction path must pass engine=TimeoutSyncEngine.
+
+    Before this change the four branches were eight literal Redmine() calls,
+    so it was possible to time half of them.
+    """
+
+    def _fake_redmine(self):
+        return MagicMock(name="Redmine")
+
+    def test_legacy_api_key_path(self, monkeypatch):
+        fake = self._fake_redmine()
+        monkeypatch.setattr(_client, "Redmine", fake)
+        monkeypatch.setattr(_client, "REDMINE_URL", "https://redmine.example.com")
+        monkeypatch.setattr(_client, "REDMINE_API_KEY", "k")
+        _client._build_legacy_client()
+        assert fake.call_args.kwargs["engine"] is TimeoutSyncEngine
+
+    def test_legacy_username_password_path(self, monkeypatch):
+        fake = self._fake_redmine()
+        monkeypatch.setattr(_client, "Redmine", fake)
+        monkeypatch.setattr(_client, "REDMINE_URL", "https://redmine.example.com")
+        monkeypatch.setattr(_client, "REDMINE_API_KEY", "")
+        monkeypatch.setattr(_client, "REDMINE_USERNAME", "u")
+        monkeypatch.setattr(_client, "REDMINE_PASSWORD", "p")
+        _client._build_legacy_client()
+        assert fake.call_args.kwargs["engine"] is TimeoutSyncEngine
+
+    def test_oauth_bearer_path(self, monkeypatch):
+        fake = self._fake_redmine()
+        monkeypatch.setattr(_client, "Redmine", fake)
+        monkeypatch.setattr(_client, "redmine", None)
+        monkeypatch.setattr(_client, "REDMINE_URL", "https://redmine.example.com")
+        token = MagicMock()
+        token.token = "bearer-token"
+        with patch.object(_client, "get_access_token", return_value=token):
+            _client._get_redmine_client()
+        assert fake.call_args.kwargs["engine"] is TimeoutSyncEngine
+        assert (
+            fake.call_args.kwargs["requests"]["headers"]["Authorization"]
+            == "Bearer bearer-token"
+        )
+
+    def test_legacy_per_user_path(self, monkeypatch):
+        fake = self._fake_redmine()
+        monkeypatch.setattr(_client, "Redmine", fake)
+        monkeypatch.setattr(_client, "redmine", None)
+        monkeypatch.setattr(_client, "REDMINE_URL", "https://redmine.example.com")
+        monkeypatch.setattr(_client, "REDMINE_AUTH_MODE", "legacy-per-user")
+        with (
+            patch.object(_client, "get_access_token", return_value=None),
+            patch(
+                "redmine_mcp_server._per_user.resolve_per_user_key", return_value="k"
+            ),
+            patch("redmine_mcp_server._per_user.maybe_log_identity"),
+        ):
+            _client._get_redmine_client()
+        assert fake.call_args.kwargs["engine"] is TimeoutSyncEngine
+
+    def test_ssl_config_still_reaches_the_client(self, monkeypatch):
+        """engine= must compose with the existing requests= config."""
+        fake = self._fake_redmine()
+        monkeypatch.setattr(_client, "Redmine", fake)
+        monkeypatch.setattr(_client, "REDMINE_URL", "https://redmine.example.com")
+        monkeypatch.setattr(_client, "REDMINE_API_KEY", "k")
+        monkeypatch.setattr(_client, "REDMINE_SSL_VERIFY", False)
+        _client._build_legacy_client()
+        assert fake.call_args.kwargs["requests"]["verify"] is False
+        assert fake.call_args.kwargs["engine"] is TimeoutSyncEngine

--- a/tests/test_client_timeout.py
+++ b/tests/test_client_timeout.py
@@ -8,9 +8,16 @@ errors are distinguishable.
 
 from unittest.mock import MagicMock, patch
 
+from requests.exceptions import (
+    ConnectionError as RequestsConnectionError,
+    ConnectTimeout,
+    ReadTimeout,
+)
+
 from redmine_mcp_server import _client
 from redmine_mcp_server._client import TimeoutSyncEngine
 from redmine_mcp_server._env import get_redmine_timeout
+from redmine_mcp_server._errors import _handle_redmine_error
 
 
 class TestGetRedmineTimeout:
@@ -139,3 +146,26 @@ class TestEveryBuildPathIsTimed:
         _client._build_legacy_client()
         assert fake.call_args.kwargs["requests"]["verify"] is False
         assert fake.call_args.kwargs["engine"] is TimeoutSyncEngine
+
+
+class TestTimeoutErrorMessages:
+    def test_read_timeout_says_the_server_did_not_respond(self, monkeypatch):
+        monkeypatch.delenv("REDMINE_TIMEOUT", raising=False)
+        result = _handle_redmine_error(ReadTimeout("read timed out"), "get_issue")
+        assert "did not respond in time" in result["error"]
+        assert "REDMINE_TIMEOUT" in result["error"]
+
+    def test_connect_timeout_is_not_reported_as_a_connection_error(self):
+        """ConnectTimeout subclasses ConnectionError, so branch order matters."""
+        result = _handle_redmine_error(ConnectTimeout("timed out"), "get_issue")
+        assert "Timed out connecting" in result["error"]
+        assert "URL is correct" not in result["error"]
+
+    def test_plain_connection_error_still_reported_as_such(self):
+        result = _handle_redmine_error(RequestsConnectionError("refused"), "get_issue")
+        assert "Cannot connect to Redmine" in result["error"]
+
+    def test_message_reports_the_configured_budget(self, monkeypatch):
+        monkeypatch.setenv("REDMINE_TIMEOUT", "45")
+        result = _handle_redmine_error(ReadTimeout("read timed out"), "get_issue")
+        assert "45" in result["error"]

--- a/tests/test_client_timeout.py
+++ b/tests/test_client_timeout.py
@@ -6,13 +6,19 @@ tests lock in that every client carries a timeout and that the resulting
 errors are distinguishable.
 """
 
+import socket
+import threading
+import time
 from unittest.mock import MagicMock, patch
 
+import pytest
+from redminelib import Redmine
 from requests.exceptions import (
     ConnectionError as RequestsConnectionError,
     ConnectTimeout,
     ReadTimeout,
 )
+from requests.exceptions import Timeout as RequestsTimeoutExc
 
 from redmine_mcp_server import _client
 from redmine_mcp_server._client import TimeoutSyncEngine
@@ -169,3 +175,65 @@ class TestTimeoutErrorMessages:
         monkeypatch.setenv("REDMINE_TIMEOUT", "45")
         result = _handle_redmine_error(ReadTimeout("read timed out"), "get_issue")
         assert "45" in result["error"]
+
+
+@pytest.fixture
+def black_hole_server():
+    """A TCP server that accepts connections and never replies.
+
+    Reproduces issue #214: the connection succeeds, the request is sent, and
+    no byte ever comes back. Binds to an ephemeral port (port 0) so the test
+    cannot collide with anything on the machine, including a local Redmine on
+    8080/8081. The listener socket, every accepted socket, and the server
+    thread are all released on teardown so no thread outlives the test.
+    """
+    held = []
+    stop = threading.Event()
+    listener = socket.socket()
+    listener.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    listener.bind(("127.0.0.1", 0))
+    listener.listen(5)
+    listener.settimeout(0.5)
+    port = listener.getsockname()[1]
+
+    def serve():
+        while not stop.is_set():
+            try:
+                conn, _ = listener.accept()
+            except socket.timeout:
+                continue
+            except OSError:
+                return
+            held.append(conn)  # accept, then never respond
+
+    thread = threading.Thread(target=serve, daemon=True)
+    thread.start()
+    yield port
+    stop.set()
+    thread.join(timeout=2)
+    for conn in held:
+        conn.close()
+    listener.close()
+
+
+class TestTimeoutReachesTheWire:
+    def test_read_timeout_fires_instead_of_hanging(
+        self, black_hole_server, monkeypatch
+    ):
+        monkeypatch.setenv("REDMINE_TIMEOUT", "1")
+        client = Redmine(
+            f"http://127.0.0.1:{black_hole_server}",
+            key="test-key",
+            engine=TimeoutSyncEngine,
+        )
+        started = time.monotonic()
+        with pytest.raises(RequestsTimeoutExc):
+            client.issue.get(1)
+        elapsed = time.monotonic() - started
+        assert elapsed < 5, f"timeout did not fire promptly ({elapsed:.1f}s)"
+
+    def test_disabling_the_timeout_is_honored(self, black_hole_server, monkeypatch):
+        """REDMINE_TIMEOUT=0 must not smuggle in a default."""
+        monkeypatch.setenv("REDMINE_TIMEOUT", "0")
+        kwargs = TimeoutSyncEngine.construct_request_kwargs("get", {}, {}, None)
+        assert "timeout" not in kwargs

--- a/tests/test_client_token_access.py
+++ b/tests/test_client_token_access.py
@@ -42,7 +42,9 @@ class TestOAuthClientBuilding:
         ):
             _client._get_redmine_client()
             mock_redmine.assert_called_once_with(
-                "https://r.example.com", key="legacy-key"
+                "https://r.example.com",
+                engine=_client.TimeoutSyncEngine,
+                key="legacy-key",
             )
 
     def test_no_circular_oauth_middleware_import(self):

--- a/tests/test_error_handling.py
+++ b/tests/test_error_handling.py
@@ -93,8 +93,8 @@ class TestErrorHandler:
         error = Timeout("Read timed out")
         result = _handle_redmine_error(error, "listing projects")
 
-        assert "timed out" in result["error"].lower()
-        assert "Network connectivity" in result["error"]
+        assert "did not respond in time" in result["error"]
+        assert "REDMINE_TIMEOUT" in result["error"]
 
     def test_ssl_error_message(self):
         """SSL error provides certificate guidance."""
@@ -238,7 +238,7 @@ class TestToolErrorIntegration:
         mock_redmine.issue.search.side_effect = Timeout()
         result = await search_redmine_issues("test query")
 
-        assert "timed out" in result["error"].lower()
+        assert "did not respond in time" in result["error"]
 
 
 class TestLoggingCleanup:

--- a/tests/test_per_user_auth.py
+++ b/tests/test_per_user_auth.py
@@ -123,7 +123,11 @@ def test_client_uses_per_user_key_over_secure_transport():
         patch("redmine_mcp_server._client.get_http_request", return_value=req),
     ):
         _client._get_redmine_client()
-        mock_redmine.assert_called_once_with("https://r.example.com", key=VALID_KEY)
+        mock_redmine.assert_called_once_with(
+            "https://r.example.com",
+            engine=_client.TimeoutSyncEngine,
+            key=VALID_KEY,
+        )
 
 
 def test_client_per_user_missing_header_raises():


### PR DESCRIPTION
## Summary

Adds `REDMINE_TIMEOUT` (default 30 seconds, `0` disables) so a Redmine call cannot hang forever. Nothing set a timeout on these calls before now.

The obvious fix does not work, which is how it went unnoticed: python-redmine accepts a `requests={"timeout": ...}` setting and silently discards it. `SyncEngine.create_session()` setattrs it onto a `requests.Session`, which has no `timeout` read at request time, and `construct_request_kwargs()` never builds one. A client configured that way still hung past 45 seconds on a black-holed socket.

This is the first of two parts. It bounds the hang, but a hung call still stalls other requests including `/health`, because the synchronous call stays on the event loop. Moving those calls into a worker thread is the second part, and I will open a follow-up issue for it so the work stays tracked once this one closes.

Fixes #214 (reported by @Bricklou)

## Changes

- `get_redmine_timeout()` in `_env.py`: whole seconds, connect `min(10, value)`, read the full value, `0` or less disables. Read per request, so the cached client picks up a change without a rebuild.
- `TimeoutSyncEngine` injects it through python-redmine's `engine=` option. Patching `session.request` would not survive `Redmine.session()`, which re-instantiates the engine and is what `download()` uses, so attachment downloads would have gone untimed.
- `_new_client()` is now the only construction path, replacing eight literal `Redmine(...)` sites: four auth branches, each written twice, with and without a `requests=` config.
- `_errors.py` fixes two misdiagnoses. `ConnectTimeout` subclasses `ConnectionError`, so under the old branch order a connect timeout read as "check the URL is correct". Separately, a stalled streamed download arrives as `ConnectionError` wrapping urllib3's `ReadTimeoutError`, not `ReadTimeout`. Both now report as timeouts. Genuine connection failures are unchanged.
- Docs in README, `.env.example`, and `.env.docker.example`, plus a rewrite of the troubleshooting section that previously advised setting a timeout that did not exist.
- `timeout-minutes: 15` on both CI test jobs, since this branch adds the first test that hangs rather than fails on regression. No new dependency.

## Testing

`python tests/run_tests.py --all` passes: 1602 unit, 89 integration (81 passed, 8 skipped), the latter against both Redmine 6.1.1 and 7.0.0. black and flake8 clean.

22 new tests in `tests/test_client_timeout.py`. One uses a real black-hole socket instead of a mock, because a mocked test would have passed against the broken code and proved nothing. Removing the injection makes that test hang (`exit=124`) rather than fail, which is how I confirmed it bites.

Manual run against a black hole: `get_redmine_issue` errored at 5.0s with `REDMINE_TIMEOUT=5` and at 30.0s on the default, where it previously hung past 2m22s. I checked the connect path separately against an address that drops packets, and repeated the whole thing in Docker, where it errored at 5.1s with the container reporting healthy.

## Caveat

This bounds the freeze without ending it. At the default 30 seconds, `/health` probed with a 10 second Kubernetes-style deadline still failed during a hung call, so pods can still be restarted until the follow-up lands. Until then, set `REDMINE_TIMEOUT` below your probe deadline: at 5 seconds the same probe succeeded.

The streamed-download fix depends on `requests` wrapping `ReadTimeoutError` as `ConnectionError.args[0]`. If that shape ever changes, the message silently reverts to the connection wording, so it is worth rechecking on a major bump of requests or urllib3.

## Checklist

- [x] `python tests/run_tests.py --all` passes (activate `.venv` first)
- [x] `uv run black --check src/` and `uv run flake8 src/ --max-line-length=88` are clean
- [x] `CHANGELOG.md` [Unreleased] has a bullet for user-facing changes
- [x] No manual version bumps: `pyproject.toml`, `server.json`, and CHANGELOG version headers are managed by the release script
- [x] Docs updated where behavior changed
- [x] Change works with both local and Docker deployments
