### PR TITLE
fix: read issue includes from the payload instead of re-fetching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Fixed
+- `include=relations` is no longer discarded and re-fetched per issue.
+  python-redmine lists `relations` in both `Issue._includes` and
+  `Issue._relations`, and `BaseResource.__getattr__` tests `_relations` first,
+  so `getattr(issue, "relations")` ignored the payload the `include` had
+  already fetched and handed back a lazy resource set that requested
+  `GET /issues/{id}/relations.json` as soon as it was iterated. Redmine maps
+  that endpoint's `index` action to `manage_issue_relations`, a permission
+  reading an issue does not imply -- and one carrying no `:read => true` flag,
+  so it is also withheld in closed and archived projects. Callers holding
+  `view_issues` were therefore denied relations Redmine had already sent them.
+  Relations now come from the response payload: `get_redmine_issue(
+  include_relations=True)` works with `view_issues` alone, and
+  `get_gantt_chart` drops from one extra request per issue to none
+  ([#222](https://github.com/jztan/redmine-mcp-server/issues/222)). Each
+  relation now also carries Redmine's `delay` field, which the single-issue
+  path had omitted.
+- `delete_redmine_issue` no longer makes unguarded extra requests while
+  building its impact preview. All four included collections were read through
+  resource attributes rather than the payload, outside the `try` that wraps the
+  fetch, so the request each one could trigger escaped as an unhandled
+  exception instead of an error envelope -- before the confirmation gate. Two
+  of them really did fire: `relations` always, and `children` for every leaf
+  issue, because Redmine omits that key entirely (`render_api_issue_children`
+  returns early on `issue.leaf?`) and python-redmine re-fetches a missing
+  include. All four now come from the payload, which is what the code's own
+  comment always said the preview did. `time_entries` is the one count Redmine
+  has no issue include for, so it still needs its own request: a caller without
+  `view_time_entries` now sees `time_entries_count: null` rather than `0`,
+  which would have understated an irreversible cascade, and any other failure
+  returns a normal error envelope instead of being reported as a permission
+  problem.
 - `manage_contact` no longer fails for every action in OAuth mode. Redmine
   intersects an OAuth token's scopes with the consenting user's role
   permissions (`Role#allowed_permissions` is `unscoped & scope`), and every
@@ -25,6 +56,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Redmine OAuth application and have users re-consent.
 
 ### Tests
+- New `tests/test_relations_payload.py` covers reading relations from the
+  include payload, an absent include, an empty include, the Gantt path issuing
+  one request for a whole chart, the leaf-issue `children` case, and the delete
+  preview both surviving a caller without `manage_issue_relations` and
+  refusing to report an unreadable time-entry count as zero. The existing
+  relation fakes in `tests/test_gantt.py`,
+  `tests/test_delete_redmine_issue.py` and `tests/test_redmine_handler.py`
+  exposed `relations` as a plain attribute, which no python-redmine issue ever
+  does; they now serve includes from `raw()` and raise on the attribute, so
+  this class of bug fails in CI instead of only against a live Redmine.
 - Unit coverage for `_auth.py`, raised from 63% to 100%. The whole
   `revoke_token` RFC 7009 proxy was untested, along with the fail-fast branch
   that rejects a missing `REDMINE_URL` at boot. New

--- a/docs/tool-reference.md
+++ b/docs/tool-reference.md
@@ -531,7 +531,7 @@ Retrieve detailed information about a specific Redmine issue.
 - `journal_limit` (integer, optional): Maximum number of journals to return. When set, enables journal pagination and adds `journal_pagination` metadata. Default: `null` (all journals)
 - `journal_offset` (integer, optional): Number of journals to skip (used with `journal_limit`). Default: `0`
 - `include_watchers` (boolean, optional): Include watcher list. Default: `false`
-- `include_relations` (boolean, optional): Include issue relations. Default: `false`
+- `include_relations` (boolean, optional): Include issue relations. Default: `false`. Requires only `view_issues`. Each entry is `{id, issue_id, issue_to_id, relation_type, delay}`.
 - `include_children` (boolean, optional): Include child issues. Default: `false`
 
 
@@ -1055,6 +1055,15 @@ For other lifecycle operations, use [`create_redmine_issue`](#create_redmine_iss
 }
 ```
 
+`time_entries_count` is `null` when the count could not be read. Redmine has
+no `time_entries` include for an issue, so it is the one count that needs its
+own request, and that request needs `view_time_entries` — which permission to
+read the issue does not imply. A caller lacking it sees `null` rather than
+`0`, because `0` would understate an irreversible cascade. Any other failure
+reading it returns a normal error envelope instead. The other four counts come
+from the issue payload and cost no extra request, including `children`, which
+is absent from the payload for a leaf issue and counts as zero.
+
 **Success envelope:**
 ```json
 {
@@ -1071,6 +1080,9 @@ For other lifecycle operations, use [`create_redmine_issue`](#create_redmine_iss
     }
 }
 ```
+
+`cascade_deleted` carries the same shape as `impact` above, so
+`time_entries_count` can be `null` there too.
 
 **Error codes:** `CONFIRMATION_REQUIRED`, `CHILDREN_PRESENT`, `NOT_FOUND` (with `upstream_status: 404`).
 

--- a/src/redmine_mcp_server/_serialization.py
+++ b/src/redmine_mcp_server/_serialization.py
@@ -16,6 +16,9 @@ _DEFAULT_LIST_RESULT_CAP = 500
 # this regardless of what the caller asks for.
 _REDMINE_API_PAGE_CAP = 100
 
+# Redmine's own relation keys, from app/views/issues/index.api.rsb.
+_ISSUE_RELATION_FIELDS = ("id", "issue_id", "issue_to_id", "relation_type", "delay")
+
 
 def wrap_insecure_content(content: Any) -> Any:
     """Wrap user-controlled content in boundary tags to prevent prompt injection.
@@ -126,6 +129,47 @@ def _iter_capped(resources: Any, cap: int = _DEFAULT_LIST_RESULT_CAP) -> List[An
             break
         out.append(item)
     return out
+
+
+def _included_list(resource: Any, key: str) -> List[Any]:
+    """Read an ``include=`` collection from the payload Redmine already sent.
+
+    Use this instead of ``getattr(resource, key)`` for any name python-redmine
+    treats as a relation. ``BaseResource.__getattr__`` tests ``_relations``
+    before ``_includes``, and ``Issue`` lists ``relations`` in both, so the
+    attribute ignores an ``include=relations`` payload and hands back a lazy
+    resource set that fetches ``GET /issues/{id}/relations.json`` the moment it
+    is iterated. Redmine maps that endpoint to ``manage_issue_relations``,
+    which reading the issue does not imply, so the attribute turns an
+    already-satisfied request into an extra round trip that can also be denied.
+
+    ``raw()`` is python-redmine's accessor for the decoded payload. A key that
+    was never included reads as ``None`` there and is reported as empty, so
+    callers must have asked Redmine for the include -- this never fetches, and
+    cannot tell "no relations" from "never requested".
+    """
+    payload = resource.raw()
+    value = payload.get(key) if isinstance(payload, dict) else None
+    return list(value) if isinstance(value, list) else []
+
+
+def _issue_relation_to_dict(relation: Any) -> Dict[str, Any]:
+    """Convert an issue relation to a serializable dict.
+
+    Accepts either a payload dict from ``_included_list`` or a python-redmine
+    ``IssueRelation`` from ``issue_relation.filter``.
+    """
+    if isinstance(relation, dict):
+        return {key: relation.get(key) for key in _ISSUE_RELATION_FIELDS}
+    return {key: getattr(relation, key, None) for key in _ISSUE_RELATION_FIELDS}
+
+
+def _issue_relations_to_list(issue: Any) -> List[Dict[str, Any]]:
+    """Serialize an issue's relations from its ``include=relations`` payload.
+
+    Never fetches; see ``_included_list``.
+    """
+    return [_issue_relation_to_dict(rel) for rel in _included_list(issue, "relations")]
 
 
 def _attachment_to_dict(attachment: Any) -> Dict[str, Any]:

--- a/src/redmine_mcp_server/tools/gantt.py
+++ b/src/redmine_mcp_server/tools/gantt.py
@@ -1,6 +1,6 @@
 """Gantt chart tool — composite read tool for project timeline data."""
 
-from typing import Annotated, Any, Dict, List, Optional, Union
+from typing import Annotated, Any, Dict, Optional, Union
 
 from pydantic import Field
 
@@ -11,6 +11,7 @@ from .._serialization import (
     _DEFAULT_LIST_RESULT_CAP,
     _iter_capped,
     _named_ref,
+    _issue_relations_to_list,
     _safe_isoformat,
 )
 from .._validation import _is_valid_project_id
@@ -42,23 +43,14 @@ def _gantt_issue_to_dict(issue: Any) -> Dict[str, Any]:
         "parent_id": parent_id,
     }
 
-    rel_list: List[Dict[str, Any]] = []
-    relations = getattr(issue, "relations", None)
-    if relations is not None:
-        for rel in _iter_capped(relations):
-            rel_type = getattr(rel, "relation_type", None)
-            if rel_type not in {"precedes", "blocks"}:
-                continue
-            rel_list.append(
-                {
-                    "id": getattr(rel, "id", None),
-                    "relation_type": rel_type,
-                    "issue_id": getattr(rel, "issue_id", None),
-                    "issue_to_id": getattr(rel, "issue_to_id", None),
-                    "delay": getattr(rel, "delay", None),
-                }
-            )
-    out["relations"] = rel_list
+    # From the include= payload get_gantt_chart requests, not the lazy
+    # issue.relations attribute, which cost one request per issue --
+    # see _included_list.
+    out["relations"] = [
+        rel
+        for rel in _issue_relations_to_list(issue)
+        if rel.get("relation_type") in {"precedes", "blocks"}
+    ]
     return out
 
 

--- a/src/redmine_mcp_server/tools/issues.py
+++ b/src/redmine_mcp_server/tools/issues.py
@@ -7,7 +7,12 @@ import logging
 from typing import Annotated, Any, Dict, List, Literal, Optional, Set, Union
 
 from pydantic import Field
-from redminelib.exceptions import ResourceNotFoundError, ValidationError
+from redminelib.exceptions import (
+    AuthError,
+    ForbiddenError,
+    ResourceNotFoundError,
+    ValidationError,
+)
 
 from .._cleanup import _ensure_cleanup_started
 from .._client import _get_redmine_client, logger
@@ -28,8 +33,11 @@ from .._offload import in_thread, offloaded
 from .._serialization import (
     _attachment_to_dict,
     _coerce_json_safe,
+    _included_list,
+    _issue_relation_to_dict,
     _iter_capped,
     _named_ref,
+    _issue_relations_to_list,
     _safe_isoformat,
     wrap_insecure_content,
 )
@@ -644,17 +652,6 @@ def _augment_with_upload_result(result: Dict[str, Any], issue: Any) -> Dict[str,
     return result
 
 
-def _issue_relation_to_dict(relation: Any) -> Dict[str, Any]:
-    """Convert a python-redmine IssueRelation object to a serializable dict."""
-    return {
-        "id": getattr(relation, "id", None),
-        "issue_id": getattr(relation, "issue_id", None),
-        "issue_to_id": getattr(relation, "issue_to_id", None),
-        "relation_type": getattr(relation, "relation_type", None),
-        "delay": getattr(relation, "delay", None),
-    }
-
-
 def _issue_category_to_dict(category: Any) -> Dict[str, Any]:
     """Convert a python-redmine IssueCategory object to a serializable dict."""
     project = getattr(category, "project", None)
@@ -728,6 +725,15 @@ async def get_redmine_issue(
             metadata to the response.
         journal_offset: Number of journals to skip (used with
             ``journal_limit``). Defaults to ``0``.
+        include_watchers: Whether to include the issue's watchers, returned
+            under ``watchers`` as ``[{"id", "name"}, ...]``. Defaults to
+            ``False``.
+        include_relations: Whether to include the issue's relations, returned
+            under ``relations`` as ``[{"id", "issue_id", "issue_to_id",
+            "relation_type", "delay"}, ...]``. Defaults to ``False``.
+        include_children: Whether to include the issue's direct children,
+            returned under ``children`` as ``[{"id", "subject", "tracker"},
+            ...]``. Defaults to ``False``.
 
     Returns:
         A dictionary containing issue details, including the standard fields
@@ -799,16 +805,9 @@ async def get_redmine_issue(
                 raw = getattr(issue, "watchers", None) or []
                 result["watchers"] = [{"id": w.id, "name": w.name} for w in raw]
             if include_relations:
-                raw = getattr(issue, "relations", None) or []
-                result["relations"] = [
-                    {
-                        "id": r.id,
-                        "issue_id": r.issue_id,
-                        "issue_to_id": r.issue_to_id,
-                        "relation_type": r.relation_type,
-                    }
-                    for r in raw
-                ]
+                # From the include= payload, not the lazy issue.relations
+                # attribute -- see _included_list.
+                result["relations"] = _issue_relations_to_list(issue)
             if include_children:
                 raw = getattr(issue, "children", None) or []
                 result["children"] = [
@@ -2078,13 +2077,15 @@ async def delete_redmine_issue(
         return {"error": "issue_id must be a positive integer."}
 
     def _run():
-        # Fetch the issue + lightweight cascade hints. The include flags
-        # below are cheap (Redmine returns them inline on the issue
-        # response) and let us populate a preview without separate API
-        # round-trips. Subtask count is best-effort: when present,
-        # ``children`` is included by Redmine; otherwise we treat
-        # children-count as 0 for the preview (the actual delete still
-        # cascades the same way regardless).
+        # Fetch the issue + lightweight cascade hints. Redmine returns all
+        # four included collections inline, so the preview costs one request --
+        # but only if the payload is what gets read. The resource attributes
+        # re-fetch instead: ``relations`` always does, and ``children`` does
+        # whenever Redmine omitted the key, which it does for every leaf issue
+        # (``render_api_issue_children`` returns early on ``issue.leaf?``).
+        # Subtask count stays best-effort: an absent ``children`` key counts as
+        # 0 for the preview, which is what the omission means. The actual
+        # delete cascades the same way regardless. See _included_list.
         try:
             issue = _get_redmine_client().issue.get(
                 issue_id,
@@ -2104,11 +2105,33 @@ async def delete_redmine_issue(
                 {"resource_type": "issue", "resource_id": issue_id},
             )
 
-        children = list(getattr(issue, "children", None) or [])
-        journals = list(getattr(issue, "journals", None) or [])
-        attachments = list(getattr(issue, "attachments", None) or [])
-        relations = list(getattr(issue, "relations", None) or [])
-        time_entries = list(getattr(issue, "time_entries", None) or [])
+        children = _included_list(issue, "children")
+        journals = _included_list(issue, "journals")
+        attachments = _included_list(issue, "attachments")
+        relations = _included_list(issue, "relations")
+
+        # Redmine has no time_entries include for an issue, so unlike the four
+        # counts above this one genuinely needs its own request.
+        try:
+            time_entries_count: Optional[int] = len(
+                list(getattr(issue, "time_entries", None) or [])
+            )
+        except (ForbiddenError, AuthError):
+            # Needs view_time_entries, which reading the issue does not imply.
+            # Reported as unknown rather than 0: this previews an irreversible
+            # cascade, and 0 would understate it.
+            logging.warning(
+                "Cannot read time entries for issue %s; reporting the count as "
+                "unknown in the delete preview.",
+                issue_id,
+            )
+            time_entries_count = None
+        except Exception as e:
+            return _handle_redmine_error(
+                e,
+                f"counting time entries for issue {issue_id}",
+                {"resource_type": "issue", "resource_id": issue_id},
+            )
 
         impact: Dict[str, Any] = {
             "issue_id": issue_id,
@@ -2117,7 +2140,7 @@ async def delete_redmine_issue(
             "journals_count": len(journals),
             "attachments_count": len(attachments),
             "relations_count": len(relations),
-            "time_entries_count": len(time_entries),
+            "time_entries_count": time_entries_count,
         }
 
         if not confirm_delete:

--- a/tests/test_delete_redmine_issue.py
+++ b/tests/test_delete_redmine_issue.py
@@ -10,20 +10,38 @@ from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
-from redminelib.exceptions import ResourceNotFoundError
+from redminelib.exceptions import ForbiddenError, ResourceNotFoundError
 
 from redmine_mcp_server.tools.issues import delete_redmine_issue
 
 
-def _make_issue(issue_id: int = 1, children=(), **extras) -> SimpleNamespace:
-    return SimpleNamespace(
+class _FakeIssue(SimpleNamespace):
+    """Serves ``include=`` collections from ``raw()``, as python-redmine does.
+
+    Touching ``.relations`` raises: in the real client it is a lazy relation
+    that fetches instead of reading the payload. See
+    tests/test_relations_payload.py for the full story.
+    """
+
+    @property
+    def relations(self):
+        raise ForbiddenError
+
+    def raw(self):
+        return dict(self._payload)
+
+
+def _make_issue(issue_id: int = 1, children=(), **extras) -> _FakeIssue:
+    return _FakeIssue(
         id=issue_id,
         subject=extras.get("subject", "Test issue"),
-        children=list(children),
-        journals=extras.get("journals", []),
-        attachments=extras.get("attachments", []),
-        relations=extras.get("relations", []),
         time_entries=extras.get("time_entries", []),
+        _payload={
+            "children": list(children),
+            "journals": extras.get("journals", []),
+            "attachments": extras.get("attachments", []),
+            "relations": extras.get("relations", []),
+        },
     )
 
 
@@ -103,7 +121,7 @@ class TestImpactPreview:
             children=[SimpleNamespace(id=1), SimpleNamespace(id=2)],
             journals=[SimpleNamespace(id=3), SimpleNamespace(id=4)],
             attachments=[SimpleNamespace(id=5)],
-            relations=[SimpleNamespace(id=6)],
+            relations=[{"id": 6}],
             time_entries=[
                 SimpleNamespace(id=7),
                 SimpleNamespace(id=8),

--- a/tests/test_gantt.py
+++ b/tests/test_gantt.py
@@ -2,9 +2,10 @@
 
 import os
 import sys
-from unittest.mock import Mock, patch
+from unittest.mock import Mock, PropertyMock, patch
 
 import pytest
+from redminelib.exceptions import ForbiddenError
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
@@ -36,8 +37,23 @@ def _make_issue(
         issue.parent = parent
     else:
         issue.parent = None
-    issue.relations = relations or []
+    _serve_relations_from_payload(issue, relations or [])
     return issue
+
+
+def _serve_relations_from_payload(issue: Mock, relations) -> None:
+    """Make ``relations`` reachable only the way Redmine actually sends them.
+
+    ``get_gantt_chart`` asks for ``include=relations``, so the relations are in
+    the issue payload. python-redmine's ``issue.relations`` attribute does not
+    read that payload: it is a lazy relation that issues
+    ``GET /issues/{id}/relations.json`` per issue, and that endpoint is mapped
+    to ``manage_issue_relations``. So the fake serves them from ``raw()`` and
+    raises on the attribute -- a regression to ``getattr`` fails here rather
+    than only against a live Redmine.
+    """
+    issue.raw.return_value = {"relations": list(relations)}
+    type(issue).relations = PropertyMock(side_effect=ForbiddenError)
 
 
 def _make_relation(
@@ -46,14 +62,15 @@ def _make_relation(
     issue_id: int,
     issue_to_id: int,
     delay=None,
-) -> Mock:
-    rel = Mock()
-    rel.id = rel_id
-    rel.relation_type = relation_type
-    rel.issue_id = issue_id
-    rel.issue_to_id = issue_to_id
-    rel.delay = delay
-    return rel
+) -> dict:
+    """A relation as it appears in an ``include=relations`` payload: a dict."""
+    return {
+        "id": rel_id,
+        "relation_type": relation_type,
+        "issue_id": issue_id,
+        "issue_to_id": issue_to_id,
+        "delay": delay,
+    }
 
 
 def _make_version(

--- a/tests/test_redmine_handler.py
+++ b/tests/test_redmine_handler.py
@@ -9,7 +9,8 @@ import os
 import sys
 
 import pytest
-from unittest.mock import Mock, patch
+from redminelib.exceptions import ForbiddenError
+from unittest.mock import Mock, PropertyMock, patch
 
 # Add the src directory to the path so we can import our modules
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
@@ -2184,14 +2185,24 @@ class TestGetRedmineIssueIncludeFlags:
         w2 = Mock(id=11)
         w2.name = "Watcher Two"
         issue.watchers = [w1, w2]
-        issue.relations = [
-            Mock(
-                id=5,
-                issue_id=123,
-                issue_to_id=456,
-                relation_type="relates",
-            )
-        ]
+        # Relations come from the include=relations payload, as dicts.
+        # python-redmine's issue.relations attribute does NOT read that
+        # payload -- it is a lazy relation that issues a separate
+        # GET /issues/{id}/relations.json, mapped to manage_issue_relations.
+        # So serve them from raw() and make the attribute raise, so a
+        # regression to getattr fails here and not only against a real Redmine.
+        issue.raw.return_value = {
+            "relations": [
+                {
+                    "id": 5,
+                    "issue_id": 123,
+                    "issue_to_id": 456,
+                    "relation_type": "relates",
+                    "delay": None,
+                }
+            ]
+        }
+        type(issue).relations = PropertyMock(side_effect=ForbiddenError)
         issue.children = [
             Mock(
                 id=200,

--- a/tests/test_relations_payload.py
+++ b/tests/test_relations_payload.py
@@ -1,0 +1,232 @@
+"""Regression tests for reading ``include=relations`` from the payload (#222).
+
+python-redmine lists ``relations`` in both ``Issue._includes`` and
+``Issue._relations``, and ``BaseResource.__getattr__`` tests ``_relations``
+first, so ``issue.relations`` never reads an ``include=relations`` payload: it
+issues a fresh ``GET /issues/{id}/relations.json``. That endpoint is mapped to
+``manage_issue_relations`` (``lib/redmine/preparation.rb``), a permission
+reading the issue does not imply, so the attribute both wasted the include and
+could be denied.
+
+These tests assert the property that matters and that a mock of the attribute
+cannot show: the tools read the payload and never touch the lazy attribute.
+"""
+
+import os
+import sys
+from unittest.mock import Mock, PropertyMock, patch
+
+import pytest
+from redminelib.exceptions import ForbiddenError
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from redmine_mcp_server._serialization import (  # noqa: E402
+    _included_list,
+    _issue_relations_to_list,
+)
+from redmine_mcp_server.tools.gantt import get_gantt_chart  # noqa: E402
+from redmine_mcp_server.tools.issues import (  # noqa: E402
+    delete_redmine_issue,
+    get_redmine_issue,
+)
+
+_PAYLOAD_RELATION = {
+    "id": 5,
+    "issue_id": 123,
+    "issue_to_id": 456,
+    "relation_type": "precedes",
+    "delay": 2,
+}
+
+
+def _issue_with_payload(relations, payload=None, **attrs):
+    """An issue whose included collections live only in the payload.
+
+    Touching ``.relations`` raises ``ForbiddenError``, standing in for the 403
+    a caller without ``manage_issue_relations`` gets from the lazy re-fetch.
+    """
+    issue = Mock()
+    issue.id = attrs.pop("id", 1)
+    issue.subject = attrs.pop("subject", "Test issue")
+    for key, value in attrs.items():
+        setattr(issue, key, value)
+    issue.raw.return_value = {**(payload or {}), "relations": list(relations)}
+    type(issue).relations = PropertyMock(side_effect=ForbiddenError)
+    return issue
+
+
+class TestIncludedList:
+    def test_reads_the_payload(self):
+        issue = _issue_with_payload([_PAYLOAD_RELATION])
+        assert _included_list(issue, "relations") == [_PAYLOAD_RELATION]
+
+    def test_absent_include_is_empty_not_an_error(self):
+        issue = Mock()
+        issue.raw.return_value = {"relations": None}
+        assert _included_list(issue, "relations") == []
+
+    def test_requested_but_empty_is_empty(self):
+        issue = Mock()
+        issue.raw.return_value = {"relations": []}
+        assert _included_list(issue, "relations") == []
+
+    def test_never_touches_the_lazy_attribute(self):
+        """The whole point: reading relations must not hit the attribute.
+
+        The fake raises on ``.relations``, so a regression to ``getattr``
+        fails here instead of only against a live Redmine.
+        """
+        issue = _issue_with_payload([_PAYLOAD_RELATION])
+        assert _issue_relations_to_list(issue) == [_PAYLOAD_RELATION]
+        issue.raw.assert_called()
+
+    def test_serializes_every_relation_field(self):
+        issue = _issue_with_payload([_PAYLOAD_RELATION])
+        assert _issue_relations_to_list(issue) == [
+            {
+                "id": 5,
+                "issue_id": 123,
+                "issue_to_id": 456,
+                "relation_type": "precedes",
+                "delay": 2,
+            }
+        ]
+
+
+class TestGetRedmineIssue:
+    @pytest.mark.asyncio
+    @patch("redmine_mcp_server._cleanup._ensure_cleanup_started")
+    @patch("redmine_mcp_server._client.redmine")
+    async def test_relations_come_from_the_include(self, mock_redmine, mock_cleanup):
+        mock_redmine.issue.get.return_value = _issue_with_payload(
+            [_PAYLOAD_RELATION],
+            description="d",
+            project=Mock(id=1, name="P"),
+            status=Mock(id=1, name="New"),
+            priority=Mock(id=2, name="Normal"),
+            author=Mock(id=1, name="A"),
+            assigned_to=None,
+            created_on=None,
+            updated_on=None,
+        )
+
+        result = await get_redmine_issue(1, include_relations=True)
+
+        assert result["relations"] == [_PAYLOAD_RELATION]
+        # The include was requested, and one request served the whole call.
+        assert "relations" in mock_redmine.issue.get.call_args[1]["include"]
+        assert mock_redmine.issue.get.call_count == 1
+
+
+class TestGanttChart:
+    @pytest.mark.asyncio
+    @patch("redmine_mcp_server._client.redmine")
+    async def test_no_extra_request_per_issue(self, mock_redmine):
+        """The N+1 this fixes: three issues used to mean three extra calls."""
+        issues = [
+            _issue_with_payload([dict(_PAYLOAD_RELATION, issue_id=n)], id=n)
+            for n in (1, 2, 3)
+        ]
+        for issue in issues:
+            issue.start_date = "2026-04-01"
+            issue.due_date = "2026-04-15"
+            issue.done_ratio = 0
+            issue.estimated_hours = 1.0
+            issue.parent = None
+        mock_redmine.issue.filter.return_value = issues
+        mock_redmine.version.filter.return_value = []
+
+        result = await get_gantt_chart(project_id="proj")
+
+        assert [len(i["relations"]) for i in result["issues"]] == [1, 1, 1]
+        # One issues.json call for the whole chart, plus the versions call.
+        assert mock_redmine.issue.filter.call_count == 1
+
+
+class TestDeletePreview:
+    """The delete preview read relations outside its own try/except."""
+
+    def _issue(self, **kw):
+        return _issue_with_payload(
+            kw.pop("relations", [_PAYLOAD_RELATION]),
+            payload={"children": [], "journals": [], "attachments": []},
+            **kw,
+        )
+
+    @pytest.mark.asyncio
+    @patch("redmine_mcp_server._client.redmine")
+    async def test_preview_survives_without_manage_issue_relations(self, mock_redmine):
+        """Previously raised out of the tool instead of returning the gate."""
+        mock_redmine.issue.get.return_value = self._issue(time_entries=[])
+
+        result = await delete_redmine_issue(issue_id=42)
+
+        assert result["code"] == "CONFIRMATION_REQUIRED"
+        assert result["impact"]["relations_count"] == 1
+        mock_redmine.issue.delete.assert_not_called()
+
+    @pytest.mark.asyncio
+    @patch("redmine_mcp_server._client.redmine")
+    async def test_unreadable_time_entries_are_not_reported_as_zero(self, mock_redmine):
+        """Redmine has no time_entries include, so that fetch is real and can
+        be denied. Saying "0" would understate an irreversible cascade."""
+        issue = self._issue()
+        type(issue).time_entries = PropertyMock(side_effect=ForbiddenError)
+        mock_redmine.issue.get.return_value = issue
+
+        result = await delete_redmine_issue(issue_id=42)
+
+        impact = result["impact"]
+        # Unknown, not 0 -- 0 would understate an irreversible cascade.
+        assert impact["time_entries_count"] is None
+        mock_redmine.issue.delete.assert_not_called()
+
+    @pytest.mark.asyncio
+    @patch("redmine_mcp_server._client.redmine")
+    async def test_leaf_issue_counts_children_from_the_payload(self, mock_redmine):
+        """Redmine omits ``children`` entirely for a leaf issue --
+        ``render_api_issue_children`` returns early on ``issue.leaf?`` -- and
+        python-redmine re-fetches whenever an include key is missing. That made
+        the preview fire an unguarded extra request on the common case. The
+        omission means zero, so the payload is the answer.
+        """
+        issue = _issue_with_payload(
+            [], payload={"journals": [], "attachments": []}, time_entries=[]
+        )
+        type(issue).children = PropertyMock(side_effect=ForbiddenError)
+        mock_redmine.issue.get.return_value = issue
+
+        result = await delete_redmine_issue(issue_id=42)
+
+        assert result["code"] == "CONFIRMATION_REQUIRED"
+        assert result["impact"]["children_count"] == 0
+        # One fetch for the whole preview.
+        assert mock_redmine.issue.get.call_count == 1
+
+    @pytest.mark.asyncio
+    @patch("redmine_mcp_server._client.redmine")
+    async def test_unexpected_time_entry_error_returns_an_envelope(self, mock_redmine):
+        """A 500 or dropped connection is not a permission problem, so it must
+        surface as an error rather than a silent 'unknown'."""
+        from redminelib.exceptions import ServerError
+
+        issue = self._issue()
+        type(issue).time_entries = PropertyMock(side_effect=ServerError)
+        mock_redmine.issue.get.return_value = issue
+
+        result = await delete_redmine_issue(issue_id=42)
+
+        assert "error" in result
+        mock_redmine.issue.delete.assert_not_called()
+
+    @pytest.mark.asyncio
+    @patch("redmine_mcp_server._client.redmine")
+    async def test_readable_time_entries_are_counted(self, mock_redmine):
+        mock_redmine.issue.get.return_value = self._issue(
+            time_entries=[Mock(id=1), Mock(id=2)]
+        )
+
+        result = await delete_redmine_issue(issue_id=42)
+
+        assert result["impact"]["time_entries_count"] == 2


### PR DESCRIPTION
## Summary

`include=relations` was requested and then thrown away. python-redmine lists `relations` in both `Issue._includes` and `Issue._relations`, and `BaseResource.__getattr__` tests `_relations` first, so `getattr(issue, "relations")` returns a lazy resource set that fetches `GET /issues/{id}/relations.json` instead of reading the payload. Redmine maps that endpoint's `index` to `manage_issue_relations` — a permission reading an issue does not imply, and one with no `:read => true` flag, so it is also withheld in closed and archived projects. Callers holding `view_issues` were
denied relations Redmine had already sent them.

Fixes #222

## Changes

- Add `_included_list`, which reads an include from python-redmine's decoded payload via `raw()`, and move `_issue_relation_to_dict` beside it so a single serializer covers both payload dicts and `IssueRelation` resources.
- Use the payload in `get_redmine_issue`, `get_gantt_chart` — one request per chart instead of one per issue — and the `delete_redmine_issue` preview.
- Fix the whole delete preview, not just relations. All four included collections were read through resource attributes outside the enclosing `try`, so any request they triggered escaped as an unhandled exception before the confirmation gate. Two really fired: `relations` always, and `children` for every leaf issue, since `render_api_issue_children` returns early on `issue.leaf?` and python-redmine re-fetches a missing include. A leaf-issue preview drops from four requests to two.
- Report `time_entries_count` as `null` when it cannot be read. Redmine has no `time_entries` include, so that request is unavoidable and needs `view_time_entries`; `0` would understate an irreversible cascade. Other failures return a normal error envelope rather than a permission diagnosis.
- Relations now carry Redmine's `delay` field on the single-issue path too, which it had omitted while the Gantt path included it.

One deliberate test change: the relation fakes in `tests/test_gantt.py`, `tests/test_delete_redmine_issue.py` and `tests/test_redmine_handler.py` served includes as plain attributes, which no python-redmine issue does. They passed while the real client made an extra request that could 403 — which is how this survived. They now serve includes from `raw()` and raise on the attribute, so a regression fails in CI rather than only against a live Redmine. No assertion was weakened or removed.

## Testing

`python tests/run_tests.py --all` — passes.
`uv run black --check src/` and `uv run flake8 src/ --max-line-length=88` — clean.

New `tests/test_relations_payload.py` (12 tests) covers the payload read, an absent include, an empty include, one request for a whole Gantt chart, the leaf-issue `children` case, the preview surviving a caller without `manage_issue_relations`, an unreadable time-entry count reported as unknown rather than zero, and an unexpected time-entry error returning an error envelope. Each was checked to fail against `develop` before the fix.

Verified end to end by counting requests through a fake transport under real python-redmine, on a leaf issue:

```
before: 4 requests   issue.json(include=...) + issue.json(include=children)
                     + issues/1/relations.json + time_entries.json
after:  2 requests   issue.json(include=...) + time_entries.json
```

With the relations endpoint deliberately returning different data than the payload, the output now matches the payload — confirming the include is what is read, not a second request.

## Checklist

- [x] `python tests/run_tests.py --all` passes (activate `.venv` first)
- [x] `uv run black --check src/` and `uv run flake8 src/ --max-line-length=88` are clean
- [x] `CHANGELOG.md` [Unreleased] has a bullet for user-facing changes
- [x] No manual version bumps
- [x] Docs updated where behavior changed: `docs/tool-reference.md`
- [x] Change works with both local and Docker deployments (no deployment surface touched)
