### PR TITLE
feat: return custom fields and relations from the issue list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   signature serves all seven, and with no `Args` section nothing stated that
   `is_company` writes rather than filters, or that `fields` is for `create` and
   `update` only.
+- `list_redmine_issues` can return `custom_fields` and `relations`, both
+  opt-in. Reading either across a project previously cost one request per
+  issue, because the list serializer dropped data Redmine had already sent:
+  `render_api_custom_values` runs unconditionally on `issues/index.api.rsb`,
+  and the list renders `relations` under `include=relations`. Pass
+  `include_custom_fields=True` / `include_relations=True`, or name
+  `custom_fields` / `relations` in `fields` -- naming `relations` there also
+  adds the include to the request, so the key can never come back
+  misleadingly empty, and setting a flag adds its key to a narrowed `fields`
+  list rather than dropping it. Relations are read from the response payload,
+  so a page of issues stays one request and needs only `view_issues`. An
+  `include` passed through `filters` is preserved and merged, given as either
+  a string or a list. Defaults are unchanged, so existing responses keep their
+  current size, and no new scope is required.
+  ([#228](https://github.com/jztan/redmine-mcp-server/issues/228))
+- `search_redmine_issues` can select `custom_fields` too, as a consequence of
+  sharing the issue serializer: it hydrates its results through the issues
+  endpoint, which renders the values, so the key was already paid for and
+  discarded. `relations` is deliberately not offered there, since that tool
+  never requests the include and the key could only ever be empty.
+
+  One asymmetry: Redmine filters custom field values per caller
+  (`Issue#visible_custom_field_values`), but filters relations by target-issue
+  visibility only on `GET /issues/{id}`, not on `GET /issues.json`. So
+  `issue_to_id` in list output can name an issue the caller cannot read. This
+  exposes nothing a caller could not get from the same endpoint directly, and
+  filtering it client-side would cost one request per relation target -- the
+  overhead this option exists to remove. Resolve a target through
+  `get_redmine_issue`, which does apply the filter.
 
 ### Fixed
 - `include=relations` is no longer discarded and re-fetched per issue.
@@ -168,6 +197,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   [#227](https://github.com/jztan/redmine-mcp-server/pull/227))
 
 ### Tests
+- New `tests/test_list_issue_custom_fields_and_relations.py` covers the new
+  list keys, the defaults staying absent, `fields` selection implying the
+  request-side include, a caller's own `include` surviving in string, list and
+  tuple form without being duplicated, a flag adding its key to a narrowed
+  `fields` list, the `["*"]` sentinel behaving the same as a tuple, the
+  pagination count query dropping the include, per-issue values not being
+  shared across a page, and both halves of the shared serializer in
+  `search_redmine_issues` -- `custom_fields` selectable, `relations` withheld.
+  The issue fakes raise on `issue.relations`, so a regression to the lazy
+  attribute fails rather than quietly slowing down.
 - New `tests/test_relations_payload.py` covers reading relations from the
   include payload, an absent include, an empty include, the Gantt path issuing
   one request for a whole chart, the leaf-issue `children` case, and the delete

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -107,7 +107,7 @@ Cross-cutting utilities live as flat private modules:
 | `_client.py` | Redmine connection (legacy, `oauth`, and `oauth-proxy`), module-level config, logger |
 | `_errors.py` | `_handle_redmine_error`, `_scrub_error_message`, `_READ_ONLY_ERROR` |
 | `_validation.py` | Input validators (`_is_positive_int`, `_is_valid_project_id`, `_validate_hours`) |
-| `_serialization.py` | `wrap_insecure_content`, `_safe_isoformat`, `_iter_capped`, `_named_ref`, `_coerce_json_safe` |
+| `_serialization.py` | `wrap_insecure_content`, `_safe_isoformat`, `_iter_capped`, `_named_ref`, `_coerce_json_safe`, `_normalize_csv_list` |
 | `_env.py` | Environment accessors: read-only / plugin flags (`_is_read_only_mode`, `_is_*_enabled`), secret resolution with Docker/Kubernetes `*_FILE` support (`get_secret`, `get_required`, `get_required_secret`), `require_introspection_credentials`, `get_allowed_client_redirect_uris` (oauth-proxy redirect-URI allowlist), `get_health_introspection_ttl_seconds` |
 | `_custom_fields.py` | Custom-field parsing, autofill, and update coercion |
 | `_ssrf.py` | SSRF protection for `upload_file`'s `source_url` |

--- a/docs/tool-reference.md
+++ b/docs/tool-reference.md
@@ -642,11 +642,31 @@ List Redmine issues with flexible filtering and pagination support. A general-pu
 - `limit` (integer, optional): Maximum issues to return. Default: `25`, Max: `1000`
 - `offset` (integer, optional): Number of issues to skip for pagination. Default: `0`
 - `include_pagination_info` (boolean, optional): Return structured response with metadata. Default: `false`
+- `include_custom_fields` (boolean, optional): Add `custom_fields` to each issue. Default: `false` — unlike `get_redmine_issue`, which defaults to `true`, because a list page multiplies the payload
+- `include_relations` (boolean, optional): Add `relations` to each issue. Default: `false`. Each entry is `{id, issue_id, issue_to_id, relation_type, delay}`
 - `fields` (array of strings, optional): List of field names to include in results. Default: all fields
-  - Available fields: `id`, `subject`, `description`, `project`, `status`, `priority`, `tracker`, `author`, `assigned_to`, `created_on`, `updated_on` — `tracker` is returned by default
-  - Special values: `["*"]` or `["all"]` for all fields
+  - Available fields: `id`, `subject`, `description`, `project`, `status`, `priority`, `tracker`, `author`, `assigned_to`, `category`, `fixed_version`, `parent`, `start_date`, `due_date`, `done_ratio`, `estimated_hours`, `spent_hours`, `is_private`, `closed_on`, `created_on`, `updated_on`, `custom_fields`, `relations` — `tracker` is returned by default
+  - Special values: `["*"]` or `["all"]`, on their own, select every field except `custom_fields` and `relations`. Those two need their flag — naming one alongside `["*"]` narrows the result to just it, rather than adding it to the full set
+  - Naming `custom_fields` or `relations` in a normal field list does the same as the matching flag. For `relations` that includes adding the include to the request, so the key cannot come back empty just because the flag was not also set. Setting a flag also adds its key to a narrowed `fields` list rather than dropping it.
 
 **Returns:** List of issue dictionaries, or structured response with pagination metadata
+
+**Notes on `custom_fields` and `relations`:**
+- Both come from data Redmine already returns on the list endpoint, so a whole page costs one request either way. Custom field values are rendered unconditionally; relations are read from the `include=relations` payload, so `view_issues` is sufficient and no per-issue call is made.
+- An `include` passed through `filters` is kept and merged. Passing `include=relations` that way alone does not add the key — use the flag or name the field.
+- They are opt-in only to keep the default response small. The default output is unchanged.
+- Custom field values are filtered per caller by Redmine (`Issue#visible_custom_field_values`). **Relations on the list endpoint are not:** Redmine applies the target-issue visibility filter on `GET /issues/{id}` but not on `GET /issues.json`, so `issue_to_id` may name an issue the caller cannot read. Resolve a target through `get_redmine_issue`, which does apply the filter, rather than inferring anything from the id alone.
+- `search_redmine_issues` shares this serializer and can select `custom_fields` the same way, but not `relations` — it never requests the include, so the key could only ever be empty there.
+
+```python
+# One request, not one per issue.
+list_redmine_issues(
+    project_id="my-project",
+    fields=["id", "subject", "custom_fields", "relations"],
+    include_relations=True,
+    limit=100,
+)
+```
 
 **Examples:**
 
@@ -709,7 +729,7 @@ Search issues using text queries with support for pagination, field selection, a
 - `offset` (integer, optional): Number of issues to skip for pagination. Default: `0`
 - `include_pagination_info` (boolean, optional): Return structured response with pagination metadata. Default: `false`
 - `fields` (array of strings, optional): List of field names to include in results. Default: `null` (all fields)
-  - Available fields: `id`, `subject`, `description`, `project`, `status`, `priority`, `tracker`, `author`, `assigned_to`, `created_on`, `updated_on` — `tracker` is returned by default
+  - Available fields: `id`, `subject`, `description`, `project`, `status`, `priority`, `tracker`, `author`, `assigned_to`, `created_on`, `updated_on`, `custom_fields` — `tracker` is returned by default. Naming `custom_fields` hydrates the results through the issues endpoint, which renders the values; there is no `relations` here, since this tool never requests that include
   - Special values: `["*"]` or `["all"]` for all fields
 - `scope` (string, optional): Search scope. Default: `"all"`
   - Values: `"all"`, `"my_project"`, `"subprojects"`

--- a/src/redmine_mcp_server/_serialization.py
+++ b/src/redmine_mcp_server/_serialization.py
@@ -131,6 +131,25 @@ def _iter_capped(resources: Any, cap: int = _DEFAULT_LIST_RESULT_CAP) -> List[An
     return out
 
 
+def _normalize_csv_list(value: Any) -> List[str]:
+    """Coerce a comma-separated string, list, tuple or scalar to a str list.
+
+    ``None`` yields an empty list; names are stripped and blanks dropped.
+    Redmine's query parameters that accept several values (``include``,
+    ``tag_list``) all take either form, so callers normalize before editing
+    one -- ``str()`` on a list would put a Python repr on the wire.
+    """
+    if value is None:
+        return []
+    if isinstance(value, str):
+        parts: Any = value.split(",")
+    elif isinstance(value, (list, tuple)):
+        parts = value
+    else:
+        parts = [value]
+    return [name for name in (str(part).strip() for part in parts) if name]
+
+
 def _included_list(resource: Any, key: str) -> List[Any]:
     """Read an ``include=`` collection from the payload Redmine already sent.
 
@@ -181,20 +200,7 @@ def _normalize_tag_list(value: Any) -> List[str]:
     additional_tags plugin's own delimiter; Redmine's ``Array(tag_list)``
     would otherwise treat ``"a,b"`` as one tag named ``"a,b"``.
     """
-    if value is None:
-        return []
-    if isinstance(value, str):
-        parts: Any = value.split(",")
-    elif isinstance(value, (list, tuple)):
-        parts = value
-    else:
-        parts = [value]
-    result: List[str] = []
-    for part in parts:
-        name = str(part).strip()
-        if name:
-            result.append(name)
-    return result
+    return _normalize_csv_list(value)
 
 
 def _custom_fields_to_list(resource: Any) -> List[Dict[str, Any]]:

--- a/src/redmine_mcp_server/tools/issues.py
+++ b/src/redmine_mcp_server/tools/issues.py
@@ -35,10 +35,11 @@ from .._serialization import (
     _custom_fields_to_list,
     _included_list,
     _issue_relation_to_dict,
+    _issue_relations_to_list,
     _iter_capped,
     _normalize_tag_list,
     _named_ref,
-    _issue_relations_to_list,
+    _normalize_csv_list,
     _safe_isoformat,
     wrap_insecure_content,
 )
@@ -287,7 +288,11 @@ def _hydrate_search_results(search_results: List[Any]) -> List[Any]:
     ]
 
 
-def _issue_to_dict(issue: Any, include_custom_fields: bool = False) -> Dict[str, Any]:
+def _issue_to_dict(
+    issue: Any,
+    include_custom_fields: bool = False,
+    include_relations: bool = False,
+) -> Dict[str, Any]:
     """Convert a python-redmine Issue object to a serializable dict."""
     # Use getattr for all potentially missing attributes (search API may not return all)
     assigned = getattr(issue, "assigned_to", None)
@@ -352,12 +357,17 @@ def _issue_to_dict(issue: Any, include_custom_fields: bool = False) -> Dict[str,
 
     if include_custom_fields:
         issue_dict["custom_fields"] = _custom_fields_to_list(issue)
+    if include_relations:
+        issue_dict["relations"] = _issue_relations_to_list(issue)
 
     return issue_dict
 
 
 def _issue_to_dict_selective(
-    issue: Any, fields: Optional[List[str]] = None
+    issue: Any,
+    fields: Optional[List[str]] = None,
+    include_custom_fields: bool = False,
+    include_relations: bool = False,
 ) -> Dict[str, Any]:
     """Convert a python-redmine Issue object to a dict with selected fields.
 
@@ -366,6 +376,12 @@ def _issue_to_dict_selective(
         fields: List of field names to include. If None, ["*"], or ["all"],
                 returns all fields (same as _issue_to_dict). Invalid or
                 missing fields are silently skipped.
+        include_custom_fields: Add ``custom_fields``, whether or not
+                ``fields`` names it.
+        include_relations: Add ``relations``, whether or not ``fields`` names
+                it. The caller must have asked Redmine for
+                ``include=relations``; this reads the payload and never
+                fetches.
 
     Available fields:
         - id: Issue ID
@@ -389,6 +405,10 @@ def _issue_to_dict_selective(
         - closed_on: Closure timestamp (ISO format, or None)
         - created_on: Creation timestamp (ISO format)
         - updated_on: Last update timestamp (ISO format)
+        - custom_fields: Custom field values (list of {id, name, value})
+        - relations: Issue relations (list of
+          {id, issue_id, issue_to_id, relation_type, delay}); needs
+          ``include=relations`` on the request that fetched the issue
 
     Returns:
         Dictionary containing only the requested fields.
@@ -403,9 +423,18 @@ def _issue_to_dict_selective(
         >>> _issue_to_dict_selective(issue, None)
         # Returns all fields (same as _issue_to_dict)
     """
+    # The request-side guard in list_redmine_issues accepts any sequence, so
+    # normalize before the sentinel comparisons or ("*",) would select nothing.
+    if isinstance(fields, tuple):
+        fields = list(fields)
+
     # Handle "all fields" cases
     if fields is None or fields == ["*"] or fields == ["all"]:
-        return _issue_to_dict(issue)
+        return _issue_to_dict(
+            issue,
+            include_custom_fields=include_custom_fields,
+            include_relations=include_relations,
+        )
 
     # Build field mapping with all available fields
     # Use getattr for all potentially missing attributes (search API may not return all)
@@ -466,8 +495,28 @@ def _issue_to_dict_selective(
         "updated_on": _safe_isoformat(getattr(issue, "updated_on", None)),
     }
 
+    # A flag means the same thing here as in _issue_to_dict: add the key.
+    # Without this, combining a flag with a narrowed `fields` would request the
+    # include, pay for the bigger payload, and drop the result.
+    keys = list(fields)
+    if include_custom_fields and "custom_fields" not in keys:
+        keys.append("custom_fields")
+    if include_relations and "relations" not in keys:
+        keys.append("relations")
+
+    # Both read the payload Redmine already sent, so neither costs a request --
+    # but building one is not free, so only do it when it was selected.
+    if "custom_fields" in keys:
+        all_fields["custom_fields"] = _custom_fields_to_list(issue)
+    if include_relations:
+        # Gated on the flag rather than on `keys`, because only the flag says
+        # `include=relations` was requested. `search_redmine_issues` shares
+        # this serializer and never requests it, so honouring the name alone
+        # there would return a permanently empty key.
+        all_fields["relations"] = _issue_relations_to_list(issue)
+
     # Return only requested fields (silently skip invalid field names)
-    return {key: all_fields[key] for key in fields if key in all_fields}
+    return {key: all_fields[key] for key in keys if key in all_fields}
 
 
 # Attribute changes whose values are free-form user text (rather than numeric
@@ -794,6 +843,8 @@ async def list_redmine_issues(
     limit: Annotated[int, Field(ge=1, le=1000)] = 25,
     offset: Annotated[int, Field(ge=0)] = 0,
     include_pagination_info: bool = False,
+    include_custom_fields: bool = False,
+    include_relations: bool = False,
     fields: Optional[List[str]] = None,
     filters: Optional[Dict[str, Any]] = None,
 ) -> Union[List[Dict[str, Any]], Dict[str, Any]]:
@@ -828,9 +879,24 @@ async def list_redmine_issues(
         offset: Number of issues to skip for pagination (default: 0).
         include_pagination_info: Return structured response with pagination
             metadata (default: False).
+        include_custom_fields: Add ``custom_fields`` to each issue
+            (default: False). Costs no extra request; opt-in only to keep the
+            default response small.
+        include_relations: Add ``relations`` to each issue (default: False).
+            Costs no extra request -- a whole page of issues is one call.
+            ``issue_to_id`` may name an issue the caller cannot read, so do
+            not classify or count relation edges by their target from this
+            output alone.
         fields: List of field names to include in results (default: all).
             Available: id, subject, description, project, status, priority,
-            tracker, author, assigned_to, created_on, updated_on.
+            tracker, author, assigned_to, category, fixed_version, parent,
+            start_date, due_date, done_ratio, estimated_hours, spent_hours,
+            is_private, closed_on, created_on, updated_on, custom_fields,
+            relations. Naming ``custom_fields`` or ``relations`` here has the
+            same effect as the matching flag, including asking Redmine for the
+            relations include. ``["*"]`` or ``["all"]``, on their own, select
+            every field except those two, which need their flag -- naming one
+            alongside ``["*"]`` narrows the result to just it.
         filters: Additional Redmine API filter parameters as a dict. Use this
             for any filter not listed above (e.g., {"cf_1": "value"}).
 
@@ -857,6 +923,13 @@ async def list_redmine_issues(
         ...     project_id=1, fields=["id", "subject", "status"]
         ... )
         [{"id": 1, "subject": "Bug fix", "status": {...}}, ...]
+
+        >>> await list_redmine_issues(
+        ...     project_id=1,
+        ...     fields=["id", "custom_fields", "relations"],
+        ...     include_relations=True,
+        ... )
+        [{"id": 1, "custom_fields": [...], "relations": [...]}, ...]
 
     Performance:
         - Memory efficient: Uses server-side pagination
@@ -890,6 +963,23 @@ async def list_redmine_issues(
             # Merge additional arbitrary Redmine filters if provided
             if filters:
                 redmine_api_filters.update(filters)
+
+            # Naming either in `fields` implies the flag, so a caller does not
+            # have to set both and get an empty key for their trouble.
+            selected = fields if isinstance(fields, (list, tuple)) else []
+            want_custom_fields = include_custom_fields or "custom_fields" in selected
+            want_relations = include_relations or "relations" in selected
+
+            if want_relations:
+                # Relations need an explicit include; custom field values come
+                # back unconditionally. Normalized first because python-redmine
+                # accepts `include` as a list too, and stringifying one would
+                # put a Python repr on the wire and lose the caller's includes.
+                parts = _normalize_csv_list(redmine_api_filters.get("include"))
+                if "relations" not in parts:
+                    parts.append("relations")
+                redmine_api_filters["include"] = ",".join(parts)
+
             filters = redmine_api_filters
 
             # Log request for monitoring
@@ -971,7 +1061,13 @@ async def list_redmine_issues(
 
             # Convert to dictionaries with optional field selection
             result_issues = [
-                _issue_to_dict_selective(issue, fields) for issue in issues_list
+                _issue_to_dict_selective(
+                    issue,
+                    fields,
+                    include_custom_fields=want_custom_fields,
+                    include_relations=want_relations,
+                )
+                for issue in issues_list
             ]
 
             # Handle metadata response format
@@ -986,6 +1082,9 @@ async def list_redmine_issues(
                     # large project) just to compute the count, which can exceed
                     # the MCP ``tools/call`` timeout.
                     count_filters = {**filters, "limit": 1, "offset": 0}
+                    # The count query reads total_count off the envelope; it
+                    # has no use for included collections.
+                    count_filters.pop("include", None)
                     count_query = _get_redmine_client().issue.filter(**count_filters)
                     # Trigger a single request so total_count is populated.
                     list(count_query)
@@ -1065,7 +1164,11 @@ def search_redmine_issues(
             metadata (default: False).
         fields: List of field names to include in results (default: all).
             Available: id, subject, description, project, status, priority,
-            tracker, author, assigned_to, created_on, updated_on.
+            tracker, author, assigned_to, created_on, updated_on,
+            custom_fields. Naming ``custom_fields`` hydrates the results
+            through the issues endpoint, which renders the values. There is
+            no ``relations``: this tool never asks for that include, so the
+            key could only ever come back empty.
         scope: Search scope. Values: "all", "my_project", "subprojects".
         open_issues: Search only open issues (default: False).
         options: Additional Redmine Search API parameters as a dict.

--- a/tests/test_list_issue_custom_fields_and_relations.py
+++ b/tests/test_list_issue_custom_fields_and_relations.py
@@ -1,0 +1,242 @@
+"""Tests for custom fields and relations in issue list output.
+
+Redmine returns issue custom field values on ``GET /issues.json``
+unconditionally (``render_api_custom_values`` in ``issues/index.api.rsb``) and
+renders relations there under ``include=relations``. ``list_redmine_issues``
+discarded both, so reading a custom field or a relation across a project cost
+one request per issue.
+
+Relations are read from the payload rather than through ``issue.relations``,
+which is a lazy relation in python-redmine -- see
+``_serialization._included_list``. The fakes here raise on that attribute so a
+regression cannot pass.
+
+See https://github.com/jztan/redmine-mcp-server/issues/228.
+"""
+
+import os
+import sys
+from unittest.mock import Mock, PropertyMock, patch
+
+import pytest
+from redminelib.exceptions import ForbiddenError
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from redmine_mcp_server.tools.issues import (  # noqa: E402
+    list_redmine_issues,
+    search_redmine_issues,
+)
+
+_CF = [{"id": 12, "name": "Size", "value": "S"}]
+_REL = [
+    {
+        "id": 5,
+        "issue_id": 1,
+        "issue_to_id": 2,
+        "relation_type": "precedes",
+        "delay": 0,
+    }
+]
+
+
+def _named(id, name):
+    """A {id, name} reference.
+
+    ``name`` is assigned rather than passed to the constructor: ``Mock(name=)``
+    sets the mock's own name instead of an attribute.
+    """
+    ref = Mock(id=id)
+    ref.name = name
+    return ref
+
+
+def _mock_issue(issue_id=1, custom_fields=None, relations=None):
+    issue = Mock()
+    issue.id = issue_id
+    issue.subject = f"Issue {issue_id}"
+    issue.description = ""
+    issue.project = _named(1, "Test Project")
+    issue.status = _named(1, "New")
+    issue.priority = _named(2, "Normal")
+    issue.author = _named(10, "Alice")
+    issue.assigned_to = None
+    issue.created_on = None
+    issue.updated_on = None
+    issue.custom_fields = list(custom_fields or [])
+    issue.raw.return_value = {"relations": list(relations or [])}
+    type(issue).relations = PropertyMock(side_effect=ForbiddenError)
+    return issue
+
+
+@pytest.fixture
+def mock_redmine():
+    with patch("redmine_mcp_server._client.redmine") as mock:
+        yield mock
+
+
+class TestIssueCustomFields:
+    @pytest.mark.asyncio
+    async def test_absent_by_default(self, mock_redmine):
+        mock_redmine.issue.filter.return_value = [_mock_issue(custom_fields=_CF)]
+        result = await list_redmine_issues(project_id=1)
+        assert "custom_fields" not in result[0]
+
+    @pytest.mark.asyncio
+    async def test_included_on_request(self, mock_redmine):
+        mock_redmine.issue.filter.return_value = [_mock_issue(custom_fields=_CF)]
+        result = await list_redmine_issues(project_id=1, include_custom_fields=True)
+        assert result[0]["custom_fields"] == _CF
+
+    @pytest.mark.asyncio
+    async def test_each_issue_gets_its_own_values(self, mock_redmine):
+        """One page, one request, and the values are not shared between issues."""
+        mock_redmine.issue.filter.return_value = [
+            _mock_issue(n, custom_fields=[{"id": 12, "name": "Size", "value": f"S{n}"}])
+            for n in (1, 2, 3)
+        ]
+        result = await list_redmine_issues(project_id=1, include_custom_fields=True)
+        assert [i["custom_fields"][0]["value"] for i in result] == ["S1", "S2", "S3"]
+        assert mock_redmine.issue.filter.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_selecting_the_field_name_is_enough(self, mock_redmine):
+        """Naming it in `fields` used to be dropped silently."""
+        mock_redmine.issue.filter.return_value = [_mock_issue(custom_fields=_CF)]
+        result = await list_redmine_issues(project_id=1, fields=["id", "custom_fields"])
+        assert result[0] == {"id": 1, "custom_fields": _CF}
+
+
+class TestIssueRelations:
+    @pytest.mark.asyncio
+    async def test_absent_by_default_and_include_not_requested(self, mock_redmine):
+        mock_redmine.issue.filter.return_value = [_mock_issue(relations=_REL)]
+        result = await list_redmine_issues(project_id=1)
+        assert "relations" not in result[0]
+        assert "include" not in mock_redmine.issue.filter.call_args[1]
+
+    @pytest.mark.asyncio
+    async def test_included_on_request(self, mock_redmine):
+        mock_redmine.issue.filter.return_value = [_mock_issue(relations=_REL)]
+        result = await list_redmine_issues(project_id=1, include_relations=True)
+        assert result[0]["relations"] == _REL
+        assert mock_redmine.issue.filter.call_args[1]["include"] == "relations"
+
+    @pytest.mark.asyncio
+    async def test_one_request_for_a_whole_page(self, mock_redmine):
+        """The N+1 this removes. The fakes raise on issue.relations, so a
+        regression to the lazy attribute fails rather than slowing down."""
+        mock_redmine.issue.filter.return_value = [
+            _mock_issue(n, relations=_REL) for n in range(1, 11)
+        ]
+        result = await list_redmine_issues(project_id=1, include_relations=True)
+        assert [len(i["relations"]) for i in result] == [1] * 10
+        assert mock_redmine.issue.filter.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_selecting_the_field_name_requests_the_include(self, mock_redmine):
+        """`fields` alone has to reach the request, or the key comes back
+        empty and the caller cannot tell why."""
+        mock_redmine.issue.filter.return_value = [_mock_issue(relations=_REL)]
+        result = await list_redmine_issues(project_id=1, fields=["id", "relations"])
+        assert result[0] == {"id": 1, "relations": _REL}
+        assert "relations" in mock_redmine.issue.filter.call_args[1]["include"]
+
+    @pytest.mark.parametrize(
+        "supplied",
+        [
+            "attachments",
+            " attachments ",
+            ["attachments"],
+            ("attachments",),
+            ["attachments", ""],
+        ],
+        ids=["str", "padded-str", "list", "tuple", "list-with-blank"],
+    )
+    @pytest.mark.asyncio
+    async def test_caller_supplied_include_is_preserved(self, mock_redmine, supplied):
+        """python-redmine accepts `include` as a list too, so stringifying one
+        would put a Python repr on the wire and silently drop the caller's
+        includes."""
+        mock_redmine.issue.filter.return_value = [_mock_issue(relations=_REL)]
+        await list_redmine_issues(
+            project_id=1,
+            include_relations=True,
+            filters={"include": supplied},
+        )
+        include = mock_redmine.issue.filter.call_args[1]["include"]
+        assert include.split(",") == ["attachments", "relations"]
+
+    @pytest.mark.asyncio
+    async def test_include_not_duplicated(self, mock_redmine):
+        mock_redmine.issue.filter.return_value = [_mock_issue(relations=_REL)]
+        await list_redmine_issues(
+            project_id=1,
+            include_relations=True,
+            filters={"include": "relations"},
+        )
+        assert mock_redmine.issue.filter.call_args[1]["include"] == "relations"
+
+    @pytest.mark.asyncio
+    async def test_flag_adds_the_key_to_a_narrowed_fields_list(self, mock_redmine):
+        """The advertised flag says "add relations"; narrowing `fields` used to
+        request the include, pay for it, and drop the result."""
+        mock_redmine.issue.filter.return_value = [
+            _mock_issue(custom_fields=_CF, relations=_REL)
+        ]
+        result = await list_redmine_issues(
+            project_id=1,
+            fields=["id", "subject"],
+            include_relations=True,
+            include_custom_fields=True,
+        )
+        assert set(result[0]) == {"id", "subject", "relations", "custom_fields"}
+        assert result[0]["relations"] == _REL
+
+    @pytest.mark.asyncio
+    async def test_fields_as_a_tuple_still_requests_the_include(self, mock_redmine):
+        """The guard and the serializer must agree on what counts as a
+        sequence, or the key is emitted without the include behind it."""
+        mock_redmine.issue.filter.return_value = [_mock_issue(relations=_REL)]
+        result = await list_redmine_issues(project_id=1, fields=("id", "relations"))
+        assert result[0] == {"id": 1, "relations": _REL}
+        assert "relations" in mock_redmine.issue.filter.call_args[1]["include"]
+
+    @pytest.mark.asyncio
+    async def test_star_sentinel_works_as_a_tuple_too(self, mock_redmine):
+        """The guard accepts any sequence, so the sentinel comparison must not
+        be list-only or ("*",) would silently select nothing."""
+        mock_redmine.issue.filter.return_value = [_mock_issue(custom_fields=_CF)]
+        as_list = await list_redmine_issues(project_id=1, fields=["*"])
+        mock_redmine.issue.filter.return_value = [_mock_issue(custom_fields=_CF)]
+        as_tuple = await list_redmine_issues(project_id=1, fields=("*",))
+        assert set(as_tuple[0]) == set(as_list[0])
+
+    @pytest.mark.asyncio
+    async def test_search_does_not_offer_an_empty_relations_key(self, mock_redmine):
+        """search_redmine_issues shares the serializer but never requests the
+        include, so offering `relations` there could only ever return []."""
+        mock_redmine.issue.search.return_value = [_mock_issue(relations=_REL)]
+        result = await search_redmine_issues(query="x", fields=["id", "relations"])
+        assert isinstance(result, list)
+        assert result and "relations" not in result[0]
+
+    @pytest.mark.asyncio
+    async def test_search_can_select_custom_fields(self, mock_redmine):
+        """The other half of the shared serializer: unlike `relations`, custom
+        field values are rendered without an include, so search can select
+        them. Documented rather than suppressed."""
+        mock_redmine.issue.search.return_value = [_mock_issue(custom_fields=_CF)]
+        result = await search_redmine_issues(query="x", fields=["id", "custom_fields"])
+        assert result[0] == {"id": 1, "custom_fields": _CF}
+
+    @pytest.mark.asyncio
+    async def test_count_query_drops_the_include(self, mock_redmine):
+        """The pagination count reads total_count off the envelope."""
+        mock_redmine.issue.filter.return_value = [_mock_issue(relations=_REL)]
+        await list_redmine_issues(
+            project_id=1, include_relations=True, include_pagination_info=True
+        )
+        count_call = mock_redmine.issue.filter.call_args_list[-1][1]
+        assert count_call["limit"] == 1
+        assert "include" not in count_call


### PR DESCRIPTION
## Summary

Redmine returns issue custom field values on `GET /issues.json` unconditionally, and renders relations there under `include=relations`. `list_redmine_issues` dropped both, so reading a custom field or a relation across a project cost one request per issue.

This adds opt-in flags that surface data already in the payload. Defaults are unchanged, so existing responses keep their current shape and size, and no new scope is required.

Fixes #228

This targets `develop` directly and has no open dependency. It does build on #223, now merged, for the `_included_list` helper it uses to read an include from the response payload — reading relations through `getattr(issue, "relations")` instead would reintroduce exactly the per-issue request that change removed.

## Changes

- `list_redmine_issues` gains `include_custom_fields` and `include_relations`, both defaulting to `False`.
- Naming `custom_fields` or `relations` in `fields` does the same as the matching flag. For `relations` that also adds the include to the outgoing request, so the key cannot come back empty because only one of the two was set. Conversely, setting a flag adds its key to a narrowed `fields` list rather than dropping it, so the flag means the same thing in both forms.
- An `include` supplied through `filters` is normalized and merged rather than overwritten, accepting the string and list forms python-redmine both supports. The pagination count query drops it, since `total_count` comes off the envelope.
- `search_redmine_issues` shares this serializer, so it can now select `custom_fields` too. It hydrates its results through the issues endpoint, which renders the values, so the key was already paid for and discarded. `relations` stays unavailable there: that tool never requests the include, so the key could only ever be empty. Both halves are documented and tested.
- Neither key is built unless it was selected. The serializer computes its field map eagerly, so an unconditional entry would be paid for on every issue of every page — by exactly the callers who narrowed `fields` to avoid that.
- `["*"]` and `["all"]` now behave the same given a tuple, since the request-side guard already accepted any sequence and the sentinel comparison did not.
- Add `_normalize_csv_list` to `_serialization.py` for the include merge. `_normalize_tag_list` delegates to it rather than keeping a second copy of the same coercion, and `docs/contributing.md`'s helper index gains the new name.
- Document the relations visibility asymmetry: Redmine filters relations by target-issue visibility on `GET /issues/{id}` but not on `GET /issues.json`, so a relation edge cannot be classified or counted by its target from list output alone.

Relations are read from the response payload, so a page of issues stays one request and needs only `view_issues`. Custom field values need no include at all — Redmine renders them unconditionally — and arrive already filtered per caller by `Issue#visible_custom_field_values`.

## Testing

`uv run pytest -m "not integration" tests/` — 1777 passed, 0 failed.
`python tests/run_tests.py --all` — same, plus one pre-existing failure:
`test_ssl_integration.py::test_ssl_cert_file_exists` wants a local certificate
file. It fails identically on `develop`, it is `@pytest.mark.integration`, and CI
deselects it.
`uv run black --check src/` and `uv run flake8 src/ --max-line-length=88` — clean.

New `tests/test_list_issue_custom_fields_and_relations.py` (20 tests) covers the new keys, the defaults staying absent, `fields` selection implying the request-side include, a flag adding its key to a narrowed `fields` list, `fields` and the `["*"]` sentinel given as tuples, a caller's own `include` surviving in string, list and tuple form without being duplicated, the count query dropping the include, per-issue values not being shared across a page, and both halves of the shared serializer in `search_redmine_issues` — `custom_fields` selectable, `relations` withheld.

The issue fakes raise `ForbiddenError` on `issue.relations`, so a regression to the lazy attribute fails the suite rather than quietly costing a request per issue.

Run against `develop`'s code, 17 of the 20 fail. The 3 that pass are the regression pins, by design: both `test_absent_by_default` cases and `test_search_does_not_offer_an_empty_relations_key` assert behaviour that must not change, so they hold on either side. Verified separately, with real `redminelib` resources, that neither key costs a request: `custom_fields` is in neither `Issue._includes` nor `Issue._relations`, so it reads from the decoded payload, and relations go through `raw()`. With the engine rigged to raise on any request, a whole page serializes without one.

## Checklist

- [x] `python tests/run_tests.py --all` passes (activate `.venv` first) — apart from the pre-existing `@pytest.mark.integration` SSL-certificate case noted above, which CI deselects
- [x] `uv run black --check src/` and `uv run flake8 src/ --max-line-length=88` are clean
- [x] `CHANGELOG.md` [Unreleased] has a bullet for user-facing changes
- [x] No manual version bumps
- [x] Docs updated where behavior changed: `docs/tool-reference.md`, `docs/contributing.md`
- [x] Change works with both local and Docker deployments (no deployment surface touched)
