### PR TITLE
fix: advertise CRM scopes so manage_contact can reach Redmine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- `manage_contact` no longer fails for every action in OAuth mode. Redmine
+  intersects an OAuth token's scopes with the consenting user's role
+  permissions (`Role#allowed_permissions` is `unscoped & scope`), and every
+  contacts endpoint the tool calls runs a scope-aware authorization check --
+  `contacts#index` through `authorize_global`, `contacts#show` through
+  `Contact#visible?`, and the mutations through `authorize`,
+  `Contact#editable?` and `Contact#deletable?`. Since the CRM permissions were
+  never advertised, no token could carry them and all seven actions were denied
+  even for users whose Redmine role granted the permission. Setting
+  `REDMINE_CRM_ENABLED=true` now adds `view_contacts` and
+  `view_private_contacts` to the advertised scopes, plus `add_contacts`,
+  `edit_contacts` and `delete_contacts` unless `REDMINE_MCP_READ_ONLY` is set,
+  following the existing `REDMINE_AGILE_ENABLED` / `REDMINE_TAGS_ENABLED`
+  pattern. Deployments enabling the flag must grant the new scopes on the
+  Redmine OAuth application and have users re-consent.
+
 ### Tests
 - Unit coverage for `_auth.py`, raised from 63% to 100%. The whole
   `revoke_token` RFC 7009 proxy was untested, along with the fail-fast branch

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ The server runs on `http://localhost:8000` with the MCP endpoint at `/mcp`, heal
 | `REDMINE_AGILE_ENABLED` | No | `false` | Enable RedmineUP Agile plugin support: `get_redmine_issue` returns `story_points`, `agile_sprint_id`, `agile_position`; `update_redmine_issue` accepts `story_points` |
 | `REDMINE_CHECKLISTS_ENABLED` | No | `false` | Enable RedmineUP Checklists plugin support: `get_checklist`, `create_checklist_item`, `update_checklist_item` (requires Checklists Pro plugin) |
 | `REDMINE_PRODUCTS_ENABLED` | No | `false` | Enable RedmineUP Products plugin support: `manage_product` (action=list/get/create/update) |
-| `REDMINE_CRM_ENABLED` | No | `false` | Enable RedmineUP CRM plugin support: `manage_contact` (action=list/get/create/update/delete/assign_to_project/remove_from_project) |
+| `REDMINE_CRM_ENABLED` | No | `false` | Enable RedmineUP CRM plugin support: `manage_contact` (action=list/get/create/update/delete/assign_to_project/remove_from_project). Requires the CRM plugin and the `view_contacts` / `view_private_contacts` permissions on the Redmine server, plus `add_contacts` / `edit_contacts` / `delete_contacts` for the write actions. In OAuth mode these are advertised as scopes only when this flag is set, so the OAuth application must grant them too. |
 | `REDMINE_DMSF_ENABLED` | No | `false` | Enable DMSF document-management plugin support: `manage_document` (action=list/get/create/update). Requires `redmine_dmsf` plugin on the Redmine server. |
 | `REDMINE_TAGS_ENABLED` | No | `false` | Enable AlphaNodes additional_tags plugin support: `get_redmine_issue` returns a `tags` array, and `create_redmine_issue`/`update_redmine_issue` accept a `tag_list`. Requires the `additional_tags` plugin and the `view_issue_tags` / `create_issue_tags` / `edit_issue_tags` permissions on the Redmine server. |
 | `REDMINE_AUTOFILL_REQUIRED_CUSTOM_FIELDS` | No | `false` | Enable one retry for issue creation by filling missing required custom fields |
