### PR TITLE
fix: run blocking Redmine calls off the event loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,9 +18,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   covers a stalled attachment download: a Redmine that starts sending an
   attachment and then goes silent is now reported as a timeout instead of a
   connection error.
-  Note that a hung call can still stall other requests for the duration of the
-  timeout, including `/health`; moving the blocking calls off the event loop
-  is tracked separately.
+- Blocking Redmine calls no longer stall the event loop. Every tool now runs its
+  synchronous section in a worker thread, so a hung or slow Redmine server can
+  no longer delay other requests. Previously a single hung call blocked
+  everything else for the full `REDMINE_TIMEOUT`: measured against a server that
+  accepts connections and never answers, `/health` probed with a 10 second
+  deadline failed outright during one hung call, so a liveness probe could
+  restart the pod. It now answers throughout. Wrapping the client call alone
+  was not enough, because python-redmine issues its request on first iteration
+  of a result set and can re-fetch on attribute access, so each tool moves its
+  whole synchronous section in one hop ([#216](https://github.com/jztan/redmine-mcp-server/issues/216)).
 
 ### Changed
 - The README Contributors list is now generated from the `### Contributors`

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -113,11 +113,67 @@ Cross-cutting utilities live as flat private modules:
 | `_cleanup.py` | Background cleanup task |
 | `_http_routes.py` | Starlette routes (`/health` with a Doorkeeper introspection probe in `oauth` / `oauth-proxy` modes and a Redmine credential probe in legacy mode, `/files/{id}`, `/cleanup/status`) |
 | `_decorators.py` | `@action_dispatch` decorator + `ActionMode` enum |
+| `_offload.py` | `@offloaded` decorator and `in_thread()`: run blocking python-redmine work in a worker thread instead of on the event loop |
 | `_auth.py` | `RedmineAuthProvider` (a `RemoteAuthProvider` subclass) and its `build_remote_auth()` factory: composes `IntrospectionTokenVerifier` (RFC 7662) and adds the RFC 8414 AS-metadata mirror plus the RFC 7009 `/revoke` route. Used by `oauth` mode. |
 | `_oauth_proxy.py` | `build_oauth_proxy()` factory: a FastMCP `OAuthProxy` backed by `IntrospectionTokenVerifier`, proxying `/authorize`, `/token`, and `/revoke` to Doorkeeper with external consent and a loopback-default redirect-URI allowlist. Used by `oauth-proxy` mode. |
 | `_mount.py` | Public base-URL helpers (`mcp_base_url`, `mcp_path_for_http_app`, `mcp_mount_prefix`) for serving the authenticated app behind `REDMINE_MCP_BASE_URL`. |
 | `_tool_error_middleware.py` | FastMCP middleware that surfaces tool-validation errors with a clean payload. |
 | `oauth_scopes.py` | `READ_SCOPES` / `WRITE_SCOPES` inventory + `advertised_scopes()` used by both the protected-resource and AS-metadata discovery documents. |
+
+### Keeping blocking calls off the event loop
+
+python-redmine is synchronous, so any tool that calls it on the event loop
+stalls every other request until the call returns, including `/health`
+([#216](https://github.com/jztan/redmine-mcp-server/issues/216)). Two rules
+follow, and `_get_redmine_client()` enforces them at runtime: it raises if it
+is called on the event loop thread.
+
+**Rule 1: if the function has no `await`, make it a plain `def` and decorate it
+with `@offloaded`.** This is most tools and every per-action handler.
+
+```python
+from .._offload import offloaded
+
+@mcp.tool()
+@offloaded
+def list_widgets(project_id: int) -> Dict[str, Any]:
+    ...
+```
+
+**Rule 2: if the function must stay a coroutine because it awaits something,
+wrap its synchronous remainder in a nested closure and hand that to
+`in_thread()`.**
+
+```python
+from .._offload import in_thread
+
+@mcp.tool()
+async def get_widget(widget_id: int) -> Dict[str, Any]:
+    await _ensure_cleanup_started()
+
+    def _run() -> Dict[str, Any]:
+        try:
+            widget = _get_redmine_client().widget.get(widget_id)
+            return _widget_to_dict(widget)
+        except Exception as e:
+            return _handle_redmine_error(e, f"fetching widget {widget_id}")
+
+    return await in_thread(_run)
+```
+
+Use a nested closure rather than a separate top-level function so parameters
+are captured instead of re-declared in a second signature. If the closure
+assigns to a name that also exists outside it, add a `nonlocal` for that name,
+otherwise Python makes it a closure-local and the read before assignment raises
+`UnboundLocalError`.
+
+Move the **whole** synchronous section in one hop, not just the client call.
+python-redmine issues its HTTP request on the first iteration of a result set,
+not at `.filter()`, and re-fetches on attribute access for a field that was not
+included, so iteration and serialization block too.
+
+`tests/test_offload.py` has a static check that fails with the offending file,
+line, and function if a blocking call is left on the loop.
 
 ### Adding a new `manage_X` tool
 
@@ -125,13 +181,18 @@ The 9 `manage_X` tools (plus `manage_redmine_version`) follow a consistent patte
 
 ```python
 from .._decorators import ActionMode, action_dispatch
+from .._offload import offloaded
 
-# Per-action handlers (private async functions in the same file)
-async def _list_widgets_action(project_id=None, **_):
+# Per-action handlers (private functions in the same file). They are plain
+# `def` carrying @offloaded, so the blocking Redmine work runs in a worker
+# thread; action_dispatch awaits them exactly the same way.
+@offloaded
+def _list_widgets_action(project_id=None, **_):
     # validation, fetch, return
     ...
 
-async def _create_widget_action(project_id=None, name=None, **_):
+@offloaded
+def _create_widget_action(project_id=None, name=None, **_):
     # validation, create, return
     ...
 
@@ -377,7 +438,8 @@ git push origin feature/your-feature-name
 
 ```python
 # Good: Clear function with type hints and docstring
-async def get_issue(issue_id: int, include_journals: bool = True) -> Dict[str, Any]:
+@offloaded
+def get_issue(issue_id: int, include_journals: bool = True) -> Dict[str, Any]:
     """
     Retrieve detailed information about a Redmine issue.
 
@@ -409,9 +471,13 @@ except Exception as e:
 ### MCP Tool Implementation
 
 ```python
-# Good: MCP tool with clear documentation
+# Good: MCP tool with clear documentation.
+# Plain `def` + @offloaded so the blocking Redmine call runs in a worker
+# thread. See "Keeping blocking calls off the event loop" above for the
+# case where the tool has to stay a coroutine.
 @mcp.tool()
-async def tool_name(param: str) -> Dict[str, Any]:
+@offloaded
+def tool_name(param: str) -> Dict[str, Any]:
     """
     Brief description of what this tool does.
 
@@ -591,6 +657,7 @@ redmine-mcp-server/
 │   ├── _cleanup.py          # Background attachment cleanup task
 │   ├── _http_routes.py      # Starlette routes (/health w/ introspection + legacy redmine probe, /files, /cleanup/status)
 │   ├── _decorators.py       # `@action_dispatch` decorator + `ActionMode` enum
+│   ├── _offload.py          # `@offloaded` / `in_thread()`: keep blocking calls off the event loop
 │   ├── _tool_error_middleware.py  # FastMCP middleware that normalizes tool validation errors
 │   ├── oauth_scopes.py      # READ_SCOPES / WRITE_SCOPES inventory + advertised_scopes()
 │   └── file_manager.py      # Attachment file storage manager
@@ -646,9 +713,11 @@ To add a new MCP tool to the server:
    ```python
    from ..server import mcp
    from .._errors import _handle_redmine_error
+   from .._offload import offloaded
 
    @mcp.tool()
-   async def your_new_tool(param: str) -> Dict[str, Any]:
+   @offloaded
+   def your_new_tool(param: str) -> Dict[str, Any]:
        """
        Brief description of what this tool does.
 

--- a/src/redmine_mcp_server/_client.py
+++ b/src/redmine_mcp_server/_client.py
@@ -16,9 +16,12 @@ Tests patch this module's attributes directly, e.g.
 ``patch("redmine_mcp_server._client.Redmine")``.
 """
 
+import asyncio
+import contextlib
 import logging
 import os
 import threading
+from contextvars import ContextVar
 from pathlib import Path
 from typing import Optional, Union
 from urllib.parse import urlparse
@@ -342,7 +345,49 @@ def _build_legacy_client() -> Redmine:
         )
 
 
+# When true, _get_redmine_client() skips the event-loop check. Only for
+# callers that are provably non-blocking or for tests exercising the client
+# factory directly.
+_loop_thread_allowed: ContextVar[bool] = ContextVar(
+    "_loop_thread_allowed", default=False
+)
+
+
+@contextlib.contextmanager
+def allow_loop_thread():
+    """Temporarily permit _get_redmine_client() on the event loop thread."""
+    token = _loop_thread_allowed.set(True)
+    try:
+        yield
+    finally:
+        _loop_thread_allowed.reset(token)
+
+
+def _reject_event_loop_thread() -> None:
+    """Fail loudly if a blocking client is being built on the event loop.
+
+    python-redmine is synchronous, so every call made through this client
+    blocks whichever thread it runs on. On the event loop that stalls every
+    other request, including the /health probe (issue #216). Tools must go
+    through ``@offloaded`` or ``in_thread()``; inside a worker thread there is
+    no running loop, so this check is a no-op there.
+    """
+    if _loop_thread_allowed.get():
+        return
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        return
+    raise RuntimeError(
+        "_get_redmine_client() was called on the event loop thread. Blocking "
+        "Redmine calls must run inside @offloaded or in_thread() so a hung "
+        "server cannot stall other requests. See issue #216."
+    )
+
+
 def _get_redmine_client() -> Redmine:
+    _reject_event_loop_thread()
+
     # Read this module's attributes via globals() so tests patching
     # `_client.redmine`, `_client._legacy_client`, and `_client.Redmine`
     # are observed at call time.

--- a/src/redmine_mcp_server/_client.py
+++ b/src/redmine_mcp_server/_client.py
@@ -18,6 +18,7 @@ Tests patch this module's attributes directly, e.g.
 
 import logging
 import os
+import threading
 from pathlib import Path
 from typing import Optional, Union
 from urllib.parse import urlparse
@@ -296,7 +297,24 @@ redmine: Optional[Redmine] = None
 
 # Cached legacy-mode client — avoids recreating Redmine() on every tool call
 # when running without OAuth.
+#
+# Tests patch this module attribute directly, so it stays the authoritative
+# override: when it is not None it is returned as is. The automatic cache lives
+# in a threading.local() instead, because tools now run in worker threads and
+# a requests.Session is not documented as thread-safe (issue #216).
 _legacy_client: Optional[Redmine] = None
+
+_legacy_client_local = threading.local()
+
+
+def _reset_legacy_client_cache() -> None:
+    """Drop the per-thread cached legacy client.
+
+    Used by the test suite so a test patching ``_legacy_client`` to None gets a
+    freshly built client rather than one cached by an earlier test.
+    """
+    if hasattr(_legacy_client_local, "client"):
+        del _legacy_client_local.client
 
 
 def _build_legacy_client() -> Redmine:
@@ -325,8 +343,6 @@ def _build_legacy_client() -> Redmine:
 
 
 def _get_redmine_client() -> Redmine:
-    global _legacy_client
-
     # Read this module's attributes via globals() so tests patching
     # `_client.redmine`, `_client._legacy_client`, and `_client.Redmine`
     # are observed at call time.
@@ -357,8 +373,13 @@ def _get_redmine_client() -> Redmine:
         maybe_log_identity(client, key)
         return client
 
-    # Legacy mode: reuse a cached singleton.
-    if g["_legacy_client"] is None:
-        g["_legacy_client"] = _build_legacy_client()
-    _legacy_client = g["_legacy_client"]
-    return g["_legacy_client"]
+    # Legacy mode: an explicitly set module attribute wins (tests patch it),
+    # otherwise use the per-thread cache.
+    if g["_legacy_client"] is not None:
+        return g["_legacy_client"]
+
+    client = getattr(_legacy_client_local, "client", None)
+    if client is None:
+        client = _build_legacy_client()
+        _legacy_client_local.client = client
+    return client

--- a/src/redmine_mcp_server/_offload.py
+++ b/src/redmine_mcp_server/_offload.py
@@ -1,0 +1,61 @@
+"""Run blocking python-redmine work off the asyncio event loop.
+
+python-redmine is synchronous, and its laziness makes the blocking surface
+wider than it looks: ``BaseResourceSet.__iter__`` issues the HTTP request on
+first iteration rather than at ``.filter()``, and ``BaseResource.__getattr__``
+calls ``refresh()`` when an included field is missing. A tool that only wrapped
+its client call would still block the loop while iterating results or
+serializing them.
+
+So the rule is: a tool's entire synchronous section moves in one hop.
+
+``@offloaded`` is the preferred form because it moves a whole function body by
+construction. ``in_thread()`` is for tools that must stay coroutines because
+they await something (an httpx upload, ``_ensure_cleanup_started()``); those
+wrap their synchronous remainder in a nested closure.
+
+Both use ``asyncio.to_thread``, which copies the current context into the
+worker. That propagation is load-bearing: FastMCP's ``get_access_token()`` and
+``get_http_request()`` read contextvars, so OAuth, oauth-proxy, and
+legacy-per-user auth all resolve inside the worker.
+
+See issue #216.
+"""
+
+import asyncio
+import functools
+import inspect
+from typing import Any, Awaitable, Callable, TypeVar
+
+T = TypeVar("T")
+
+
+async def in_thread(func: Callable[..., T], /, *args: Any, **kwargs: Any) -> T:
+    """Run a blocking callable in a worker thread.
+
+    Exceptions propagate to the caller unchanged, so an existing
+    ``try``/``except`` around the call site keeps working.
+    """
+    return await asyncio.to_thread(func, *args, **kwargs)
+
+
+def offloaded(fn: Callable[..., T]) -> Callable[..., Awaitable[T]]:
+    """Turn a synchronous function into a coroutine function run in a thread.
+
+    Applied under ``@mcp.tool()`` so FastMCP registers the coroutine wrapper.
+    ``functools.wraps`` keeps the name, docstring, and signature, so the
+    generated tool schema and any ``await tool(...)`` in the tests are
+    unchanged.
+    """
+    if inspect.iscoroutinefunction(fn):
+        raise TypeError(
+            f"@offloaded got {fn.__name__}, which is already a coroutine "
+            "function. Drop the 'async' keyword, or use in_thread() for the "
+            "synchronous section if the function must stay a coroutine."
+        )
+
+    @functools.wraps(fn)
+    async def wrapper(*args: Any, **kwargs: Any) -> T:
+        return await asyncio.to_thread(fn, *args, **kwargs)
+
+    return wrapper

--- a/src/redmine_mcp_server/tools/checklists.py
+++ b/src/redmine_mcp_server/tools/checklists.py
@@ -6,6 +6,7 @@ from typing import Any, Dict, List, Optional
 from .._client import _get_redmine_client
 from .._env import _is_checklists_enabled, _is_read_only_mode
 from .._errors import _READ_ONLY_ERROR, _handle_redmine_error
+from .._offload import offloaded
 from .._serialization import wrap_insecure_content
 from .._validation import _is_positive_int
 from ..server import mcp
@@ -79,7 +80,8 @@ def _create_checklist_item_api(issue_id: int, payload: Dict[str, Any]) -> Any:
 
 
 @mcp.tool()
-async def get_checklist(issue_id: int) -> Dict[str, Any]:
+@offloaded
+def get_checklist(issue_id: int) -> Dict[str, Any]:
     """Retrieve all checklist items for a Redmine issue.
 
     Requires the RedmineUP Checklists plugin and
@@ -121,7 +123,8 @@ async def get_checklist(issue_id: int) -> Dict[str, Any]:
 
 
 @mcp.tool()
-async def update_checklist_item(
+@offloaded
+def update_checklist_item(
     checklist_item_id: int,
     subject: Optional[str] = None,
     is_done: Optional[bool] = None,
@@ -192,7 +195,8 @@ async def update_checklist_item(
 
 
 @mcp.tool()
-async def create_checklist_item(
+@offloaded
+def create_checklist_item(
     issue_id: int,
     subject: str,
     is_section: bool = False,

--- a/src/redmine_mcp_server/tools/contacts.py
+++ b/src/redmine_mcp_server/tools/contacts.py
@@ -9,6 +9,7 @@ from .._client import _get_redmine_client
 from .._decorators import ActionMode, action_dispatch
 from .._env import _is_crm_enabled
 from .._errors import _handle_redmine_error
+from .._offload import offloaded
 from .._serialization import (
     _REDMINE_API_PAGE_CAP,
     _safe_isoformat,
@@ -101,7 +102,8 @@ def _contact_to_dict(contact: Dict[str, Any]) -> Dict[str, Any]:
     }
 
 
-async def _list_contacts_action(
+@offloaded
+def _list_contacts_action(
     project_id: Optional[Union[str, int]] = None,
     search: Optional[str] = None,
     tags: Optional[str] = None,
@@ -144,7 +146,8 @@ async def _list_contacts_action(
         )
 
 
-async def _get_contact_action(
+@offloaded
+def _get_contact_action(
     contact_id: Optional[int] = None,
     include: Optional[str] = None,
     **_: Any,
@@ -172,7 +175,8 @@ async def _get_contact_action(
         )
 
 
-async def _create_contact_action(
+@offloaded
+def _create_contact_action(
     project_id: Optional[Union[str, int]] = None,
     first_name: Optional[str] = None,
     last_name: Optional[str] = None,
@@ -234,7 +238,8 @@ async def _create_contact_action(
         )
 
 
-async def _update_contact_action(
+@offloaded
+def _update_contact_action(
     contact_id: Optional[int] = None,
     fields: Optional[Dict[str, Any]] = None,
     **_: Any,
@@ -275,7 +280,8 @@ async def _update_contact_action(
         )
 
 
-async def _delete_contact_action(
+@offloaded
+def _delete_contact_action(
     contact_id: Optional[int] = None,
     **_: Any,
 ) -> Dict[str, Any]:
@@ -300,7 +306,8 @@ async def _delete_contact_action(
         )
 
 
-async def _assign_contact_to_project_action(
+@offloaded
+def _assign_contact_to_project_action(
     contact_id: Optional[int] = None,
     project_id: Optional[Union[str, int]] = None,
     **_: Any,
@@ -338,7 +345,8 @@ async def _assign_contact_to_project_action(
         )
 
 
-async def _remove_contact_from_project_action(
+@offloaded
+def _remove_contact_from_project_action(
     contact_id: Optional[int] = None,
     project_id: Optional[Union[str, int]] = None,
     **_: Any,

--- a/src/redmine_mcp_server/tools/documents.py
+++ b/src/redmine_mcp_server/tools/documents.py
@@ -66,6 +66,7 @@ from .._client import _get_redmine_client
 from .._decorators import ActionMode, action_dispatch
 from .._env import _is_dmsf_enabled
 from .._errors import _handle_redmine_error
+from .._offload import offloaded
 from .._serialization import (
     _REDMINE_API_PAGE_CAP,
     _safe_isoformat,
@@ -212,7 +213,8 @@ def _extract_dmsf_single_doc(payload: Any) -> Dict[str, Any]:
     return {}
 
 
-async def _list_documents_action(
+@offloaded
+def _list_documents_action(
     project_id: Optional[Union[str, int]] = None,
     folder_id: Optional[int] = None,
     limit: int = 100,
@@ -268,7 +270,8 @@ async def _list_documents_action(
         )
 
 
-async def _get_document_action(
+@offloaded
+def _get_document_action(
     document_id: Optional[int] = None,
     **_: Any,
 ) -> Dict[str, Any]:
@@ -336,7 +339,8 @@ def _split_dmsf_version(version: str) -> Union[Dict[str, str], Dict[str, str]]:
     }
 
 
-async def _create_document_action(
+@offloaded
+def _create_document_action(
     project_id: Optional[Union[str, int]] = None,
     filename: Optional[str] = None,
     content_base64: Optional[str] = None,
@@ -463,7 +467,8 @@ def _fetch_current_dmsf_doc(document_id: int) -> Dict[str, Any]:
     return _extract_dmsf_single_doc(payload)
 
 
-async def _update_document_action(
+@offloaded
+def _update_document_action(
     document_id: Optional[int] = None,
     fields: Optional[Dict[str, Any]] = None,
     **_: Any,

--- a/src/redmine_mcp_server/tools/enumeration.py
+++ b/src/redmine_mcp_server/tools/enumeration.py
@@ -11,12 +11,14 @@ from pydantic import Field
 
 from .._client import _get_redmine_client
 from .._errors import _handle_redmine_error
+from .._offload import offloaded
 from .._serialization import _iter_capped, _safe_isoformat
 from ..server import mcp
 
 
 @mcp.tool()
-async def list_redmine_trackers() -> Union[List[Dict[str, Any]], Dict[str, Any]]:
+@offloaded
+def list_redmine_trackers() -> Union[List[Dict[str, Any]], Dict[str, Any]]:
     """List all trackers (issue types) defined in the Redmine instance.
 
     Trackers classify issues (e.g., Bug, Feature, Support). Use this tool
@@ -50,7 +52,8 @@ async def list_redmine_trackers() -> Union[List[Dict[str, Any]], Dict[str, Any]]
 
 
 @mcp.tool()
-async def list_redmine_issue_statuses() -> Union[List[Dict[str, Any]], Dict[str, Any]]:
+@offloaded
+def list_redmine_issue_statuses() -> Union[List[Dict[str, Any]], Dict[str, Any]]:
     """List all issue statuses defined in the Redmine instance.
 
     Use this tool to discover valid ``status_id`` values before calling
@@ -86,9 +89,8 @@ async def list_redmine_issue_statuses() -> Union[List[Dict[str, Any]], Dict[str,
 
 
 @mcp.tool()
-async def list_redmine_issue_priorities() -> (
-    Union[List[Dict[str, Any]], Dict[str, Any]]
-):
+@offloaded
+def list_redmine_issue_priorities() -> Union[List[Dict[str, Any]], Dict[str, Any]]:
     """List all issue priority levels defined in the Redmine instance.
 
     Use this tool to discover valid ``priority_id`` values before calling
@@ -125,7 +127,8 @@ async def list_redmine_issue_priorities() -> (
 
 
 @mcp.tool()
-async def list_redmine_users(
+@offloaded
+def list_redmine_users(
     name: Optional[str] = None,
     group_id: Optional[int] = None,
     limit: Annotated[int, Field(ge=1, le=100)] = 25,
@@ -178,7 +181,8 @@ async def list_redmine_users(
 
 
 @mcp.tool()
-async def get_current_user() -> Dict[str, Any]:
+@offloaded
+def get_current_user() -> Dict[str, Any]:
     """Retrieve the currently authenticated user's profile.
 
     Resolves to ``GET /my/account.json`` under the hood. Works for any
@@ -212,7 +216,8 @@ async def get_current_user() -> Dict[str, Any]:
 
 
 @mcp.tool()
-async def list_redmine_queries() -> Union[List[Dict[str, Any]], Dict[str, Any]]:
+@offloaded
+def list_redmine_queries() -> Union[List[Dict[str, Any]], Dict[str, Any]]:
     """List all saved custom queries visible to the current user.
 
     Custom queries are saved issue filters (defined via the Redmine web

--- a/src/redmine_mcp_server/tools/files.py
+++ b/src/redmine_mcp_server/tools/files.py
@@ -23,6 +23,7 @@ from .._env import (
     _is_read_only_mode,
 )
 from .._errors import _READ_ONLY_ERROR, _handle_redmine_error
+from .._offload import in_thread, offloaded
 from .._serialization import (
     _iter_capped,
     _named_ref,
@@ -209,7 +210,10 @@ async def _build_upload_descriptors(
         if not isinstance(entry, dict):
             return [], {"error": f"uploads[{index}] must be an object."}
 
-    client = _get_redmine_client()
+    # This helper interleaves async downloads with blocking uploads, so it
+    # cannot move to a worker wholesale like a tool body. Each blocking step
+    # gets its own hop instead (issue #216).
+    client = await in_thread(_get_redmine_client)
     descriptors: List[Dict[str, Any]] = []
     for index, entry in enumerate(uploads):
         content_bytes, final_name, resolve_error = await _resolve_upload_content(
@@ -221,9 +225,13 @@ async def _build_upload_descriptors(
         if resolve_error is not None:
             return [], {"error": f"uploads[{index}]: {resolve_error['error']}"}
         try:
-            token = client.upload(io.BytesIO(content_bytes), filename=final_name)[
-                "token"
-            ]
+
+            def _upload() -> str:
+                return client.upload(io.BytesIO(content_bytes), filename=final_name)[
+                    "token"
+                ]
+
+            token = await in_thread(_upload)
         except Exception as e:  # noqa: BLE001 - surfaced as an error dict
             return [], {"error": f"uploads[{index}]: failed to upload. Details: {e}"}
         descriptor: Dict[str, Any] = {"token": token, "filename": final_name}
@@ -302,154 +310,167 @@ async def get_redmine_attachment(
     """
     await _ensure_cleanup_started()
 
-    try:
-        client = _get_redmine_client()
+    def _run():
         try:
-            attachment = client.attachment.get(attachment_id)
-        except ResourceNotFoundError:
-            # Redmine's GET /attachments/{id}.json returns 404 in three
-            # situations and does not distinguish between them:
-            #   1. the attachment row truly does not exist;
-            #   2. the caller lacks view permission on the container
-            #      (Redmine collapses 403 -> 404 to avoid leaking
-            #      existence of attachments the user cannot see);
-            #   3. the underlying file is unreadable on the Redmine
-            #      server's filesystem (orphan metadata).
-            # The embed path used by get_redmine_issue(include_attachments)
-            # surfaces (3) and sometimes (2), which is why callers see
-            # the attachment via one tool but get "not found" here.
-            return {
-                "error": (
-                    f"Attachment {attachment_id} could not be fetched "
-                    f"from /attachments/{attachment_id}.json (HTTP 404)."
-                ),
-                "code": "ATTACHMENT_UNAVAILABLE",
-                "upstream_status": 404,
-                "hint": (
-                    "Redmine returns 404 here for missing attachments, "
-                    "for callers who lack view permission on the "
-                    "container, and for attachments whose underlying "
-                    "file is missing on the Redmine server's disk. If "
-                    "get_redmine_issue(include_attachments=True) lists "
-                    "this attachment, it exists but is either "
-                    "permission-restricted or orphaned on disk -- "
-                    "contact the Redmine administrator."
-                ),
-                "attachment_id": attachment_id,
-            }
-
-        # Sanitize filename: basename only (path traversal protection)
-        raw_filename = getattr(attachment, "filename", "") or ""
-        original_filename = os.path.basename(raw_filename)
-        if not original_filename:
-            original_filename = f"attachment_{attachment_id}"
-
-        content_type = getattr(attachment, "content_type", "application/octet-stream")
-        content_url = getattr(attachment, "content_url", "")
-
-        # Prepare UUID-based storage directory
-        attachments_dir = Path(os.getenv("ATTACHMENTS_DIR", "./attachments"))
-        attachments_dir.mkdir(parents=True, exist_ok=True)
-        file_id = str(uuid.uuid4())
-        uuid_dir = attachments_dir / file_id
-        uuid_dir.mkdir(exist_ok=True)
-
-        temp_path = uuid_dir / f"{original_filename}.tmp"
-        final_path = uuid_dir / original_filename
-
-        # Stream download with byte-cap abort
-        max_bytes = _get_int_env(
-            "ATTACHMENT_MAX_DOWNLOAD_BYTES",
-            _ATTACHMENT_MAX_DOWNLOAD_BYTES_DEFAULT,
-        )
-        response = client.download(content_url, savepath=None)
-
-        try:
-            byte_count = 0
-            with open(temp_path, "wb") as fh:
-                for chunk in response.iter_content(65536):
-                    byte_count += len(chunk)
-                    if byte_count > max_bytes:
-                        fh.close()
-                        _cleanup_uuid_dir(uuid_dir, temp_path)
-                        return {
-                            "error": (
-                                f"Attachment {attachment_id} exceeds the "
-                                f"{max_bytes}-byte download limit."
-                            )
-                        }
-                    fh.write(chunk)
-        except Exception:
-            _cleanup_uuid_dir(uuid_dir, temp_path)
-            raise
-
-        # Atomic rename: temp -> final
-        os.rename(str(temp_path), str(final_path))
-
-        # Write metadata for the cleanup manager
-        expires_minutes = float(os.getenv("ATTACHMENT_EXPIRES_MINUTES", "60"))
-        expires_at = datetime.now(timezone.utc) + timedelta(minutes=expires_minutes)
-        file_size = final_path.stat().st_size
-        absolute_path = str(final_path.resolve())
-
-        metadata = {
-            "file_id": file_id,
-            "attachment_id": attachment_id,
-            "original_filename": original_filename,
-            "file_path": absolute_path,
-            "content_type": content_type,
-            "size": file_size,
-            "created_at": datetime.now(timezone.utc).isoformat(),
-            "expires_at": expires_at.isoformat(),
-        }
-        metadata_file = uuid_dir / "metadata.json"
-        temp_metadata = uuid_dir / "metadata.json.tmp"
-        try:
-            with open(temp_metadata, "w") as fh:
-                json.dump(metadata, fh, indent=2)
-            os.rename(str(temp_metadata), str(metadata_file))
-        except (OSError, IOError, ValueError) as exc:
+            client = _get_redmine_client()
             try:
-                if temp_metadata.exists():
-                    temp_metadata.unlink()
-                if final_path.exists():
-                    final_path.unlink()
-            except OSError:
-                pass
-            return {"error": f"Failed to save metadata: {exc}"}
+                attachment = client.attachment.get(attachment_id)
+            except ResourceNotFoundError:
+                # Redmine's GET /attachments/{id}.json returns 404 in three
+                # situations and does not distinguish between them:
+                #   1. the attachment row truly does not exist;
+                #   2. the caller lacks view permission on the container
+                #      (Redmine collapses 403 -> 404 to avoid leaking
+                #      existence of attachments the user cannot see);
+                #   3. the underlying file is unreadable on the Redmine
+                #      server's filesystem (orphan metadata).
+                # The embed path used by get_redmine_issue(include_attachments)
+                # surfaces (3) and sometimes (2), which is why callers see
+                # the attachment via one tool but get "not found" here.
+                return {
+                    "error": (
+                        f"Attachment {attachment_id} could not be fetched "
+                        f"from /attachments/{attachment_id}.json (HTTP 404)."
+                    ),
+                    "code": "ATTACHMENT_UNAVAILABLE",
+                    "upstream_status": 404,
+                    "hint": (
+                        "Redmine returns 404 here for missing attachments, "
+                        "for callers who lack view permission on the "
+                        "container, and for attachments whose underlying "
+                        "file is missing on the Redmine server's disk. If "
+                        "get_redmine_issue(include_attachments=True) lists "
+                        "this attachment, it exists but is either "
+                        "permission-restricted or orphaned on disk -- "
+                        "contact the Redmine administrator."
+                    ),
+                    "attachment_id": attachment_id,
+                }
 
-        # Mode detection:
-        # - Explicit PUBLIC_HOST always selects HTTP mode (respect user
-        #   intent, e.g. Docker port-forward where localhost is reachable
-        #   on the host).
-        # - Otherwise, SERVER_HOST promotes to HTTP mode only when it
-        #   names a non-loopback host (SERVER_HOST is the bind address
-        #   and is commonly "0.0.0.0", which is not reachable as a URL).
-        # - Otherwise, fall back to stdio/file mode.
-        public_host_env = os.environ.get("PUBLIC_HOST")
-        server_host_env = os.environ.get("SERVER_HOST")
-        if public_host_env is not None:
-            public_host = public_host_env
-            use_file_mode = False
-        elif server_host_env and server_host_env not in _LOOPBACK_HOSTS:
-            public_host = server_host_env
-            use_file_mode = False
-        else:
-            public_host = "localhost"
-            use_file_mode = True
+            # Sanitize filename: basename only (path traversal protection)
+            raw_filename = getattr(attachment, "filename", "") or ""
+            original_filename = os.path.basename(raw_filename)
+            if not original_filename:
+                original_filename = f"attachment_{attachment_id}"
 
-        public_port = os.getenv("PUBLIC_PORT", os.getenv("SERVER_PORT", "8000"))
+            content_type = getattr(
+                attachment, "content_type", "application/octet-stream"
+            )
+            content_url = getattr(attachment, "content_url", "")
 
-        expires_str = expires_at.isoformat()
-        # filename is structured metadata (used for paths, URLs,
-        # identifiers); not wrapped per #109. Path-traversal sanitization
-        # already ran above via os.path.basename().
-        safe_filename = original_filename
+            # Prepare UUID-based storage directory
+            attachments_dir = Path(os.getenv("ATTACHMENTS_DIR", "./attachments"))
+            attachments_dir.mkdir(parents=True, exist_ok=True)
+            file_id = str(uuid.uuid4())
+            uuid_dir = attachments_dir / file_id
+            uuid_dir.mkdir(exist_ok=True)
 
-        if use_file_mode:
-            return {
+            temp_path = uuid_dir / f"{original_filename}.tmp"
+            final_path = uuid_dir / original_filename
+
+            # Stream download with byte-cap abort
+            max_bytes = _get_int_env(
+                "ATTACHMENT_MAX_DOWNLOAD_BYTES",
+                _ATTACHMENT_MAX_DOWNLOAD_BYTES_DEFAULT,
+            )
+            response = client.download(content_url, savepath=None)
+
+            try:
+                byte_count = 0
+                with open(temp_path, "wb") as fh:
+                    for chunk in response.iter_content(65536):
+                        byte_count += len(chunk)
+                        if byte_count > max_bytes:
+                            fh.close()
+                            _cleanup_uuid_dir(uuid_dir, temp_path)
+                            return {
+                                "error": (
+                                    f"Attachment {attachment_id} exceeds the "
+                                    f"{max_bytes}-byte download limit."
+                                )
+                            }
+                        fh.write(chunk)
+            except Exception:
+                _cleanup_uuid_dir(uuid_dir, temp_path)
+                raise
+
+            # Atomic rename: temp -> final
+            os.rename(str(temp_path), str(final_path))
+
+            # Write metadata for the cleanup manager
+            expires_minutes = float(os.getenv("ATTACHMENT_EXPIRES_MINUTES", "60"))
+            expires_at = datetime.now(timezone.utc) + timedelta(minutes=expires_minutes)
+            file_size = final_path.stat().st_size
+            absolute_path = str(final_path.resolve())
+
+            metadata = {
+                "file_id": file_id,
+                "attachment_id": attachment_id,
+                "original_filename": original_filename,
                 "file_path": absolute_path,
-                "uri_type": "file",
+                "content_type": content_type,
+                "size": file_size,
+                "created_at": datetime.now(timezone.utc).isoformat(),
+                "expires_at": expires_at.isoformat(),
+            }
+            metadata_file = uuid_dir / "metadata.json"
+            temp_metadata = uuid_dir / "metadata.json.tmp"
+            try:
+                with open(temp_metadata, "w") as fh:
+                    json.dump(metadata, fh, indent=2)
+                os.rename(str(temp_metadata), str(metadata_file))
+            except (OSError, IOError, ValueError) as exc:
+                try:
+                    if temp_metadata.exists():
+                        temp_metadata.unlink()
+                    if final_path.exists():
+                        final_path.unlink()
+                except OSError:
+                    pass
+                return {"error": f"Failed to save metadata: {exc}"}
+
+            # Mode detection:
+            # - Explicit PUBLIC_HOST always selects HTTP mode (respect user
+            #   intent, e.g. Docker port-forward where localhost is reachable
+            #   on the host).
+            # - Otherwise, SERVER_HOST promotes to HTTP mode only when it
+            #   names a non-loopback host (SERVER_HOST is the bind address
+            #   and is commonly "0.0.0.0", which is not reachable as a URL).
+            # - Otherwise, fall back to stdio/file mode.
+            public_host_env = os.environ.get("PUBLIC_HOST")
+            server_host_env = os.environ.get("SERVER_HOST")
+            if public_host_env is not None:
+                public_host = public_host_env
+                use_file_mode = False
+            elif server_host_env and server_host_env not in _LOOPBACK_HOSTS:
+                public_host = server_host_env
+                use_file_mode = False
+            else:
+                public_host = "localhost"
+                use_file_mode = True
+
+            public_port = os.getenv("PUBLIC_PORT", os.getenv("SERVER_PORT", "8000"))
+
+            expires_str = expires_at.isoformat()
+            # filename is structured metadata (used for paths, URLs,
+            # identifiers); not wrapped per #109. Path-traversal sanitization
+            # already ran above via os.path.basename().
+            safe_filename = original_filename
+
+            if use_file_mode:
+                return {
+                    "file_path": absolute_path,
+                    "uri_type": "file",
+                    "filename": safe_filename,
+                    "content_type": content_type,
+                    "size": file_size,
+                    "expires_at": expires_str,
+                    "attachment_id": attachment_id,
+                }
+
+            return {
+                "uri": f"http://{public_host}:{public_port}/files/{file_id}",
+                "uri_type": "http",
                 "filename": safe_filename,
                 "content_type": content_type,
                 "size": file_size,
@@ -457,22 +478,14 @@ async def get_redmine_attachment(
                 "attachment_id": attachment_id,
             }
 
-        return {
-            "uri": f"http://{public_host}:{public_port}/files/{file_id}",
-            "uri_type": "http",
-            "filename": safe_filename,
-            "content_type": content_type,
-            "size": file_size,
-            "expires_at": expires_str,
-            "attachment_id": attachment_id,
-        }
+        except Exception as exc:
+            return _handle_redmine_error(
+                exc,
+                f"downloading attachment {attachment_id}",
+                {"resource_type": "attachment", "resource_id": attachment_id},
+            )
 
-    except Exception as exc:
-        return _handle_redmine_error(
-            exc,
-            f"downloading attachment {attachment_id}",
-            {"resource_type": "attachment", "resource_id": attachment_id},
-        )
+    return await in_thread(_run)
 
 
 def _cleanup_uuid_dir(uuid_dir: Path, *extra_paths: Path) -> None:
@@ -491,7 +504,8 @@ def _cleanup_uuid_dir(uuid_dir: Path, *extra_paths: Path) -> None:
 
 
 @mcp.tool()
-async def list_files(
+@offloaded
+def list_files(
     project_id: Union[str, int],
 ) -> Union[List[Dict[str, Any]], Dict[str, Any]]:
     """List all files uploaded to a Redmine project.
@@ -624,55 +638,59 @@ async def upload_file(
     if resolve_error is not None:
         return resolve_error
 
-    client = _get_redmine_client()
-    try:
-        # Step 1: upload raw bytes to /uploads.json, get token
-        token = client.upload(io.BytesIO(content_bytes), filename=filename)["token"]
+    def _run():
+        client = _get_redmine_client()
+        try:
+            # Step 1: upload raw bytes to /uploads.json, get token
+            token = client.upload(io.BytesIO(content_bytes), filename=filename)["token"]
 
-        # Step 2: create the File resource using the token
-        create_params: Dict[str, Any] = {
-            "project_id": project_id,
-            "token": token,
-            "filename": filename,
-        }
-        if description is not None:
-            create_params["description"] = description
-        if version_id is not None:
-            create_params["version_id"] = version_id
+            # Step 2: create the File resource using the token
+            create_params: Dict[str, Any] = {
+                "project_id": project_id,
+                "token": token,
+                "filename": filename,
+            }
+            if description is not None:
+                create_params["description"] = description
+            if version_id is not None:
+                create_params["version_id"] = version_id
 
-        uploaded = client.file.create(**create_params)
+            uploaded = client.file.create(**create_params)
 
-        # Redmine returns HTTP 204 (empty body) on successful file creation,
-        # so python-redmine's FileManager synthesizes a minimal response that
-        # only contains the ID. Re-fetch the full attachment metadata so the
-        # caller gets filename, size, content type, author, etc.
-        uploaded_id = getattr(uploaded, "id", None)
-        if uploaded_id is not None:
-            try:
-                full = client.attachment.get(uploaded_id)
-                return _file_to_dict(full)
-            except Exception:
-                # If re-fetch fails for any reason, fall back to the minimal
-                # response + the known fields we already have.
-                pass
-        result = _file_to_dict(uploaded)
-        # Fallback enrichment when the re-fetch failed: ensure the caller at
-        # least sees the filename and description they just uploaded.
-        if not result.get("filename"):
-            result["filename"] = filename
-        if description is not None and not result.get("description"):
-            result["description"] = description
-        return result
-    except Exception as e:
-        return _handle_redmine_error(
-            e,
-            f"uploading file '{filename}' to project {project_id}",
-            {"resource_type": "project", "resource_id": project_id},
-        )
+            # Redmine returns HTTP 204 (empty body) on successful file creation,
+            # so python-redmine's FileManager synthesizes a minimal response that
+            # only contains the ID. Re-fetch the full attachment metadata so the
+            # caller gets filename, size, content type, author, etc.
+            uploaded_id = getattr(uploaded, "id", None)
+            if uploaded_id is not None:
+                try:
+                    full = client.attachment.get(uploaded_id)
+                    return _file_to_dict(full)
+                except Exception:
+                    # If re-fetch fails for any reason, fall back to the minimal
+                    # response + the known fields we already have.
+                    pass
+            result = _file_to_dict(uploaded)
+            # Fallback enrichment when the re-fetch failed: ensure the caller at
+            # least sees the filename and description they just uploaded.
+            if not result.get("filename"):
+                result["filename"] = filename
+            if description is not None and not result.get("description"):
+                result["description"] = description
+            return result
+        except Exception as e:
+            return _handle_redmine_error(
+                e,
+                f"uploading file '{filename}' to project {project_id}",
+                {"resource_type": "project", "resource_id": project_id},
+            )
+
+    return await in_thread(_run)
 
 
 @mcp.tool()
-async def delete_file(
+@offloaded
+def delete_file(
     file_id: int,
     confirm_delete_any_attachment: bool = False,
 ) -> Dict[str, Any]:

--- a/src/redmine_mcp_server/tools/gantt.py
+++ b/src/redmine_mcp_server/tools/gantt.py
@@ -6,6 +6,7 @@ from pydantic import Field
 
 from .._client import _get_redmine_client
 from .._errors import _handle_redmine_error
+from .._offload import offloaded
 from .._serialization import (
     _DEFAULT_LIST_RESULT_CAP,
     _iter_capped,
@@ -71,7 +72,8 @@ def _gantt_version_to_dict(version: Any) -> Dict[str, Any]:
 
 
 @mcp.tool()
-async def get_gantt_chart(
+@offloaded
+def get_gantt_chart(
     project_id: Union[str, int],
     start_date_after: Optional[str] = None,
     due_date_before: Optional[str] = None,

--- a/src/redmine_mcp_server/tools/issues.py
+++ b/src/redmine_mcp_server/tools/issues.py
@@ -24,6 +24,7 @@ from .._custom_fields import (
 from .._decorators import ActionMode, action_dispatch
 from .._env import _is_agile_enabled, _is_read_only_mode, _is_tags_enabled
 from .._errors import _READ_ONLY_ERROR, _handle_redmine_error
+from .._offload import in_thread, offloaded
 from .._serialization import (
     _attachment_to_dict,
     _coerce_json_safe,
@@ -750,88 +751,93 @@ async def get_redmine_issue(
 
     # Ensure cleanup task is started (lazy initialization)
     await _ensure_cleanup_started()
-    try:
-        # python-redmine is synchronous, so we don't use await here for the library call
-        includes = []
-        if include_journals:
-            includes.append("journals")
-        if include_attachments:
-            includes.append("attachments")
-        if include_watchers:
-            includes.append("watchers")
-        if include_relations:
-            includes.append("relations")
-        if include_children:
-            includes.append("children")
 
-        if includes:
-            issue = _get_redmine_client().issue.get(
-                issue_id, include=",".join(includes)
-            )
-        else:
-            issue = _get_redmine_client().issue.get(issue_id)
+    def _run():
+        try:
+            # python-redmine is synchronous, so this whole block runs in a
+            # worker thread via in_thread() rather than on the event loop.
+            includes = []
+            if include_journals:
+                includes.append("journals")
+            if include_attachments:
+                includes.append("attachments")
+            if include_watchers:
+                includes.append("watchers")
+            if include_relations:
+                includes.append("relations")
+            if include_children:
+                includes.append("children")
 
-        result = _issue_to_dict(issue, include_custom_fields=include_custom_fields)
-        if include_journals:
-            all_journals = _journals_to_list(issue)
-            if journal_limit is not None:
-                total = len(all_journals)
-                offset = journal_offset
-                paginated = all_journals[offset : offset + journal_limit]
-                result["journals"] = paginated
-                result["journal_pagination"] = {
-                    "total": total,
-                    "offset": offset,
-                    "limit": journal_limit,
-                    "count": len(paginated),
-                    "has_more": (offset + journal_limit) < total,
-                }
+            if includes:
+                issue = _get_redmine_client().issue.get(
+                    issue_id, include=",".join(includes)
+                )
             else:
-                result["journals"] = all_journals
-        if include_attachments:
-            result["attachments"] = _attachments_to_list(issue)
+                issue = _get_redmine_client().issue.get(issue_id)
 
-        if include_watchers:
-            raw = getattr(issue, "watchers", None) or []
-            result["watchers"] = [{"id": w.id, "name": w.name} for w in raw]
-        if include_relations:
-            raw = getattr(issue, "relations", None) or []
-            result["relations"] = [
-                {
-                    "id": r.id,
-                    "issue_id": r.issue_id,
-                    "issue_to_id": r.issue_to_id,
-                    "relation_type": r.relation_type,
-                }
-                for r in raw
-            ]
-        if include_children:
-            raw = getattr(issue, "children", None) or []
-            result["children"] = [
-                {
-                    "id": c.id,
-                    "subject": getattr(c, "subject", ""),
-                    "tracker": (
-                        {"id": c.tracker.id, "name": c.tracker.name}
-                        if getattr(c, "tracker", None)
-                        else None
-                    ),
-                }
-                for c in raw
-            ]
+            result = _issue_to_dict(issue, include_custom_fields=include_custom_fields)
+            if include_journals:
+                all_journals = _journals_to_list(issue)
+                if journal_limit is not None:
+                    total = len(all_journals)
+                    offset = journal_offset
+                    paginated = all_journals[offset : offset + journal_limit]
+                    result["journals"] = paginated
+                    result["journal_pagination"] = {
+                        "total": total,
+                        "offset": offset,
+                        "limit": journal_limit,
+                        "count": len(paginated),
+                        "has_more": (offset + journal_limit) < total,
+                    }
+                else:
+                    result["journals"] = all_journals
+            if include_attachments:
+                result["attachments"] = _attachments_to_list(issue)
 
-        if _is_tags_enabled():
-            result["tags"] = _issue_tags_to_list(issue)
+            if include_watchers:
+                raw = getattr(issue, "watchers", None) or []
+                result["watchers"] = [{"id": w.id, "name": w.name} for w in raw]
+            if include_relations:
+                raw = getattr(issue, "relations", None) or []
+                result["relations"] = [
+                    {
+                        "id": r.id,
+                        "issue_id": r.issue_id,
+                        "issue_to_id": r.issue_to_id,
+                        "relation_type": r.relation_type,
+                    }
+                    for r in raw
+                ]
+            if include_children:
+                raw = getattr(issue, "children", None) or []
+                result["children"] = [
+                    {
+                        "id": c.id,
+                        "subject": getattr(c, "subject", ""),
+                        "tracker": (
+                            {"id": c.tracker.id, "name": c.tracker.name}
+                            if getattr(c, "tracker", None)
+                            else None
+                        ),
+                    }
+                    for c in raw
+                ]
 
-        result = _augment_with_agile_data(issue_id, result)
+            if _is_tags_enabled():
+                result["tags"] = _issue_tags_to_list(issue)
 
-        return result
-    except Exception as e:
-        return _handle_redmine_error(
-            e,
-            f"fetching issue {issue_id}",
-            {"resource_type": "issue", "resource_id": issue_id},
-        )
+            result = _augment_with_agile_data(issue_id, result)
+
+            return result
+        except Exception as e:
+            return _handle_redmine_error(
+                e,
+                f"fetching issue {issue_id}",
+                {"resource_type": "issue", "resource_id": issue_id},
+            )
+
+    return await in_thread(_run)
 
 
 @mcp.tool()
@@ -920,160 +926,175 @@ async def list_redmine_issues(
     # Ensure cleanup task is started (lazy initialization)
     await _ensure_cleanup_started()
 
-    try:
-        # Build Redmine API filter dict from explicit parameters
-        redmine_api_filters: Dict[str, Any] = {}
-        if project_id is not None:
-            redmine_api_filters["project_id"] = project_id
-        if status_id is not None:
-            redmine_api_filters["status_id"] = status_id
-        if tracker_id is not None:
-            redmine_api_filters["tracker_id"] = tracker_id
-        if assigned_to_id is not None:
-            redmine_api_filters["assigned_to_id"] = assigned_to_id
-        if priority_id is not None:
-            redmine_api_filters["priority_id"] = priority_id
-        if fixed_version_id is not None:
-            redmine_api_filters["fixed_version_id"] = fixed_version_id
-        if sort is not None:
-            redmine_api_filters["sort"] = sort
-        # Merge additional arbitrary Redmine filters if provided
-        if filters:
-            redmine_api_filters.update(filters)
-        filters = redmine_api_filters
+    def _run():
+        nonlocal filters, limit, offset
+        try:
+            # Build Redmine API filter dict from explicit parameters
+            redmine_api_filters: Dict[str, Any] = {}
+            if project_id is not None:
+                redmine_api_filters["project_id"] = project_id
+            if status_id is not None:
+                redmine_api_filters["status_id"] = status_id
+            if tracker_id is not None:
+                redmine_api_filters["tracker_id"] = tracker_id
+            if assigned_to_id is not None:
+                redmine_api_filters["assigned_to_id"] = assigned_to_id
+            if priority_id is not None:
+                redmine_api_filters["priority_id"] = priority_id
+            if fixed_version_id is not None:
+                redmine_api_filters["fixed_version_id"] = fixed_version_id
+            if sort is not None:
+                redmine_api_filters["sort"] = sort
+            # Merge additional arbitrary Redmine filters if provided
+            if filters:
+                redmine_api_filters.update(filters)
+            filters = redmine_api_filters
 
-        # Log request for monitoring
-        filter_keys = list(filters.keys()) if filters else []
-        logging.info(
-            f"Pagination request: limit={limit}, offset={offset}, filters={filter_keys}"
-        )
+            # Log request for monitoring
+            filter_keys = list(filters.keys()) if filters else []
+            logging.info(
+                "Pagination request: limit=%s, offset=%s, filters=%s",
+                limit,
+                offset,
+                filter_keys,
+            )
 
-        # Validate and sanitize parameters
-        if limit is not None:
-            if not isinstance(limit, int):
-                try:
-                    limit = int(limit)
-                except (ValueError, TypeError):
+            # Validate and sanitize parameters
+            if limit is not None:
+                if not isinstance(limit, int):
+                    try:
+                        limit = int(limit)
+                    except (ValueError, TypeError):
+                        logging.warning(
+                            f"Invalid limit type {type(limit)}, using default 25"
+                        )
+                        limit = 25
+
+                if limit <= 0:
+                    logging.debug(f"Limit {limit} <= 0, returning empty result")
+                    empty_result = []
+                    if include_pagination_info:
+                        empty_result = {
+                            "issues": [],
+                            "pagination": {
+                                "total": 0,
+                                "limit": limit,
+                                "offset": offset,
+                                "count": 0,
+                                "has_next": False,
+                                "has_previous": False,
+                                "next_offset": None,
+                                "previous_offset": None,
+                            },
+                        }
+                    return empty_result
+
+                # Cap at reasonable maximum
+                original_limit = limit
+                limit = min(limit, 1000)
+                if original_limit > limit:
                     logging.warning(
-                        f"Invalid limit type {type(limit)}, using default 25"
+                        "Limit %s exceeds maximum 1000, capped to %s",
+                        original_limit,
+                        limit,
                     )
-                    limit = 25
 
-            if limit <= 0:
-                logging.debug(f"Limit {limit} <= 0, returning empty result")
-                empty_result = []
-                if include_pagination_info:
-                    empty_result = {
-                        "issues": [],
-                        "pagination": {
-                            "total": 0,
-                            "limit": limit,
-                            "offset": offset,
-                            "count": 0,
-                            "has_next": False,
-                            "has_previous": False,
-                            "next_offset": None,
-                            "previous_offset": None,
-                        },
-                    }
-                return empty_result
+            # Validate offset
+            if not isinstance(offset, int) or offset < 0:
+                logging.warning(f"Invalid offset {offset}, reset to 0")
+                offset = 0
 
-            # Cap at reasonable maximum
-            original_limit = limit
-            limit = min(limit, 1000)
-            if original_limit > limit:
-                logging.warning(
-                    f"Limit {original_limit} exceeds maximum 1000, capped to {limit}"
-                )
-
-        # Validate offset
-        if not isinstance(offset, int) or offset < 0:
-            logging.warning(f"Invalid offset {offset}, reset to 0")
-            offset = 0
-
-        # Use python-redmine ResourceSet native pagination
-        # Server-side filtering more efficient than client-side
-        redmine_filters = {
-            "offset": offset,
-            "limit": min(limit or 25, 100),  # Redmine API max per request
-            **filters,
-        }
-
-        # Get paginated issues from Redmine
-        logging.debug(
-            f"Calling _get_redmine_client().issue.filter with: {redmine_filters}"
-        )
-        issues = _get_redmine_client().issue.filter(**redmine_filters)
-
-        # Convert ResourceSet to list (triggers server-side pagination)
-        issues_list = list(issues)
-        logging.debug(
-            f"Retrieved {len(issues_list)} issues with offset={offset}, limit={limit}"
-        )
-
-        # Convert to dictionaries with optional field selection
-        result_issues = [
-            _issue_to_dict_selective(issue, fields) for issue in issues_list
-        ]
-
-        # Handle metadata response format
-        if include_pagination_info:
-            # Get total count from a separate query.
-            try:
-                # Redmine returns the full ``total_count`` in the first page of
-                # any filtered response, so we only need to fetch a single
-                # issue to read it. Omitting the limit here would make
-                # python-redmine's ResourceSet materialize *every* matching
-                # issue (chunk-by-chunk, dozens of sequential requests for a
-                # large project) just to compute the count, which can exceed
-                # the MCP ``tools/call`` timeout.
-                count_filters = {**filters, "limit": 1, "offset": 0}
-                count_query = _get_redmine_client().issue.filter(**count_filters)
-                # Trigger a single request so total_count is populated.
-                list(count_query)
-                total_count = count_query.total_count
-                logging.debug(f"Got total count from separate query: {total_count}")
-            except Exception as e:
-                logging.warning(
-                    f"Could not get total count: {e}, using estimated value"
-                )
-                # For unknown total, use a conservative estimate
-                if len(result_issues) == limit:
-                    # If we got a full page, there might be more
-                    total_count = offset + len(result_issues) + 1
-                else:
-                    # If we got less than requested, this is likely the end
-                    total_count = offset + len(result_issues)
-
-            pagination_info = {
-                "total": total_count,
-                "limit": limit,
+            # Use python-redmine ResourceSet native pagination
+            # Server-side filtering more efficient than client-side
+            redmine_filters = {
                 "offset": offset,
-                "count": len(result_issues),
-                "has_next": len(result_issues) == limit,
-                "has_previous": offset > 0,
-                "next_offset": offset + limit if len(result_issues) == limit else None,
-                "previous_offset": max(0, offset - limit) if offset > 0 else None,
+                "limit": min(limit or 25, 100),  # Redmine API max per request
+                **filters,
             }
 
-            result = {"issues": result_issues, "pagination": pagination_info}
-
-            logging.info(
-                f"Returning paginated response: {len(result_issues)} issues, "
-                f"total={total_count}"
+            # Get paginated issues from Redmine
+            logging.debug(
+                f"Calling _get_redmine_client().issue.filter with: {redmine_filters}"
             )
-            return result
+            issues = _get_redmine_client().issue.filter(**redmine_filters)
 
-        # Log success and return simple list
-        logging.info(f"Successfully retrieved {len(result_issues)} issues")
-        return result_issues
+            # Convert ResourceSet to list (triggers server-side pagination)
+            issues_list = list(issues)
+            logging.debug(
+                "Retrieved %s issues with offset=%s, limit=%s",
+                len(issues_list),
+                offset,
+                limit,
+            )
 
-    except Exception as e:
-        return _handle_redmine_error(e, "listing issues")
+            # Convert to dictionaries with optional field selection
+            result_issues = [
+                _issue_to_dict_selective(issue, fields) for issue in issues_list
+            ]
+
+            # Handle metadata response format
+            if include_pagination_info:
+                # Get total count from a separate query.
+                try:
+                    # Redmine returns the full ``total_count`` in the first page of
+                    # any filtered response, so we only need to fetch a single
+                    # issue to read it. Omitting the limit here would make
+                    # python-redmine's ResourceSet materialize *every* matching
+                    # issue (chunk-by-chunk, dozens of sequential requests for a
+                    # large project) just to compute the count, which can exceed
+                    # the MCP ``tools/call`` timeout.
+                    count_filters = {**filters, "limit": 1, "offset": 0}
+                    count_query = _get_redmine_client().issue.filter(**count_filters)
+                    # Trigger a single request so total_count is populated.
+                    list(count_query)
+                    total_count = count_query.total_count
+                    logging.debug(f"Got total count from separate query: {total_count}")
+                except Exception as e:
+                    logging.warning(
+                        f"Could not get total count: {e}, using estimated value"
+                    )
+                    # For unknown total, use a conservative estimate
+                    if len(result_issues) == limit:
+                        # If we got a full page, there might be more
+                        total_count = offset + len(result_issues) + 1
+                    else:
+                        # If we got less than requested, this is likely the end
+                        total_count = offset + len(result_issues)
+
+                pagination_info = {
+                    "total": total_count,
+                    "limit": limit,
+                    "offset": offset,
+                    "count": len(result_issues),
+                    "has_next": len(result_issues) == limit,
+                    "has_previous": offset > 0,
+                    "next_offset": (
+                        offset + limit if len(result_issues) == limit else None
+                    ),
+                    "previous_offset": max(0, offset - limit) if offset > 0 else None,
+                }
+
+                result = {"issues": result_issues, "pagination": pagination_info}
+
+                logging.info(
+                    f"Returning paginated response: {len(result_issues)} issues, "
+                    f"total={total_count}"
+                )
+                return result
+
+            # Log success and return simple list
+            logging.info(f"Successfully retrieved {len(result_issues)} issues")
+            return result_issues
+
+        except Exception as e:
+            return _handle_redmine_error(e, "listing issues")
+
+    return await in_thread(_run)
 
 
 @mcp.tool()
-async def search_redmine_issues(
+@offloaded
+def search_redmine_issues(
     query: str,
     limit: Annotated[int, Field(ge=1, le=1000)] = 25,
     offset: Annotated[int, Field(ge=0)] = 0,
@@ -1355,74 +1376,27 @@ async def create_redmine_issue(
     else:
         issue_fields.pop("tag_list", None)
 
-    # Resolve name-keyed custom fields (e.g. fields={"Department": "..."})
-    # to id-keyed custom_fields entries Redmine expects. See #123 for
-    # the cross-tool parity rationale.
-    try:
-        issue_fields = _map_named_custom_fields_for_create(project_id, issue_fields)
-    except ValueError as e:
-        return {"error": str(e)}
-
-    try:
-        create_kwargs = dict(issue_fields)
-        if tags_create_needed:
-            create_kwargs["tag_list"] = tag_list
-        if upload_descriptors:
-            create_kwargs["uploads"] = upload_descriptors
-        issue = _get_redmine_client().issue.create(
-            project_id=project_id,
-            subject=subject,
-            description=description,
-            **create_kwargs,
-        )
-        if upload_descriptors:
-            fetched = _get_redmine_client().issue.get(
-                issue.id, include="attachments,journals"
-            )
-            return _augment_with_upload_result(_issue_to_dict(fetched), fetched)
-        return _issue_to_dict(issue)
-    except ValidationError as e:
-        if not _is_required_custom_field_autofill_enabled():
-            return _augment_validation_error_with_field_hint(
-                _handle_redmine_error(e, f"creating issue in project {project_id}"),
-                str(e),
-            )
-
-        missing_names = _extract_missing_required_field_names(str(e))
-        if not missing_names:
-            return _augment_validation_error_with_field_hint(
-                _handle_redmine_error(e, f"creating issue in project {project_id}"),
-                str(e),
-            )
+    def _run():
+        nonlocal issue_fields
+        # Resolve name-keyed custom fields (e.g. fields={"Department": "..."})
+        # to id-keyed custom_fields entries Redmine expects. See #123 for
+        # the cross-tool parity rationale.
+        try:
+            issue_fields = _map_named_custom_fields_for_create(project_id, issue_fields)
+        except ValueError as e:
+            return {"error": str(e)}
 
         try:
-            retry_fields = _augment_fields_with_required_custom_fields(
-                project_id=project_id,
-                issue_fields=issue_fields,
-                missing_field_names=missing_names,
-            )
-
-            # Retry only when we have actually augmented payload.
-            if retry_fields == issue_fields:
-                return _augment_validation_error_with_field_hint(
-                    _handle_redmine_error(e, f"creating issue in project {project_id}"),
-                    str(e),
-                )
-
-            logger.info(
-                "Retrying issue creation with auto-filled custom fields: %s",
-                missing_names,
-            )
-            retry_create_kwargs = dict(retry_fields)
+            create_kwargs = dict(issue_fields)
             if tags_create_needed:
-                retry_create_kwargs["tag_list"] = tag_list
+                create_kwargs["tag_list"] = tag_list
             if upload_descriptors:
-                retry_create_kwargs["uploads"] = upload_descriptors
+                create_kwargs["uploads"] = upload_descriptors
             issue = _get_redmine_client().issue.create(
                 project_id=project_id,
                 subject=subject,
                 description=description,
-                **retry_create_kwargs,
+                **create_kwargs,
             )
             if upload_descriptors:
                 fetched = _get_redmine_client().issue.get(
@@ -1430,46 +1404,99 @@ async def create_redmine_issue(
                 )
                 return _augment_with_upload_result(_issue_to_dict(fetched), fetched)
             return _issue_to_dict(issue)
-        except Exception as retry_error:
-            # The retry failure may also be a ValidationError; surface the
-            # field hint when applicable so the caller still gets recovery
-            # context even when autofill couldn't satisfy all required fields.
-            return _augment_validation_error_with_field_hint(
-                _handle_redmine_error(
-                    retry_error, f"creating issue in project {project_id}"
-                ),
-                str(retry_error),
+        except ValidationError as e:
+            if not _is_required_custom_field_autofill_enabled():
+                return _augment_validation_error_with_field_hint(
+                    _handle_redmine_error(e, f"creating issue in project {project_id}"),
+                    str(e),
+                )
+
+            missing_names = _extract_missing_required_field_names(str(e))
+            if not missing_names:
+                return _augment_validation_error_with_field_hint(
+                    _handle_redmine_error(e, f"creating issue in project {project_id}"),
+                    str(e),
+                )
+
+            try:
+                retry_fields = _augment_fields_with_required_custom_fields(
+                    project_id=project_id,
+                    issue_fields=issue_fields,
+                    missing_field_names=missing_names,
+                )
+
+                # Retry only when we have actually augmented payload.
+                if retry_fields == issue_fields:
+                    return _augment_validation_error_with_field_hint(
+                        _handle_redmine_error(
+                            e, f"creating issue in project {project_id}"
+                        ),
+                        str(e),
+                    )
+
+                logger.info(
+                    "Retrying issue creation with auto-filled custom fields: %s",
+                    missing_names,
+                )
+                retry_create_kwargs = dict(retry_fields)
+                if tags_create_needed:
+                    retry_create_kwargs["tag_list"] = tag_list
+                if upload_descriptors:
+                    retry_create_kwargs["uploads"] = upload_descriptors
+                issue = _get_redmine_client().issue.create(
+                    project_id=project_id,
+                    subject=subject,
+                    description=description,
+                    **retry_create_kwargs,
+                )
+                if upload_descriptors:
+                    fetched = _get_redmine_client().issue.get(
+                        issue.id, include="attachments,journals"
+                    )
+                    return _augment_with_upload_result(_issue_to_dict(fetched), fetched)
+                return _issue_to_dict(issue)
+            except Exception as retry_error:
+                # The retry failure may also be a ValidationError; surface the
+                # field hint when applicable so the caller still gets recovery
+                # context even when autofill couldn't satisfy all required fields.
+                return _augment_validation_error_with_field_hint(
+                    _handle_redmine_error(
+                        retry_error, f"creating issue in project {project_id}"
+                    ),
+                    str(retry_error),
+                )
+        except ResourceNotFoundError:
+            # A 404 on a create POST is anomalous: the issue may have been created
+            # anyway. The 404 generally comes from the deployment or from Redmine
+            # itself rather than a genuinely missing resource (e.g. a sub-URI or
+            # Passenger deployment, a reverse proxy, or a plugin or controller
+            # filter on the create path), so Redmine can process the POST while the
+            # client ultimately sees a 404. Returning the bare "not found" message
+            # invites blind retries and risks silent duplicate issues (see #146), so
+            # warn the caller to verify first.
+            logger.warning(
+                "create issue returned HTTP 404 for project %s; the issue may have "
+                "been created. The 404 likely originates from the deployment or "
+                "Redmine itself (a sub-URI/Passenger setup, a reverse proxy, or a "
+                "plugin or controller filter on the create path) rather than a "
+                "missing resource.",
+                project_id,
             )
-    except ResourceNotFoundError:
-        # A 404 on a create POST is anomalous: the issue may have been created
-        # anyway. The 404 generally comes from the deployment or from Redmine
-        # itself rather than a genuinely missing resource (e.g. a sub-URI or
-        # Passenger deployment, a reverse proxy, or a plugin or controller
-        # filter on the create path), so Redmine can process the POST while the
-        # client ultimately sees a 404. Returning the bare "not found" message
-        # invites blind retries and risks silent duplicate issues (see #146), so
-        # warn the caller to verify first.
-        logger.warning(
-            "create issue returned HTTP 404 for project %s; the issue may have "
-            "been created. The 404 likely originates from the deployment or "
-            "Redmine itself (a sub-URI/Passenger setup, a reverse proxy, or a "
-            "plugin or controller filter on the create path) rather than a "
-            "missing resource.",
-            project_id,
-        )
-        return {
-            "error": (
-                "Redmine returned HTTP 404 for the create request, but the issue "
-                "may have been created anyway. This usually originates from the "
-                "deployment or from Redmine itself rather than a missing "
-                "resource (for example a sub-URI/Passenger deployment, a reverse "
-                "proxy, or a plugin or controller filter on the create path). "
-                "Before retrying, check Redmine for a newly created issue to "
-                "avoid creating a duplicate."
-            )
-        }
-    except Exception as e:
-        return _handle_redmine_error(e, f"creating issue in project {project_id}")
+            return {
+                "error": (
+                    "Redmine returned HTTP 404 for the create request, but the issue "
+                    "may have been created anyway. This usually originates from the "
+                    "deployment or from Redmine itself rather than a missing "
+                    "resource (for example a sub-URI/Passenger deployment, a reverse "
+                    "proxy, or a plugin or controller filter on the create path). "
+                    "Before retrying, check Redmine for a newly created issue to "
+                    "avoid creating a duplicate."
+                )
+            }
+        except Exception as e:
+            return _handle_redmine_error(e, f"creating issue in project {project_id}")
+
+    return await in_thread(_run)
 
 
 @mcp.tool()
@@ -1590,115 +1617,31 @@ async def update_redmine_issue(
     else:
         update_fields.pop("tag_list", None)
 
-    # Convert status name to id if requested
-    if "status_name" in update_fields and "status_id" not in update_fields:
-        name = str(update_fields.pop("status_name")).lower()
-        try:
-            statuses = _get_redmine_client().issue_status.all()
-            for status in statuses:
-                if getattr(status, "name", "").lower() == name:
-                    update_fields["status_id"] = status.id
-                    break
-        except Exception as e:
-            logger.warning(f"Error resolving status name '{name}': {e}")
-
-    try:
-        if update_fields or upload_descriptors or tags_update_needed:
-            update_fields = _map_named_custom_fields_for_update(issue_id, update_fields)
-            update_kwargs = dict(update_fields)
-            if tags_update_needed:
-                update_kwargs["tag_list"] = tag_list
-            if upload_descriptors:
-                update_kwargs["uploads"] = upload_descriptors
-            _get_redmine_client().issue.update(issue_id, **update_kwargs)
-        if agile_update_needed:
+    def _run():
+        nonlocal update_fields
+        # Convert status name to id if requested
+        if "status_name" in update_fields and "status_id" not in update_fields:
+            name = str(update_fields.pop("status_name")).lower()
             try:
-                _apply_agile_data(issue_id, agile_attrs)
-            except Exception as agile_e:
-                return _handle_redmine_error(
-                    agile_e,
-                    f"updating agile fields for issue {issue_id}",
-                    {"resource_type": "issue", "resource_id": issue_id},
-                )
-        if upload_descriptors:
-            updated_issue = _get_redmine_client().issue.get(
-                issue_id, include="attachments,journals"
-            )
-            result = _augment_with_upload_result(
-                _issue_to_dict(updated_issue, include_custom_fields=True),
-                updated_issue,
-            )
-            if agile_update_needed:
-                result = _augment_with_agile_data(issue_id, result)
-            return result
-        updated_issue = _get_redmine_client().issue.get(issue_id)
-        result = _issue_to_dict(updated_issue, include_custom_fields=True)
-        if agile_update_needed:
-            result = _augment_with_agile_data(issue_id, result)
-        return result
-    except ValidationError as e:
-        if not _is_required_custom_field_autofill_enabled():
-            return _augment_validation_error_with_field_hint(
-                _handle_redmine_error(
-                    e,
-                    f"updating issue {issue_id}",
-                    {"resource_type": "issue", "resource_id": issue_id},
-                ),
-                str(e),
-            )
-
-        missing_names = _extract_missing_required_field_names(str(e))
-        if not missing_names:
-            return _augment_validation_error_with_field_hint(
-                _handle_redmine_error(
-                    e,
-                    f"updating issue {issue_id}",
-                    {"resource_type": "issue", "resource_id": issue_id},
-                ),
-                str(e),
-            )
+                statuses = _get_redmine_client().issue_status.all()
+                for status in statuses:
+                    if getattr(status, "name", "").lower() == name:
+                        update_fields["status_id"] = status.id
+                        break
+            except Exception as e:
+                logger.warning(f"Error resolving status name '{name}': {e}")
 
         try:
-            issue = _get_redmine_client().issue.get(issue_id)
-            project = getattr(issue, "project", None)
-            project_id = getattr(project, "id", None)
-            if project_id is None:
-                return _augment_validation_error_with_field_hint(
-                    _handle_redmine_error(
-                        e,
-                        f"updating issue {issue_id}",
-                        {"resource_type": "issue", "resource_id": issue_id},
-                    ),
-                    str(e),
+            if update_fields or upload_descriptors or tags_update_needed:
+                update_fields = _map_named_custom_fields_for_update(
+                    issue_id, update_fields
                 )
-
-            retry_fields = _augment_fields_with_required_custom_fields(
-                project_id=project_id,
-                issue_fields=update_fields,
-                missing_field_names=missing_names,
-            )
-
-            # Retry only when we have actually augmented payload.
-            if retry_fields == update_fields:
-                return _augment_validation_error_with_field_hint(
-                    _handle_redmine_error(
-                        e,
-                        f"updating issue {issue_id}",
-                        {"resource_type": "issue", "resource_id": issue_id},
-                    ),
-                    str(e),
-                )
-
-            logger.info(
-                "Retrying issue update with auto-filled custom fields: %s",
-                missing_names,
-            )
-            retry_kwargs = dict(retry_fields)
-            if tags_update_needed:
-                retry_kwargs["tag_list"] = tag_list
-            if upload_descriptors:
-                retry_kwargs["uploads"] = upload_descriptors
-            _get_redmine_client().issue.update(issue_id, **retry_kwargs)
+                update_kwargs = dict(update_fields)
+                if tags_update_needed:
+                    update_kwargs["tag_list"] = tag_list
+                if upload_descriptors:
+                    update_kwargs["uploads"] = upload_descriptors
+                _get_redmine_client().issue.update(issue_id, **update_kwargs)
             if agile_update_needed:
                 try:
                     _apply_agile_data(issue_id, agile_attrs)
@@ -1724,25 +1667,116 @@ async def update_redmine_issue(
             if agile_update_needed:
                 result = _augment_with_agile_data(issue_id, result)
             return result
-        except Exception as retry_error:
-            return _augment_validation_error_with_field_hint(
-                _handle_redmine_error(
-                    retry_error,
-                    f"updating issue {issue_id}",
-                    {"resource_type": "issue", "resource_id": issue_id},
-                ),
-                str(retry_error),
+        except ValidationError as e:
+            if not _is_required_custom_field_autofill_enabled():
+                return _augment_validation_error_with_field_hint(
+                    _handle_redmine_error(
+                        e,
+                        f"updating issue {issue_id}",
+                        {"resource_type": "issue", "resource_id": issue_id},
+                    ),
+                    str(e),
+                )
+
+            missing_names = _extract_missing_required_field_names(str(e))
+            if not missing_names:
+                return _augment_validation_error_with_field_hint(
+                    _handle_redmine_error(
+                        e,
+                        f"updating issue {issue_id}",
+                        {"resource_type": "issue", "resource_id": issue_id},
+                    ),
+                    str(e),
+                )
+
+            try:
+                issue = _get_redmine_client().issue.get(issue_id)
+                project = getattr(issue, "project", None)
+                project_id = getattr(project, "id", None)
+                if project_id is None:
+                    return _augment_validation_error_with_field_hint(
+                        _handle_redmine_error(
+                            e,
+                            f"updating issue {issue_id}",
+                            {"resource_type": "issue", "resource_id": issue_id},
+                        ),
+                        str(e),
+                    )
+
+                retry_fields = _augment_fields_with_required_custom_fields(
+                    project_id=project_id,
+                    issue_fields=update_fields,
+                    missing_field_names=missing_names,
+                )
+
+                # Retry only when we have actually augmented payload.
+                if retry_fields == update_fields:
+                    return _augment_validation_error_with_field_hint(
+                        _handle_redmine_error(
+                            e,
+                            f"updating issue {issue_id}",
+                            {"resource_type": "issue", "resource_id": issue_id},
+                        ),
+                        str(e),
+                    )
+
+                logger.info(
+                    "Retrying issue update with auto-filled custom fields: %s",
+                    missing_names,
+                )
+                retry_kwargs = dict(retry_fields)
+                if tags_update_needed:
+                    retry_kwargs["tag_list"] = tag_list
+                if upload_descriptors:
+                    retry_kwargs["uploads"] = upload_descriptors
+                _get_redmine_client().issue.update(issue_id, **retry_kwargs)
+                if agile_update_needed:
+                    try:
+                        _apply_agile_data(issue_id, agile_attrs)
+                    except Exception as agile_e:
+                        return _handle_redmine_error(
+                            agile_e,
+                            f"updating agile fields for issue {issue_id}",
+                            {"resource_type": "issue", "resource_id": issue_id},
+                        )
+                if upload_descriptors:
+                    updated_issue = _get_redmine_client().issue.get(
+                        issue_id, include="attachments,journals"
+                    )
+                    result = _augment_with_upload_result(
+                        _issue_to_dict(updated_issue, include_custom_fields=True),
+                        updated_issue,
+                    )
+                    if agile_update_needed:
+                        result = _augment_with_agile_data(issue_id, result)
+                    return result
+                updated_issue = _get_redmine_client().issue.get(issue_id)
+                result = _issue_to_dict(updated_issue, include_custom_fields=True)
+                if agile_update_needed:
+                    result = _augment_with_agile_data(issue_id, result)
+                return result
+            except Exception as retry_error:
+                return _augment_validation_error_with_field_hint(
+                    _handle_redmine_error(
+                        retry_error,
+                        f"updating issue {issue_id}",
+                        {"resource_type": "issue", "resource_id": issue_id},
+                    ),
+                    str(retry_error),
+                )
+        except Exception as e:
+            return _handle_redmine_error(
+                e,
+                f"updating issue {issue_id}",
+                {"resource_type": "issue", "resource_id": issue_id},
             )
-    except Exception as e:
-        return _handle_redmine_error(
-            e,
-            f"updating issue {issue_id}",
-            {"resource_type": "issue", "resource_id": issue_id},
-        )
+
+    return await in_thread(_run)
 
 
 @mcp.tool()
-async def copy_issue(
+@offloaded
+def copy_issue(
     issue_id: int,
     project_id: Optional[Union[str, int]] = None,
     subject: Optional[str] = None,
@@ -1828,7 +1862,8 @@ async def copy_issue(
         )
 
 
-async def _list_issue_relations_action(
+@offloaded
+def _list_issue_relations_action(
     issue_id: Optional[int] = None,
     **_: Any,
 ) -> Union[List[Dict[str, Any]], Dict[str, Any]]:
@@ -1845,7 +1880,8 @@ async def _list_issue_relations_action(
         )
 
 
-async def _create_issue_relation_action(
+@offloaded
+def _create_issue_relation_action(
     issue_id: Optional[int] = None,
     issue_to_id: Optional[int] = None,
     relation_type: Optional[str] = None,
@@ -1884,7 +1920,8 @@ async def _create_issue_relation_action(
         )
 
 
-async def _delete_issue_relation_action(
+@offloaded
+def _delete_issue_relation_action(
     relation_id: Optional[int] = None,
     **_: Any,
 ) -> Dict[str, Any]:
@@ -1945,7 +1982,8 @@ async def manage_issue_relation(
 
 
 @mcp.tool()
-async def list_subtasks(
+@offloaded
+def list_subtasks(
     issue_id: int,
 ) -> Union[List[Dict[str, Any]], Dict[str, Any]]:
     """List subtasks (child issues) of a given Redmine issue.
@@ -2039,103 +2077,108 @@ async def delete_redmine_issue(
     if not _is_positive_int(issue_id):
         return {"error": "issue_id must be a positive integer."}
 
-    # Fetch the issue + lightweight cascade hints. The include flags
-    # below are cheap (Redmine returns them inline on the issue
-    # response) and let us populate a preview without separate API
-    # round-trips. Subtask count is best-effort: when present,
-    # ``children`` is included by Redmine; otherwise we treat
-    # children-count as 0 for the preview (the actual delete still
-    # cascades the same way regardless).
-    try:
-        issue = _get_redmine_client().issue.get(
-            issue_id,
-            include="journals,attachments,relations,children",
-        )
-    except ResourceNotFoundError:
-        return {
-            "error": f"Issue {issue_id} not found.",
-            "code": "NOT_FOUND",
-            "upstream_status": 404,
+    def _run():
+        # Fetch the issue + lightweight cascade hints. The include flags
+        # below are cheap (Redmine returns them inline on the issue
+        # response) and let us populate a preview without separate API
+        # round-trips. Subtask count is best-effort: when present,
+        # ``children`` is included by Redmine; otherwise we treat
+        # children-count as 0 for the preview (the actual delete still
+        # cascades the same way regardless).
+        try:
+            issue = _get_redmine_client().issue.get(
+                issue_id,
+                include="journals,attachments,relations,children",
+            )
+        except ResourceNotFoundError:
+            return {
+                "error": f"Issue {issue_id} not found.",
+                "code": "NOT_FOUND",
+                "upstream_status": 404,
+                "issue_id": issue_id,
+            }
+        except Exception as e:
+            return _handle_redmine_error(
+                e,
+                f"fetching issue {issue_id} for delete",
+                {"resource_type": "issue", "resource_id": issue_id},
+            )
+
+        children = list(getattr(issue, "children", None) or [])
+        journals = list(getattr(issue, "journals", None) or [])
+        attachments = list(getattr(issue, "attachments", None) or [])
+        relations = list(getattr(issue, "relations", None) or [])
+        time_entries = list(getattr(issue, "time_entries", None) or [])
+
+        impact: Dict[str, Any] = {
             "issue_id": issue_id,
+            "subject": getattr(issue, "subject", ""),
+            "children_count": len(children),
+            "journals_count": len(journals),
+            "attachments_count": len(attachments),
+            "relations_count": len(relations),
+            "time_entries_count": len(time_entries),
         }
-    except Exception as e:
-        return _handle_redmine_error(
-            e,
-            f"fetching issue {issue_id} for delete",
-            {"resource_type": "issue", "resource_id": issue_id},
-        )
 
-    children = list(getattr(issue, "children", None) or [])
-    journals = list(getattr(issue, "journals", None) or [])
-    attachments = list(getattr(issue, "attachments", None) or [])
-    relations = list(getattr(issue, "relations", None) or [])
-    time_entries = list(getattr(issue, "time_entries", None) or [])
+        if not confirm_delete:
+            return {
+                "error": (
+                    f"Refusing to delete issue {issue_id} without "
+                    "explicit confirmation."
+                ),
+                "code": "CONFIRMATION_REQUIRED",
+                "hint": (
+                    "Issue deletion in Redmine is irreversible and cascades "
+                    "to children, journals, attachments, time entries, and "
+                    "inbound relations from issues that reference this one. "
+                    "Re-invoke with confirm_delete=True to proceed."
+                ),
+                "impact": impact,
+            }
 
-    impact: Dict[str, Any] = {
-        "issue_id": issue_id,
-        "subject": getattr(issue, "subject", ""),
-        "children_count": len(children),
-        "journals_count": len(journals),
-        "attachments_count": len(attachments),
-        "relations_count": len(relations),
-        "time_entries_count": len(time_entries),
-    }
+        if children and not confirm_delete_with_children:
+            return {
+                "error": (
+                    f"Refusing to delete issue {issue_id}: it has "
+                    f"{len(children)} subtask(s) which would be "
+                    "cascade-deleted by Redmine."
+                ),
+                "code": "CHILDREN_PRESENT",
+                "hint": (
+                    "Re-invoke with confirm_delete_with_children=True to "
+                    "proceed with the cascade, or reassign / delete the "
+                    "children first if you want to keep them."
+                ),
+                "impact": impact,
+            }
 
-    if not confirm_delete:
+        try:
+            _get_redmine_client().issue.delete(issue_id)
+        except ResourceNotFoundError:
+            return {
+                "error": f"Issue {issue_id} not found.",
+                "code": "NOT_FOUND",
+                "upstream_status": 404,
+                "issue_id": issue_id,
+            }
+        except Exception as e:
+            return _handle_redmine_error(
+                e,
+                f"deleting issue {issue_id}",
+                {"resource_type": "issue", "resource_id": issue_id},
+            )
+
         return {
-            "error": (
-                f"Refusing to delete issue {issue_id} without " "explicit confirmation."
-            ),
-            "code": "CONFIRMATION_REQUIRED",
-            "hint": (
-                "Issue deletion in Redmine is irreversible and cascades "
-                "to children, journals, attachments, time entries, and "
-                "inbound relations from issues that reference this one. "
-                "Re-invoke with confirm_delete=True to proceed."
-            ),
-            "impact": impact,
+            "success": True,
+            "deleted_issue_id": issue_id,
+            "cascade_deleted": impact,
         }
 
-    if children and not confirm_delete_with_children:
-        return {
-            "error": (
-                f"Refusing to delete issue {issue_id}: it has "
-                f"{len(children)} subtask(s) which would be "
-                "cascade-deleted by Redmine."
-            ),
-            "code": "CHILDREN_PRESENT",
-            "hint": (
-                "Re-invoke with confirm_delete_with_children=True to "
-                "proceed with the cascade, or reassign / delete the "
-                "children first if you want to keep them."
-            ),
-            "impact": impact,
-        }
-
-    try:
-        _get_redmine_client().issue.delete(issue_id)
-    except ResourceNotFoundError:
-        return {
-            "error": f"Issue {issue_id} not found.",
-            "code": "NOT_FOUND",
-            "upstream_status": 404,
-            "issue_id": issue_id,
-        }
-    except Exception as e:
-        return _handle_redmine_error(
-            e,
-            f"deleting issue {issue_id}",
-            {"resource_type": "issue", "resource_id": issue_id},
-        )
-
-    return {
-        "success": True,
-        "deleted_issue_id": issue_id,
-        "cascade_deleted": impact,
-    }
+    return await in_thread(_run)
 
 
-async def _add_issue_watcher_action(
+@offloaded
+def _add_issue_watcher_action(
     issue_id: Optional[int] = None,
     user_id: Optional[int] = None,
     **_: Any,
@@ -2157,7 +2200,8 @@ async def _add_issue_watcher_action(
         )
 
 
-async def _remove_issue_watcher_action(
+@offloaded
+def _remove_issue_watcher_action(
     issue_id: Optional[int] = None,
     user_id: Optional[int] = None,
     **_: Any,
@@ -2208,7 +2252,8 @@ async def manage_issue_watcher(
     }
 
 
-async def _edit_issue_note_action(
+@offloaded
+def _edit_issue_note_action(
     journal_id: Optional[int] = None,
     notes: Optional[str] = None,
     private_notes: Optional[bool] = None,
@@ -2237,7 +2282,8 @@ async def _edit_issue_note_action(
         )
 
 
-async def _set_private_issue_note_action(
+@offloaded
+def _set_private_issue_note_action(
     journal_id: Optional[int] = None,
     is_private: Optional[bool] = None,
     **_: Any,
@@ -2302,7 +2348,8 @@ async def manage_issue_note(
 
 
 @mcp.tool()
-async def get_private_notes(issue_id: int) -> List[Dict[str, Any]]:
+@offloaded
+def get_private_notes(issue_id: int) -> List[Dict[str, Any]]:
     """Retrieve only the private notes/journals of a Redmine issue.
 
     Fetches the issue's journals and filters for entries where
@@ -2345,7 +2392,8 @@ async def get_private_notes(issue_id: int) -> List[Dict[str, Any]]:
         ]
 
 
-async def _list_issue_categories_action(
+@offloaded
+def _list_issue_categories_action(
     project_id: Optional[Union[str, int]] = None,
     **_: Any,
 ) -> Union[List[Dict[str, Any]], Dict[str, Any]]:
@@ -2362,7 +2410,8 @@ async def _list_issue_categories_action(
         )
 
 
-async def _create_issue_category_action(
+@offloaded
+def _create_issue_category_action(
     project_id: Optional[Union[str, int]] = None,
     name: Optional[str] = None,
     assigned_to_id: Optional[int] = None,
@@ -2390,7 +2439,8 @@ async def _create_issue_category_action(
         )
 
 
-async def _update_issue_category_action(
+@offloaded
+def _update_issue_category_action(
     category_id: Optional[int] = None,
     name: Optional[str] = None,
     assigned_to_id: Optional[int] = None,
@@ -2424,7 +2474,8 @@ async def _update_issue_category_action(
         )
 
 
-async def _delete_issue_category_action(
+@offloaded
+def _delete_issue_category_action(
     category_id: Optional[int] = None,
     reassign_to_id: Optional[int] = None,
     **_: Any,

--- a/src/redmine_mcp_server/tools/products.py
+++ b/src/redmine_mcp_server/tools/products.py
@@ -9,6 +9,7 @@ from .._client import _get_redmine_client
 from .._decorators import ActionMode, action_dispatch
 from .._env import _is_products_enabled
 from .._errors import _handle_redmine_error
+from .._offload import offloaded
 from .._serialization import (
     _REDMINE_API_PAGE_CAP,
     _safe_isoformat,
@@ -81,7 +82,8 @@ def _product_to_dict(product: Dict[str, Any]) -> Dict[str, Any]:
     }
 
 
-async def _list_products_action(
+@offloaded
+def _list_products_action(
     project_id: Optional[Union[str, int]] = None,
     limit: int = 100,
     **_: Any,
@@ -117,7 +119,8 @@ async def _list_products_action(
         )
 
 
-async def _get_product_action(
+@offloaded
+def _get_product_action(
     product_id: Optional[int] = None,
     **_: Any,
 ) -> Dict[str, Any]:
@@ -141,7 +144,8 @@ async def _get_product_action(
         )
 
 
-async def _create_product_action(
+@offloaded
+def _create_product_action(
     project_id: Optional[Union[str, int]] = None,
     name: Optional[str] = None,
     status_id: int = 1,
@@ -198,7 +202,8 @@ async def _create_product_action(
         )
 
 
-async def _update_product_action(
+@offloaded
+def _update_product_action(
     product_id: Optional[int] = None,
     fields: Optional[Dict[str, Any]] = None,
     **_: Any,

--- a/src/redmine_mcp_server/tools/projects.py
+++ b/src/redmine_mcp_server/tools/projects.py
@@ -12,6 +12,7 @@ from .._client import _get_redmine_client
 from .._custom_fields import _extract_possible_values
 from .._decorators import ActionMode, action_dispatch
 from .._errors import _handle_redmine_error
+from .._offload import in_thread, offloaded
 from .._serialization import (
     _named_ref,
     _safe_isoformat,
@@ -203,7 +204,8 @@ def _membership_to_dict(membership: Any) -> Dict[str, Any]:
 
 
 @mcp.tool()
-async def list_redmine_projects() -> Union[List[Dict[str, Any]], Dict[str, Any]]:
+@offloaded
+def list_redmine_projects() -> Union[List[Dict[str, Any]], Dict[str, Any]]:
     """
     Lists all accessible projects in Redmine.
     Returns:
@@ -290,25 +292,30 @@ async def list_project_issue_custom_fields(
 
     await _ensure_cleanup_started()
 
-    try:
-        project = _get_redmine_client().project.get(
-            project_id, include="issue_custom_fields"
-        )
-        custom_fields = getattr(project, "issue_custom_fields", None) or []
+    def _run() -> Union[List[Dict[str, Any]], Dict[str, Any]]:
+        try:
+            project = _get_redmine_client().project.get(
+                project_id, include="issue_custom_fields"
+            )
+            custom_fields = getattr(project, "issue_custom_fields", None) or []
 
-        result: List[Dict[str, Any]] = []
-        for custom_field in custom_fields:
-            if not _custom_field_applies_to_tracker(custom_field, parsed_tracker_id):
-                continue
-            result.append(_custom_field_to_dict(custom_field))
+            result: List[Dict[str, Any]] = []
+            for custom_field in custom_fields:
+                if not _custom_field_applies_to_tracker(
+                    custom_field, parsed_tracker_id
+                ):
+                    continue
+                result.append(_custom_field_to_dict(custom_field))
 
-        return result
-    except Exception as e:
-        return _handle_redmine_error(
-            e,
-            f"listing issue custom fields for project {project_id}",
-            {"resource_type": "project", "resource_id": project_id},
-        )
+            return result
+        except Exception as e:
+            return _handle_redmine_error(
+                e,
+                f"listing issue custom fields for project {project_id}",
+                {"resource_type": "project", "resource_id": project_id},
+            )
+
+    return await in_thread(_run)
 
 
 @mcp.tool()
@@ -344,27 +351,32 @@ async def list_redmine_versions(
             }
 
     await _ensure_cleanup_started()
-    try:
-        versions = _get_redmine_client().version.filter(project_id=project_id)
-        result = []
-        for version in versions:
-            if status_filter is not None:
-                if getattr(version, "status", "") != status_filter:
-                    continue
-            result.append(_version_to_dict(version))
-        return result
-    except Exception as e:
-        return _handle_redmine_error(
-            e,
-            f"listing versions for project {project_id}",
-            {"resource_type": "project", "resource_id": project_id},
-        )
+
+    def _run() -> Union[List[Dict[str, Any]], Dict[str, Any]]:
+        try:
+            versions = _get_redmine_client().version.filter(project_id=project_id)
+            result = []
+            for version in versions:
+                if status_filter is not None:
+                    if getattr(version, "status", "") != status_filter:
+                        continue
+                result.append(_version_to_dict(version))
+            return result
+        except Exception as e:
+            return _handle_redmine_error(
+                e,
+                f"listing versions for project {project_id}",
+                {"resource_type": "project", "resource_id": project_id},
+            )
+
+    return await in_thread(_run)
 
 
 _VALID_VERSION_STATUSES = {"open", "locked", "closed"}
 
 
-async def _create_redmine_version_action(
+@offloaded
+def _create_redmine_version_action(
     project_id: Optional[Union[str, int]] = None,
     name: Optional[str] = None,
     description: Optional[str] = None,
@@ -407,7 +419,8 @@ async def _create_redmine_version_action(
         )
 
 
-async def _update_redmine_version_action(
+@offloaded
+def _update_redmine_version_action(
     version_id: Optional[int] = None,
     name: Optional[str] = None,
     description: Optional[str] = None,
@@ -447,7 +460,8 @@ async def _update_redmine_version_action(
         )
 
 
-async def _delete_redmine_version_action(
+@offloaded
+def _delete_redmine_version_action(
     version_id: Optional[int] = None,
     **_: Any,
 ) -> Dict[str, Any]:
@@ -522,7 +536,8 @@ async def manage_redmine_version(
 
 
 @mcp.tool()
-async def summarize_project_status(project_id: int, days: int = 30) -> Dict[str, Any]:
+@offloaded
+def summarize_project_status(project_id: int, days: int = 30) -> Dict[str, Any]:
     """Provide a summary of project status based on issue activity over the
     specified time period.
 
@@ -615,7 +630,8 @@ async def summarize_project_status(project_id: int, days: int = 30) -> Dict[str,
 
 
 @mcp.tool()
-async def list_project_members(
+@offloaded
+def list_project_members(
     project_id: Union[str, int],
 ) -> Union[List[Dict[str, Any]], Dict[str, Any]]:
     """List members of a Redmine project.
@@ -659,7 +675,8 @@ async def list_project_members(
 
 
 @mcp.tool()
-async def list_redmine_roles() -> Union[List[Dict[str, Any]], Dict[str, Any]]:
+@offloaded
+def list_redmine_roles() -> Union[List[Dict[str, Any]], Dict[str, Any]]:
     """List all roles defined in the Redmine instance.
 
     Returns basic role metadata (``id`` and ``name``) for every role
@@ -694,7 +711,8 @@ async def list_redmine_roles() -> Union[List[Dict[str, Any]], Dict[str, Any]]:
 
 
 @mcp.tool()
-async def get_project_modules(
+@offloaded
+def get_project_modules(
     project_id: Union[str, int],
 ) -> Dict[str, Any]:
     """Retrieve the enabled modules for a Redmine project.
@@ -756,7 +774,8 @@ async def get_project_modules(
         )
 
 
-async def _add_project_member_action(
+@offloaded
+def _add_project_member_action(
     project_id: Optional[Union[str, int]] = None,
     user_id: Optional[int] = None,
     group_id: Optional[int] = None,
@@ -804,7 +823,8 @@ async def _add_project_member_action(
         )
 
 
-async def _update_project_member_action(
+@offloaded
+def _update_project_member_action(
     membership_id: Optional[int] = None,
     role_ids: Optional[List[int]] = None,
     **_: Any,
@@ -839,7 +859,8 @@ async def _update_project_member_action(
         )
 
 
-async def _remove_project_member_action(
+@offloaded
+def _remove_project_member_action(
     membership_id: Optional[int] = None,
     **_: Any,
 ) -> Dict[str, Any]:
@@ -904,7 +925,8 @@ async def manage_project_member(
 
 
 @mcp.tool()
-async def list_project_trackers(
+@offloaded
+def list_project_trackers(
     project_id: Union[str, int],
 ) -> List[Dict[str, Any]]:
     """List the trackers (issue types) enabled for a specific Redmine project.

--- a/src/redmine_mcp_server/tools/search.py
+++ b/src/redmine_mcp_server/tools/search.py
@@ -8,6 +8,7 @@ from redminelib.exceptions import VersionMismatchError
 from .._cleanup import _ensure_cleanup_started
 from .._client import _get_redmine_client
 from .._errors import _handle_redmine_error
+from .._offload import in_thread
 from .._serialization import wrap_insecure_content
 from ..server import mcp
 
@@ -117,73 +118,77 @@ async def search_entire_redmine(
         Requires Redmine 3.3.0 or higher for search API support.
     """
 
-    try:
-        await _ensure_cleanup_started()
+    await _ensure_cleanup_started()
 
-        # Validate and enforce scope limitation (v1.4)
-        allowed_types = ["issues", "wiki_pages"]
-        if resources:
-            resources = [r for r in resources if r in allowed_types]
-            if not resources:
-                resources = allowed_types  # Fall back to default if all filtered
-        else:
-            resources = allowed_types
+    def _run():
+        nonlocal limit, resources
+        try:
+            # Validate and enforce scope limitation (v1.4)
+            allowed_types = ["issues", "wiki_pages"]
+            if resources:
+                resources = [r for r in resources if r in allowed_types]
+                if not resources:
+                    resources = allowed_types  # Fall back to default if all filtered
+            else:
+                resources = allowed_types
 
-        # Cap limit at 100 (Redmine API maximum)
-        limit = min(limit, 100)
-        if limit <= 0:
-            limit = 100
+            # Cap limit at 100 (Redmine API maximum)
+            limit = min(limit, 100)
+            if limit <= 0:
+                limit = 100
 
-        # Build search options
-        search_options = {
-            "resources": resources,
-            "limit": limit,
-            "offset": offset,
-        }
+            # Build search options
+            search_options = {
+                "resources": resources,
+                "limit": limit,
+                "offset": offset,
+            }
 
-        # Execute search
-        categorized_results = _get_redmine_client().search(query, **search_options)
+            # Execute search
+            categorized_results = _get_redmine_client().search(query, **search_options)
 
-        # Handle empty results (python-redmine returns None)
-        if not categorized_results:
+            # Handle empty results (python-redmine returns None)
+            if not categorized_results:
+                return {
+                    "results": [],
+                    "results_by_type": {},
+                    "total_count": 0,
+                    "query": query,
+                }
+
+            # Process categorized results
+            all_results = []
+            results_by_type: Dict[str, int] = {}
+
+            for resource_type, resource_set in categorized_results.items():
+                # Skip 'unknown' category (plugin resources)
+                if resource_type == "unknown":
+                    continue
+
+                # Skip if not in allowed types
+                if resource_type not in allowed_types:
+                    continue
+
+                # Handle both ResourceSet and dict (for 'unknown')
+                if hasattr(resource_set, "__iter__"):
+                    count = 0
+                    for resource in resource_set:
+                        result_dict = _resource_to_dict(resource, resource_type)
+                        all_results.append(result_dict)
+                        count += 1
+                    if count > 0:
+                        results_by_type[resource_type] = count
+
             return {
-                "results": [],
-                "results_by_type": {},
-                "total_count": 0,
+                "results": all_results,
+                "results_by_type": results_by_type,
+                "total_count": len(all_results),
                 "query": query,
             }
 
-        # Process categorized results
-        all_results = []
-        results_by_type: Dict[str, int] = {}
+        except VersionMismatchError:
+            return {"error": "Search requires Redmine 3.3.0 or higher."}
+        except Exception as e:
+            return _handle_redmine_error(e, f"searching Redmine for '{query}'")
 
-        for resource_type, resource_set in categorized_results.items():
-            # Skip 'unknown' category (plugin resources)
-            if resource_type == "unknown":
-                continue
-
-            # Skip if not in allowed types
-            if resource_type not in allowed_types:
-                continue
-
-            # Handle both ResourceSet and dict (for 'unknown')
-            if hasattr(resource_set, "__iter__"):
-                count = 0
-                for resource in resource_set:
-                    result_dict = _resource_to_dict(resource, resource_type)
-                    all_results.append(result_dict)
-                    count += 1
-                if count > 0:
-                    results_by_type[resource_type] = count
-
-        return {
-            "results": all_results,
-            "results_by_type": results_by_type,
-            "total_count": len(all_results),
-            "query": query,
-        }
-
-    except VersionMismatchError:
-        return {"error": "Search requires Redmine 3.3.0 or higher."}
-    except Exception as e:
-        return _handle_redmine_error(e, f"searching Redmine for '{query}'")
+    return await in_thread(_run)

--- a/src/redmine_mcp_server/tools/time_tracking.py
+++ b/src/redmine_mcp_server/tools/time_tracking.py
@@ -1,6 +1,5 @@
 """Time tracking tools: list, manage (create/update), activities, bulk import."""
 
-import asyncio
 from typing import Annotated, Any, Dict, List, Literal, Optional, Union
 
 from pydantic import Field
@@ -9,6 +8,7 @@ from .._client import _get_redmine_client, logger
 from .._decorators import ActionMode, action_dispatch
 from .._env import _is_read_only_mode
 from .._errors import _READ_ONLY_ERROR, _handle_redmine_error, _scrub_error_message
+from .._offload import offloaded
 from .._serialization import (
     _named_ref,
     _safe_isoformat,
@@ -19,8 +19,9 @@ from ..server import mcp
 
 # Maximum entries in a single `import_time_entries` call. Redmine has no
 # native bulk endpoint, so each entry is a sequential synchronous HTTP
-# call; capping the batch prevents a single tool invocation from pinning
-# the event loop for minutes.
+# call. The loop runs in a worker thread now (issue #216), so it no longer
+# pins the event loop, but the cap still bounds how long one tool
+# invocation can occupy a worker.
 _IMPORT_TIME_ENTRIES_MAX_BATCH = 500
 
 
@@ -53,7 +54,8 @@ def _time_entry_to_dict(time_entry: Any) -> Dict[str, Any]:
 
 
 @mcp.tool()
-async def list_time_entries(
+@offloaded
+def list_time_entries(
     project_id: Optional[Union[str, int]] = None,
     issue_id: Optional[int] = None,
     user_id: Optional[Union[int, Literal["me"]]] = None,
@@ -118,7 +120,8 @@ async def list_time_entries(
         return _handle_redmine_error(e, "listing time entries")
 
 
-async def _create_time_entry_action(
+@offloaded
+def _create_time_entry_action(
     hours: Optional[float] = None,
     project_id: Optional[Union[str, int]] = None,
     issue_id: Optional[int] = None,
@@ -163,7 +166,8 @@ async def _create_time_entry_action(
         return _handle_redmine_error(e, "creating time entry", context)
 
 
-async def _update_time_entry_action(
+@offloaded
+def _update_time_entry_action(
     time_entry_id: Optional[int] = None,
     hours: Optional[float] = None,
     activity_id: Optional[int] = None,
@@ -249,7 +253,8 @@ async def manage_time_entry(
 
 
 @mcp.tool()
-async def list_time_entry_activities(
+@offloaded
+def list_time_entry_activities(
     project_id: Optional[Union[str, int]] = None,
 ) -> Union[List[Dict[str, Any]], Dict[str, Any]]:
     """List available time entry activities from Redmine.
@@ -340,7 +345,8 @@ async def list_time_entry_activities(
 
 
 @mcp.tool()
-async def import_time_entries(
+@offloaded
+def import_time_entries(
     entries: List[Dict[str, Any]],
     stop_on_error: bool = False,
 ) -> Dict[str, Any]:
@@ -437,11 +443,6 @@ async def import_time_entries(
     client = _get_redmine_client()
 
     for index, entry in enumerate(entries_list):
-        # Yield to the event loop between synchronous HTTP calls so other
-        # MCP requests (e.g., a status check) aren't starved during a
-        # large import.
-        if index > 0:
-            await asyncio.sleep(0)
         if not isinstance(entry, dict):
             errors.append(
                 {

--- a/src/redmine_mcp_server/tools/wiki.py
+++ b/src/redmine_mcp_server/tools/wiki.py
@@ -5,6 +5,7 @@ from typing import Any, Dict, List, Literal, Optional, Union
 from .._client import _get_redmine_client
 from .._decorators import ActionMode, action_dispatch
 from .._errors import _handle_redmine_error
+from .._offload import in_thread, offloaded
 from .files import _build_upload_descriptors
 from .._serialization import (
     _attachment_to_dict,
@@ -81,7 +82,8 @@ def _require_wiki_page_title(action: str, wiki_page_title: Any) -> Optional[str]
     return None
 
 
-async def _list_wiki_pages_action(
+@offloaded
+def _list_wiki_pages_action(
     project_id: Optional[Union[str, int]] = None,
     **_: Any,
 ) -> Union[List[Dict[str, Any]], Dict[str, Any]]:
@@ -109,7 +111,8 @@ async def _list_wiki_pages_action(
         )
 
 
-async def _get_wiki_page_action(
+@offloaded
+def _get_wiki_page_action(
     project_id: Optional[Union[str, int]] = None,
     wiki_page_title: Optional[str] = None,
     version: Optional[int] = None,
@@ -166,15 +169,18 @@ async def _create_wiki_page_action(
     if upload_descriptors:
         create_kwargs["uploads"] = upload_descriptors
 
-    try:
-        wiki_page = _get_redmine_client().wiki_page.create(**create_kwargs)
-        return _wiki_page_to_dict(wiki_page)
-    except Exception as e:
-        return _handle_redmine_error(
-            e,
-            f"creating wiki page '{wiki_page_title}' in project {project_id}",
-            {"resource_type": "wiki page", "resource_id": wiki_page_title},
-        )
+    def _run():
+        try:
+            wiki_page = _get_redmine_client().wiki_page.create(**create_kwargs)
+            return _wiki_page_to_dict(wiki_page)
+        except Exception as e:
+            return _handle_redmine_error(
+                e,
+                f"creating wiki page '{wiki_page_title}' in project {project_id}",
+                {"resource_type": "wiki page", "resource_id": wiki_page_title},
+            )
+
+    return await in_thread(_run)
 
 
 async def _update_wiki_page_action(
@@ -207,12 +213,16 @@ async def _update_wiki_page_action(
         # already-uploaded blobs on the server with nothing left to attach
         # them to. Doing the cheap, most-likely-to-fail GET first avoids
         # that. Do not reorder this back for "tidiness".
-        try:
+        def _read_back():
             existing = _get_redmine_client().wiki_page.get(
                 wiki_page_title, project_id=project_id
             )
-            existing_text = existing.text
-            existing_version = existing.version
+            # Read both attributes in the worker too: a missing included
+            # field makes python-redmine re-fetch on attribute access.
+            return existing.text, existing.version
+
+        try:
+            existing_text, existing_version = await in_thread(_read_back)
         except Exception as e:
             return _handle_redmine_error(
                 e,
@@ -233,28 +243,32 @@ async def _update_wiki_page_action(
     if upload_descriptors:
         update_kwargs["uploads"] = upload_descriptors
 
-    try:
-        client = _get_redmine_client()
-        if text is None:
-            # Sending the version read above turns a concurrent edit into a
-            # 409 instead of a silent revert. Unchanged text does not create
-            # a new revision.
-            update_kwargs["text"] = existing_text
-            update_kwargs["version"] = existing_version
-        else:
-            update_kwargs["text"] = text
-        client.wiki_page.update(wiki_page_title, **update_kwargs)
-        wiki_page = client.wiki_page.get(wiki_page_title, project_id=project_id)
-        return _wiki_page_to_dict(wiki_page)
-    except Exception as e:
-        return _handle_redmine_error(
-            e,
-            f"updating wiki page '{wiki_page_title}' in project {project_id}",
-            {"resource_type": "wiki page", "resource_id": wiki_page_title},
-        )
+    def _run():
+        try:
+            client = _get_redmine_client()
+            if text is None:
+                # Sending the version read above turns a concurrent edit into a
+                # 409 instead of a silent revert. Unchanged text does not create
+                # a new revision.
+                update_kwargs["text"] = existing_text
+                update_kwargs["version"] = existing_version
+            else:
+                update_kwargs["text"] = text
+            client.wiki_page.update(wiki_page_title, **update_kwargs)
+            wiki_page = client.wiki_page.get(wiki_page_title, project_id=project_id)
+            return _wiki_page_to_dict(wiki_page)
+        except Exception as e:
+            return _handle_redmine_error(
+                e,
+                f"updating wiki page '{wiki_page_title}' in project {project_id}",
+                {"resource_type": "wiki page", "resource_id": wiki_page_title},
+            )
+
+    return await in_thread(_run)
 
 
-async def _delete_wiki_page_action(
+@offloaded
+def _delete_wiki_page_action(
     project_id: Optional[Union[str, int]] = None,
     wiki_page_title: Optional[str] = None,
     **_: Any,
@@ -278,7 +292,8 @@ async def _delete_wiki_page_action(
         )
 
 
-async def _rename_wiki_page_action(
+@offloaded
+def _rename_wiki_page_action(
     project_id: Optional[Union[str, int]] = None,
     wiki_page_title: Optional[str] = None,
     new_title: Optional[str] = None,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -99,3 +99,18 @@ def mock_api_key_env(monkeypatch):
     # Remove username/password if they exist
     monkeypatch.delenv("REDMINE_USERNAME", raising=False)
     monkeypatch.delenv("REDMINE_PASSWORD", raising=False)
+
+
+@pytest.fixture(autouse=True)
+def _reset_legacy_client_cache_between_tests():
+    """Keep the per-thread legacy client cache from leaking across tests.
+
+    Tests patch ``_client._legacy_client`` to None to force a rebuild. Without
+    this, a client cached in a worker thread by an earlier test would be
+    returned instead (issue #216).
+    """
+    from redmine_mcp_server import _client
+
+    _client._reset_legacy_client_cache()
+    yield
+    _client._reset_legacy_client_cache()

--- a/tests/test_global_search.py
+++ b/tests/test_global_search.py
@@ -610,7 +610,12 @@ class TestGlobalSearchIntegration:
 
         # Get project identifier - search API doesn't provide it for wiki pages
         # so we get the first available project
-        projects = list(_get_redmine_client().project.all())
+        # Direct client use inside an async test, so it opts out of the
+        # event-loop guard (issue #216).
+        from redmine_mcp_server._client import allow_loop_thread
+
+        with allow_loop_thread():
+            projects = list(_get_redmine_client().project.all())
         if not projects:
             pytest.skip("No projects available")
         project_id = projects[0].identifier

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -47,9 +47,18 @@ def _unwrap_insecure_content(value):
 
 
 def _get_redmine_or_none():
-    """Try to get a Redmine client, return None if not configured."""
+    """Try to get a Redmine client, return None if not configured.
+
+    ``allow_loop_thread()`` because this is a direct factory call from async
+    tests, not a tool call. Without it the event-loop guard (issue #216) raises
+    RuntimeError, which the ``except`` below would read as "not configured" and
+    silently skip the test instead of running it.
+    """
+    from redmine_mcp_server._client import allow_loop_thread
+
     try:
-        return _get_redmine_client()
+        with allow_loop_thread():
+            return _get_redmine_client()
     except RuntimeError:
         return None
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -2162,6 +2162,7 @@ class TestTagsPluginIntegration:
             subject="[MCP TAG VERIFY] delete me",
             description="additional_tags write round-trip",
             fields={"tag_list": ["mcp-verify-tag"]},
+            extra_fields=_integration_test_custom_fields(),
         )
         assert "error" not in created, f"create failed: {created}"
         issue_id = created["id"]

--- a/tests/test_oauth_integration.py
+++ b/tests/test_oauth_integration.py
@@ -118,7 +118,10 @@ async def test_end_to_end_tool_call_via_mcp():
         patch.object(_client, "_legacy_client", None),
         patch("redmine_mcp_server._client.get_access_token", return_value=access),
     ):
-        redmine = _client._get_redmine_client()
+        # This test drives the client factory directly rather than through a
+        # tool, so it opts out of the event-loop guard (issue #216).
+        with _client.allow_loop_thread():
+            redmine = _client._get_redmine_client()
         # Cheap read call to prove the bearer is forwarded correctly.
         projects = list(redmine.project.all()[:1])
         assert isinstance(projects, list)

--- a/tests/test_offload.py
+++ b/tests/test_offload.py
@@ -1,0 +1,85 @@
+"""Tests for the event-loop offload helper (issue #216)."""
+
+import asyncio
+import contextvars
+import threading
+import time
+
+import pytest
+
+from redmine_mcp_server._offload import in_thread, offloaded
+
+
+async def test_in_thread_runs_off_the_main_thread():
+    main = threading.current_thread()
+    worker = await in_thread(threading.current_thread)
+    assert worker is not main
+
+
+async def test_in_thread_passes_args_and_kwargs():
+    def add(a, b, c=0):
+        return a + b + c
+
+    assert await in_thread(add, 1, 2, c=3) == 6
+
+
+async def test_in_thread_propagates_exceptions():
+    def boom():
+        raise ValueError("kaboom")
+
+    with pytest.raises(ValueError, match="kaboom"):
+        await in_thread(boom)
+
+
+async def test_in_thread_propagates_contextvars():
+    var = contextvars.ContextVar("var", default="unset")
+    var.set("set-on-loop")
+    assert await in_thread(var.get) == "set-on-loop"
+
+
+async def test_in_thread_does_not_block_the_loop():
+    ticks = 0
+
+    async def heartbeat():
+        nonlocal ticks
+        while True:
+            await asyncio.sleep(0.01)
+            ticks += 1
+
+    task = asyncio.create_task(heartbeat())
+    await asyncio.sleep(0)
+    await in_thread(time.sleep, 0.5)
+    task.cancel()
+
+    assert ticks >= 10, f"loop only ticked {ticks} times during a 0.5s sync call"
+
+
+async def test_offloaded_preserves_name_docstring_and_signature():
+    @offloaded
+    def sample(a: int, b: str = "x") -> dict:
+        """Sample docstring."""
+        return {"a": a, "b": b}
+
+    import inspect
+
+    assert sample.__name__ == "sample"
+    assert sample.__doc__ == "Sample docstring."
+    params = list(inspect.signature(sample).parameters)
+    assert params == ["a", "b"]
+    assert await sample(1) == {"a": 1, "b": "x"}
+
+
+async def test_offloaded_runs_off_the_main_thread():
+    @offloaded
+    def where():
+        return threading.current_thread()
+
+    assert await where() is not threading.current_thread()
+
+
+def test_offloaded_rejects_a_coroutine_function():
+    with pytest.raises(TypeError, match="already a coroutine function"):
+
+        @offloaded
+        async def already_async():
+            return None

--- a/tests/test_offload.py
+++ b/tests/test_offload.py
@@ -131,3 +131,36 @@ async def test_explicitly_patched_legacy_client_still_wins():
         got = await in_thread(_client._get_redmine_client)
 
     assert got is sentinel
+
+
+async def test_tool_does_not_block_the_event_loop():
+    """A hung Redmine call must not stall the loop (issue #216)."""
+    from unittest.mock import Mock, patch
+
+    from redmine_mcp_server.tools.gantt import get_gantt_chart
+
+    client = Mock()
+
+    def slow_filter(**kwargs):
+        time.sleep(0.5)
+        return []
+
+    client.issue.filter.side_effect = slow_filter
+    client.version.filter.return_value = []
+
+    ticks = 0
+
+    async def heartbeat():
+        nonlocal ticks
+        while True:
+            await asyncio.sleep(0.01)
+            ticks += 1
+
+    with patch("redmine_mcp_server._client.redmine", client):
+        task = asyncio.create_task(heartbeat())
+        await asyncio.sleep(0)
+        result = await get_gantt_chart(project_id=1)
+        task.cancel()
+
+    assert result["total_count"] == 0
+    assert ticks >= 10, f"loop only ticked {ticks} times during a hung tool call"

--- a/tests/test_offload.py
+++ b/tests/test_offload.py
@@ -245,3 +245,37 @@ async def test_allow_loop_thread_escape_hatch():
     with patch.object(_client, "redmine", sentinel):
         with _client.allow_loop_thread():
             assert _client._get_redmine_client() is sentinel
+
+
+async def test_oauth_token_resolves_inside_the_worker():
+    """The Bearer token must survive the hop to the worker thread."""
+    from unittest.mock import Mock, patch
+
+    from redmine_mcp_server import _client
+
+    token = Mock()
+    token.token = "test-bearer-token"
+    captured = {}
+
+    def fake_new_client(**kwargs):
+        captured.update(kwargs)
+        return Mock(name="oauth-client")
+
+    # Read the token out of a ContextVar the way FastMCP's real
+    # get_access_token() does. If the context did not reach the worker this
+    # returns the default None and no Authorization header is built, which is
+    # exactly the silent OAuth breakage this test exists to catch.
+    current_token = contextvars.ContextVar("current_token", default=None)
+    current_token.set(token)
+
+    with (
+        patch.object(_client, "redmine", None),
+        patch.object(_client, "_legacy_client", None),
+        patch.object(_client, "get_access_token", current_token.get),
+        patch.object(_client, "_new_client", fake_new_client),
+    ):
+        await in_thread(_client._get_redmine_client)
+
+    assert captured["requests"]["headers"]["Authorization"] == (
+        "Bearer test-bearer-token"
+    )

--- a/tests/test_offload.py
+++ b/tests/test_offload.py
@@ -83,3 +83,51 @@ def test_offloaded_rejects_a_coroutine_function():
         @offloaded
         async def already_async():
             return None
+
+
+async def test_legacy_client_cache_is_per_thread():
+    from unittest.mock import patch
+
+    from redmine_mcp_server import _client
+
+    _client._reset_legacy_client_cache()
+    with (
+        patch.object(_client, "redmine", None),
+        patch.object(_client, "_legacy_client", None),
+        patch.object(_client, "REDMINE_AUTH_MODE", "legacy"),
+        patch.object(_client, "REDMINE_API_KEY", "key"),
+        patch.object(_client, "REDMINE_URL", "https://redmine.example.com"),
+    ):
+        # The barrier forces the two hops to overlap. Without it the first can
+        # finish before the second is submitted, both land on the same pooled
+        # worker thread, and returning the cached client there is correct.
+        barrier = threading.Barrier(2, timeout=5)
+
+        def build_client():
+            barrier.wait()
+            return _client._get_redmine_client()
+
+        first, second = await asyncio.gather(
+            in_thread(build_client),
+            in_thread(build_client),
+        )
+
+    assert first is not None and second is not None
+    assert first is not second, "each worker thread must get its own client"
+
+
+async def test_explicitly_patched_legacy_client_still_wins():
+    from unittest.mock import Mock, patch
+
+    from redmine_mcp_server import _client
+
+    _client._reset_legacy_client_cache()
+    sentinel = Mock(name="patched-client")
+    with (
+        patch.object(_client, "redmine", None),
+        patch.object(_client, "_legacy_client", sentinel),
+        patch.object(_client, "REDMINE_AUTH_MODE", "legacy"),
+    ):
+        got = await in_thread(_client._get_redmine_client)
+
+    assert got is sentinel

--- a/tests/test_offload.py
+++ b/tests/test_offload.py
@@ -164,3 +164,56 @@ async def test_tool_does_not_block_the_event_loop():
 
     assert result["total_count"] == 0
     assert ticks >= 10, f"loop only ticked {ticks} times during a hung tool call"
+
+
+def test_no_blocking_client_call_runs_on_the_event_loop():
+    """Every _get_redmine_client() call must sit in a synchronous scope.
+
+    A synchronous scope is either an @offloaded function or a `def _run()`
+    closure passed to in_thread(), both of which execute in a worker thread.
+    A call whose innermost enclosing function is `async def` runs on the event
+    loop and reintroduces issue #216.
+
+    This is a static check on purpose: it covers tools no test exercises, and
+    it names the offender instead of failing as a timeout somewhere else.
+    """
+    import ast
+    import pathlib
+    import re
+
+    import redmine_mcp_server
+
+    blocking = re.compile(
+        r"_get_redmine_client\(|_map_named_custom_fields|"
+        r"_augment_fields_with_required"
+    )
+    package = pathlib.Path(redmine_mcp_server.__file__).parent
+
+    offenders = []
+    for path in sorted(package.rglob("*.py")):
+        source = path.read_text()
+        tree = ast.parse(source)
+        for lineno, line in enumerate(source.splitlines(), 1):
+            stripped = line.strip()
+            if not blocking.search(line):
+                continue
+            # Skip imports and the continuation lines of a multi-line import.
+            if stripped.startswith(("from ", "import ", "#")) or stripped.endswith(","):
+                continue
+            innermost = None
+            for node in ast.walk(tree):
+                if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                    continue
+                if node.lineno <= lineno <= node.end_lineno:
+                    if innermost is None or node.lineno > innermost.lineno:
+                        innermost = node
+            if innermost is not None and isinstance(innermost, ast.AsyncFunctionDef):
+                offenders.append(
+                    f"{path.relative_to(package)}:{lineno} in {innermost.name}"
+                )
+
+    assert not offenders, (
+        "blocking Redmine calls still run on the event loop: "
+        + ", ".join(offenders)
+        + ". Wrap the synchronous section with @offloaded or in_thread()."
+    )

--- a/tests/test_offload.py
+++ b/tests/test_offload.py
@@ -217,3 +217,31 @@ def test_no_blocking_client_call_runs_on_the_event_loop():
         + ", ".join(offenders)
         + ". Wrap the synchronous section with @offloaded or in_thread()."
     )
+
+
+async def test_get_redmine_client_refuses_the_event_loop():
+    from redmine_mcp_server import _client
+
+    with pytest.raises(RuntimeError, match="event loop thread"):
+        _client._get_redmine_client()
+
+
+async def test_get_redmine_client_is_allowed_in_a_worker():
+    from unittest.mock import Mock, patch
+
+    from redmine_mcp_server import _client
+
+    sentinel = Mock(name="client")
+    with patch.object(_client, "redmine", sentinel):
+        assert await in_thread(_client._get_redmine_client) is sentinel
+
+
+async def test_allow_loop_thread_escape_hatch():
+    from unittest.mock import Mock, patch
+
+    from redmine_mcp_server import _client
+
+    sentinel = Mock(name="client")
+    with patch.object(_client, "redmine", sentinel):
+        with _client.allow_loop_thread():
+            assert _client._get_redmine_client() is sentinel

--- a/tests/test_security_hardening.py
+++ b/tests/test_security_hardening.py
@@ -583,13 +583,21 @@ class TestHoursValidationIntegration:
 
 
 class TestImportTimeEntriesYieldsEventLoop:
+    """The import must not starve the event loop during a long batch.
+
+    This used to be an `await asyncio.sleep(0)` between entries, asserted by
+    counting sleep calls. That only helped when every call returned promptly:
+    one hung entry still blocked the loop for the whole timeout, because the
+    yield never arrived. The whole loop now runs in a worker thread instead
+    (issue #216), so the property is asserted directly.
+    """
+
     @pytest.mark.asyncio
-    @patch(
-        "redmine_mcp_server.tools.time_tracking.asyncio.sleep",
-        new_callable=AsyncMock,
-    )
     @patch("redmine_mcp_server._client.redmine")
-    async def test_sleeps_between_entries(self, mock_redmine, mock_sleep):
+    async def test_does_not_block_the_event_loop(self, mock_redmine):
+        import asyncio
+        import time
+
         mock_te = Mock()
         mock_te.id = 1
         mock_te.hours = 1.0
@@ -601,19 +609,34 @@ class TestImportTimeEntriesYieldsEventLoop:
         mock_te.activity = None
         mock_te.created_on = None
         mock_te.updated_on = None
-        mock_redmine.time_entry.create.return_value = mock_te
 
-        await import_time_entries(
+        def slow_create(**kwargs):
+            time.sleep(0.2)
+            return mock_te
+
+        mock_redmine.time_entry.create.side_effect = slow_create
+
+        ticks = 0
+
+        async def heartbeat():
+            nonlocal ticks
+            while True:
+                await asyncio.sleep(0.01)
+                ticks += 1
+
+        task = asyncio.create_task(heartbeat())
+        await asyncio.sleep(0)
+        result = await import_time_entries(
             [
                 {"hours": 1.0, "issue_id": 1},
                 {"hours": 1.0, "issue_id": 2},
                 {"hours": 1.0, "issue_id": 3},
             ]
         )
+        task.cancel()
 
-        # We yield between entries (3 entries -> 2 sleep(0) calls)
-        sleep_0_calls = [c for c in mock_sleep.call_args_list if c.args == (0,)]
-        assert len(sleep_0_calls) == 2
+        assert len(result["created"]) == 3
+        assert ticks >= 10, f"loop only ticked {ticks} times during a 0.6s import"
 
 
 # ===========================================================================


### PR DESCRIPTION
Fixes #216.

## Problem

Every tool called the synchronous python-redmine client directly on the event
loop, so one hung Redmine call blocked every other request for the full
`REDMINE_TIMEOUT`. I measured this against a server that accepts connections and
never answers: while a call was hung, `/health` with a 10 second deadline got no
response at all. That is enough for a liveness probe to restart the pod.

## Fix

A new `_offload.py` provides `in_thread()` and an `@offloaded` decorator over
`asyncio.to_thread`. Each tool now runs its whole synchronous section in a
worker thread:

- 24 await-free tools and 43 action handlers are now plain `def` with
  `@offloaded`.
- 11 tools have to stay coroutines, so they wrap their synchronous remainder in
  a nested closure and pass it to `in_thread()`.
- The 8 `@action_dispatch` tools needed no change, since an offloaded handler is
  still awaitable.

Wrapping only the client call would not have been enough. python-redmine issues
its request on the first iteration of a result set rather than at `.filter()`,
and it re-fetches on attribute access for a field that was not included, so
iteration and serialization block too.

The cached legacy client is now per thread. Offloading would otherwise share one
`requests.Session` across threads, and the requests docs do not state that a
Session is thread safe.

`_get_redmine_client()` now raises if something calls it on the event loop
thread, so a tool that misses this treatment fails loudly rather than quietly
blocking again. Tests that drive the client factory directly opt out with
`allow_loop_thread()`.

`import_time_entries` had an `await asyncio.sleep(0)` between entries as a
partial mitigation. It did nothing while a single call hung, so I removed it and
rewrote its test to assert the real property instead of counting sleep calls.

This adds no environment variables and changes no user-visible configuration.

## Verification

| Check | Result |
|---|---|
| Unit suite | 1618 passed |
| Integration, Redmine 6.1, all plugin flags | 88 passed |
| Integration, Redmine 7.0 | 65 passed |
| black + flake8 on `src/` | clean |

I reproduced the original scenario with a socket that accepts connections and
never responds, then probed `/health` while a tool call hung for 30 seconds:

| | `/health` during the hung call |
|---|---|
| `develop` | HTTP 000, curl exit 28, timed out at 10s, 3 of 3 attempts |
| this branch | HTTP 200 in 5.01s, 3 of 3 attempts |

The 5.01s is the health endpoint's own probe timeout against the dead server,
not loop starvation.

`tests/test_offload.py` adds the heartbeat regression test from the issue, which
fails on `develop`. It also covers OAuth token propagation across the thread
hop, the guard, and the per-thread client, plus a static check that names the
exact file, line, and function if a blocking call is ever left on the loop.

I also updated `docs/contributing.md`, because its tool templates would
otherwise teach a pattern that now trips the guard.