@@ -588,7 +588,7 @@ var. Skipping a plugin costs you only that plugin's features.
 | [Agile](https://www.redmineup.com/pages/plugins/agile) | RedmineUP | `REDMINE_AGILE_ENABLED` | `get_redmine_issue` returns `story_points`, `agile_sprint_id`, `agile_position`; `update_redmine_issue` accepts `story_points` |
 | [Checklists](https://www.redmineup.com/pages/plugins/checklists) | RedmineUP (Pro) | `REDMINE_CHECKLISTS_ENABLED` | 3 tools: `get_checklist`, `create_checklist_item`, `update_checklist_item` |
 | [Products](https://www.redmineup.com/pages/plugins/products) | RedmineUP | `REDMINE_PRODUCTS_ENABLED` | 1 tool: `manage_product` |
-| [CRM](https://www.redmineup.com/pages/plugins/crm) | RedmineUP | `REDMINE_CRM_ENABLED` | 1 tool: `manage_contact` |
+| [CRM](https://www.redmineup.com/pages/plugins/crm) | RedmineUP | `REDMINE_CRM_ENABLED` | 1 tool: `manage_contact` (adds the `*_contacts` scopes to OAuth discovery when enabled) |
 | [DMSF](https://github.com/danmunn/redmine_dmsf) | danmunn (open source) | `REDMINE_DMSF_ENABLED` | 1 tool: `manage_document` |
 | [Additional Tags](https://github.com/alphanodes/additional_tags) | AlphaNodes (open source) | `REDMINE_TAGS_ENABLED` | `get_redmine_issue` returns a `tags` array; `create_redmine_issue` / `update_redmine_issue` accept `tag_list` |
 
@@ -691,7 +691,7 @@ These tools require a corresponding Redmine plugin installed on the server **and
 - **Products** (1 tool): set `REDMINE_PRODUCTS_ENABLED=true`; requires the [RedmineUP Products plugin](https://www.redmineup.com/pages/plugins/products)
   - [`manage_product`](docs/tool-reference.md#manage_product) - List, get, create, or update products
 
-- **Contacts (CRM)** (1 tool): set `REDMINE_CRM_ENABLED=true`; requires the [RedmineUP CRM plugin](https://www.redmineup.com/pages/plugins/crm)
+- **Contacts (CRM)** (1 tool): set `REDMINE_CRM_ENABLED=true`; requires the [RedmineUP CRM plugin](https://www.redmineup.com/pages/plugins/crm). In OAuth mode the flag also adds the CRM permissions to the advertised scopes, so grant them on the OAuth application and have users re-consent
   - [`manage_contact`](docs/tool-reference.md#manage_contact) - List, get, create, update, delete, or assign/remove project association for contacts
 
 - **Documents (DMSF)** (1 tool): set `REDMINE_DMSF_ENABLED=true`; requires the [`redmine_dmsf` plugin](https://github.com/danmunn/redmine_dmsf)

--- a/docs/oauth-setup.md
+++ b/docs/oauth-setup.md
@@ -213,8 +213,14 @@ Notes:
   `parent_issue_id`, or tag scopes for `tag_list`) are still enforced
   by Redmine itself.
 - RedmineUP plugin tools (`manage_product`, `manage_contact`,
-  checklists) cannot require plugin scopes because those are not
-  advertised; Redmine enforces its own plugin permissions for them.
+  checklists) do not require plugin scopes in the map; Redmine enforces
+  its own plugin permissions for them. `manage_contact` is a special
+  case: when `REDMINE_CRM_ENABLED` is set, the CRM permissions are added
+  to the advertised scopes, because Redmine intersects a token's scopes
+  with the user's role permissions and would otherwise deny every
+  contacts call. They are advertised so the token can carry them, but
+  not required here, since a CRM-disabled deployment never advertises
+  them. Grant them on the OAuth application when enabling the flag.
 - A notes-only `update_redmine_issue` call (fields containing nothing but
   `notes` / `private_notes`, no uploads) requires `add_issue_notes` instead
   of `edit_issues`, mirroring Redmine's own note-adding permission.

--- a/docs/tool-reference.md
+++ b/docs/tool-reference.md
@@ -2305,7 +2305,7 @@ These tools require the **RedmineUP CRM** plugin and `REDMINE_CRM_ENABLED=true`.
 
 List, get, create, update, delete, or change project association for RedmineUP CRM contacts. Replaces `list_contacts`, `get_contact`, `create_contact`, `edit_contact`, `delete_contact`, `assign_contact_to_project`, and `remove_contact_from_project`.
 
-Requires the **RedmineUP CRM** plugin and `REDMINE_CRM_ENABLED=true`. Visibility scoping is enforced server-side by Redmine.
+Requires the **RedmineUP CRM** plugin and `REDMINE_CRM_ENABLED=true`. Visibility scoping is enforced server-side by Redmine. In OAuth mode the token must also carry the CRM permissions (`view_contacts`, `view_private_contacts`, and `add_contacts` / `edit_contacts` / `delete_contacts` for writes); enabling the flag advertises them as scopes, and the OAuth application has to grant them.
 
 **Parameters:**
 - `action` (string, required): Allowed: `list`, `get`, `create`, `update`, `delete`, `assign_to_project`, `remove_from_project`

--- a/src/redmine_mcp_server/oauth_scopes.py
+++ b/src/redmine_mcp_server/oauth_scopes.py
@@ -20,14 +20,24 @@ Exclusions:
       per-permission checks; default-advertising it would mean every
       consent screen requests full administrative access.
     - Vendor plugin scopes (Easy Redmine, RedmineUP, agile, checklists,
-      CRM, products) are excluded. They vary by deployment; advertising
-      scopes a Redmine doesn't recognize causes consent errors.
+      CRM, products) are excluded from ``READ_SCOPES`` and
+      ``WRITE_SCOPES``. They vary by deployment; advertising scopes a
+      Redmine doesn't recognize causes consent errors. Where a tool
+      cannot function without them, they live in a feature-gated list
+      (``AGILE_READ_SCOPES``, ``TAGS_READ_SCOPES``,
+      ``TAGS_WRITE_SCOPES``, ``CRM_READ_SCOPES``, ``CRM_WRITE_SCOPES``)
+      and are advertised only when that feature's env flag is set.
 """
 
 import os
 from typing import Dict, Optional, Union
 
-from ._env import _is_agile_enabled, _is_read_only_mode, _is_tags_enabled
+from ._env import (
+    _is_agile_enabled,
+    _is_crm_enabled,
+    _is_read_only_mode,
+    _is_tags_enabled,
+)
 
 # Redmine permissions used by the read-only MCP tools.
 READ_SCOPES: list[str] = [
@@ -108,6 +118,40 @@ TAGS_WRITE_SCOPES: list[str] = [
     "edit_issue_tags",
 ]
 
+# RedmineUP CRM plugin permissions, advertised only when the CRM feature is
+# explicitly enabled (see below). Kept out of READ_SCOPES so a deployment
+# without the plugin never advertises a scope Redmine can't resolve.
+#
+# manage_contact cannot reach Redmine without these. Redmine intersects the
+# token's scopes with the user's role permissions -- Role#allowed_permissions
+# is literally ``unscoped & scope`` -- and every contacts endpoint the tool
+# calls runs a scope-aware authorization check: ContactsController#index via
+# find_optional_project -> authorize_global, #show via Contact#visible?, and
+# create / update / destroy via authorize, Contact#editable? and
+# Contact#deletable?. With the scopes absent from the token, all seven
+# manage_contact actions are denied even for a user whose Redmine role grants
+# the permission.
+CRM_READ_SCOPES: list[str] = [
+    "view_contacts",  # manage_contact(action=list|get): the plugin maps
+    # contacts#index and contacts#show to this permission.
+    "view_private_contacts",  # Contact.visible_condition also consults this
+    # for visibility=2 contacts. Without it, list
+    # and get silently omit private contacts that
+    # the user's role can otherwise see.
+]
+
+# RedmineUP CRM write permissions, advertised only when the CRM feature is
+# enabled AND the server is not read-only, matching the WRITE action modes
+# manage_contact declares.
+CRM_WRITE_SCOPES: list[str] = [
+    "add_contacts",  # manage_contact(action=create)
+    "edit_contacts",  # manage_contact(action=update), and both association
+    # actions: the plugin maps contacts_projects#create
+    # and #destroy to edit_contacts, and
+    # ContactsProjectsController checks it directly.
+    "delete_contacts",  # manage_contact(action=delete)
+]
+
 
 def advertised_scopes() -> list[str]:
     """Return the OAuth scopes to advertise in discovery documents.
@@ -121,8 +165,12 @@ def advertised_scopes() -> list[str]:
     non-agile Redmine never sees an unrecognized plugin scope. The same
     applies to :data:`TAGS_READ_SCOPES` under ``REDMINE_TAGS_ENABLED``;
     :data:`TAGS_WRITE_SCOPES` are additionally appended unless the server
-    is read-only, since they gate ``tag_list`` writes. Always returns a
-    fresh list so callers cannot mutate the source of truth.
+    is read-only, since they gate ``tag_list`` writes. :data:`CRM_READ_SCOPES`
+    follow the same rule under ``REDMINE_CRM_ENABLED`` (per
+    :func:`_is_crm_enabled`), with :data:`CRM_WRITE_SCOPES` appended unless
+    the server is read-only, since ``manage_contact`` cannot pass Redmine's
+    authorization checks without them. Always returns a fresh list so callers
+    cannot mutate the source of truth.
     """
     if _is_read_only_mode():
         scopes = list(READ_SCOPES)
@@ -134,6 +182,10 @@ def advertised_scopes() -> list[str]:
         scopes += list(TAGS_READ_SCOPES)
         if not _is_read_only_mode():
             scopes += list(TAGS_WRITE_SCOPES)
+    if _is_crm_enabled():
+        scopes += list(CRM_READ_SCOPES)
+        if not _is_read_only_mode():
+            scopes += list(CRM_WRITE_SCOPES)
     return scopes
 
 
@@ -293,9 +345,12 @@ TOOL_SCOPES: Dict[str, ToolScopeEntry] = {
     "get_checklist": frozenset({"view_issues"}),
     "create_checklist_item": frozenset({"edit_issues"}),
     "update_checklist_item": frozenset({"edit_issues"}),
-    # --- products / CRM (RedmineUP plugins; vendor scopes are not
-    # advertised and cannot be required; Redmine enforces its own
-    # plugin permissions) ---
+    # --- products / CRM (RedmineUP plugins; Redmine enforces its own
+    # plugin permissions, so these stay unrequired here. CRM scopes ARE
+    # advertised when REDMINE_CRM_ENABLED is set, so the token can reach
+    # the contacts endpoints at all, but requiring them in this map would
+    # gate the tool on a scope that a CRM-disabled deployment never
+    # advertises. Product scopes are not advertised at all yet.) ---
     "manage_product": frozenset(),
     "manage_contact": frozenset(),
     # --- MCP Apps (read-only issue queries) ---

--- a/tests/test_oauth_scopes.py
+++ b/tests/test_oauth_scopes.py
@@ -125,6 +125,33 @@ class TestScopeConstants:
         assert "view_agile_queries" not in READ_SCOPES
         assert "view_agile_queries" not in WRITE_SCOPES
 
+    def test_crm_read_scopes_cover_the_contact_read_endpoints(self):
+        """manage_contact(list|get) hits contacts#index and contacts#show."""
+        from redmine_mcp_server.oauth_scopes import CRM_READ_SCOPES
+
+        assert "view_contacts" in CRM_READ_SCOPES
+        assert "view_private_contacts" in CRM_READ_SCOPES
+
+    def test_crm_write_scopes_cover_the_contact_write_endpoints(self):
+        """create / update / delete / assign / remove need these three."""
+        from redmine_mcp_server.oauth_scopes import CRM_WRITE_SCOPES
+
+        assert "add_contacts" in CRM_WRITE_SCOPES
+        assert "edit_contacts" in CRM_WRITE_SCOPES
+        assert "delete_contacts" in CRM_WRITE_SCOPES
+
+    def test_crm_scopes_not_in_core_scope_lists(self):
+        """CRM scopes are opt-in only; core lists stay plugin-free."""
+        from redmine_mcp_server.oauth_scopes import (
+            CRM_READ_SCOPES,
+            CRM_WRITE_SCOPES,
+            READ_SCOPES,
+            WRITE_SCOPES,
+        )
+
+        core = set(READ_SCOPES) | set(WRITE_SCOPES)
+        assert not core & (set(CRM_READ_SCOPES) | set(CRM_WRITE_SCOPES))
+
 
 # ---------------------------------------------------------------------------
 # advertised_scopes()
@@ -275,3 +302,53 @@ class TestAdvertisedScopes:
         scopes = advertised_scopes()
         assert "create_issue_tags" not in scopes
         assert "edit_issue_tags" not in scopes
+
+    @pytest.mark.parametrize("value", ["true", "1", "yes", "on", "TRUE"])
+    def test_includes_crm_scopes_when_crm_enabled(self, monkeypatch, value):
+        monkeypatch.delenv("REDMINE_MCP_READ_ONLY", raising=False)
+        monkeypatch.setenv("REDMINE_CRM_ENABLED", value)
+        from redmine_mcp_server.oauth_scopes import advertised_scopes
+
+        scopes = advertised_scopes()
+        assert "view_contacts" in scopes
+        assert "add_contacts" in scopes
+
+    @pytest.mark.parametrize("value", ["false", "0", "no", "off", ""])
+    def test_excludes_crm_scopes_when_crm_disabled(self, monkeypatch, value):
+        monkeypatch.delenv("REDMINE_MCP_READ_ONLY", raising=False)
+        monkeypatch.setenv("REDMINE_CRM_ENABLED", value)
+        from redmine_mcp_server.oauth_scopes import advertised_scopes
+
+        scopes = advertised_scopes()
+        assert "view_contacts" not in scopes
+        assert "add_contacts" not in scopes
+
+    def test_excludes_crm_scopes_when_env_unset(self, monkeypatch):
+        monkeypatch.delenv("REDMINE_MCP_READ_ONLY", raising=False)
+        monkeypatch.delenv("REDMINE_CRM_ENABLED", raising=False)
+        from redmine_mcp_server.oauth_scopes import advertised_scopes
+
+        scopes = advertised_scopes()
+        assert "view_contacts" not in scopes
+        assert "add_contacts" not in scopes
+
+    def test_crm_read_scopes_present_in_read_only_mode(self, monkeypatch):
+        """view_contacts is a read permission, so read-only keeps it."""
+        monkeypatch.setenv("REDMINE_MCP_READ_ONLY", "true")
+        monkeypatch.setenv("REDMINE_CRM_ENABLED", "true")
+        from redmine_mcp_server.oauth_scopes import advertised_scopes
+
+        scopes = advertised_scopes()
+        assert "view_contacts" in scopes
+        assert "view_private_contacts" in scopes
+
+    def test_excludes_crm_write_scopes_in_read_only_mode(self, monkeypatch):
+        """add/edit/delete_contacts are writes: read-only drops them."""
+        monkeypatch.setenv("REDMINE_MCP_READ_ONLY", "true")
+        monkeypatch.setenv("REDMINE_CRM_ENABLED", "true")
+        from redmine_mcp_server.oauth_scopes import advertised_scopes
+
+        scopes = advertised_scopes()
+        assert "add_contacts" not in scopes
+        assert "edit_contacts" not in scopes
+        assert "delete_contacts" not in scopes


### PR DESCRIPTION
## Summary

Fixes #220.

`manage_contact` is denied by Redmine for every action in `oauth` and `oauth-proxy` mode, because the RedmineUP CRM permissions are never advertised as scopes and Redmine intersects a token's scopes with the consenting user's role permissions (`Role#allowed_permissions` is `unscoped & scope`). No token could carry `view_contacts`, so all seven actions failed even for users whose role granted the permission.

This follows the existing `REDMINE_AGILE_ENABLED` / `REDMINE_TAGS_ENABLED` pattern: the plugin permissions live in their own lists and are advertised only when that plugin's feature flag is set, so a deployment without the plugin never advertises a scope its Redmine cannot resolve.

`TOOL_SCOPES` is deliberately left alone. The scopes are advertised so tokens can carry them, not *required* per tool — requiring them would gate the tool on a scope that a CRM-disabled deployment never advertises, and Redmine already enforces its own plugin permissions.

## Changes

- Add `CRM_READ_SCOPES` (`view_contacts`, `view_private_contacts`) and `CRM_WRITE_SCOPES` (`add_contacts`, `edit_contacts`, `delete_contacts`), each commented with the endpoint and the permission mapping that requires it.
- `advertised_scopes()` appends the read scopes when `REDMINE_CRM_ENABLED` is truthy, and the write scopes unless `REDMINE_MCP_READ_ONLY` is set.
- `view_private_contacts` is included because `Contact.visible_condition` consults it for `visibility=2` contacts; omitting it would silently narrow `list` / `get` results for a user whose role grants it — the same failure mode this PR fixes, one level down.
- `edit_contacts` covers `assign_to_project` and `remove_from_project`: the plugin maps `contacts_projects#create` / `#destroy` to it, and `ContactsProjectsController` also checks it directly.
- Update the module docstring's Exclusions note and the `TOOL_SCOPES` comment, which both claimed CRM scopes are never advertised.
- Docs: README env table, plugin table and gated-tool list; `docs/oauth-setup.md` scope-enforcement note; `docs/tool-reference.md` `manage_contact` prerequisites.
- 8 new tests covering the constants, flag gating across truthy/falsy/unset values, and read-only behaviour.

## Testing

```
python tests/run_tests.py --all
  1651 passed (unit)
  13 passed, 76 skipped (integration; skips need a live Redmine)

uv run black --check src/     All done! 39 files would be left unchanged.
uv run flake8 src/ --max-line-length=88     clean
```

`tests/test_ssl_integration.py` needs `tests/fixtures/ssl/generate-test-certs.sh` run first, otherwise one test fails on the missing fixture on a clean checkout too.

The live-Redmine integration tests are skipped here, so the end-to-end consent-and-call path against a Redmine with the CRM plugin has not been exercised in CI. `advertised_scopes()` gating is covered by unit tests.

## Checklist

- [x] `python tests/run_tests.py --all` passes (activate `.venv` first)
- [x] `uv run black --check src/` and `uv run flake8 src/ --max-line-length=88` are clean
- [x] `CHANGELOG.md` [Unreleased] has a bullet for user-facing changes
- [x] No manual version bumps: `pyproject.toml`, `server.json`, and CHANGELOG version headers untouched
- [x] Docs updated where behavior changed: README stays concise, details in `docs/tool-reference.md` and `docs/oauth-setup.md`
- [x] Change works with both local and Docker deployments (config-only change, no new dependency or runtime requirement)

### Note for deployers

Enabling `REDMINE_CRM_ENABLED` now widens the advertised scope set. Those scopes must also be granted on the Redmine OAuth application, and existing users have to re-consent, since Doorkeeper freezes a token's granted scopes at issue time. Deployments that pin the advertised scope count in their own checks will see it change. Called out in the CHANGELOG.
