### PR TITLE
feat: return project custom field values from the project list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `is_company` stays create-only: the plugin's own filter answers with the same
   wrong set for every value, including the explicit `f[]`/`op`/`v` spelling.
 
+- `list_redmine_projects` can return `custom_fields`, opt-in. Redmine renders
+  project custom field values on `GET /projects.json` unconditionally
+  (`render_api_custom_values` in `projects/index.api.rsb`), but the tool built
+  a fixed five-key dict and dropped them -- and no other tool returned them
+  either, so project custom field values were not reachable through this
+  server at all. Pass `include_custom_fields=True` and they come back with the
+  projects, at no additional request per project. The default output is
+  unchanged and no new scope is required -- Redmine has already limited the
+  values to those the caller may see, and `view_project` is enough
+  ([#230](https://github.com/jztan/redmine-mcp-server/issues/230)).
 - `manage_contact` can filter a `list` server-side on `first_name`, `last_name`,
   `middle_name`, `company`, `job_title`, `email`, `phone` and `author_id`. Seven
   of those already existed on the tool as create-only parameters and were
@@ -178,6 +188,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   exposed `relations` as a plain attribute, which no python-redmine issue ever
   does; they now serve includes from `raw()` and raise on the attribute, so
   this class of bug fails in CI instead of only against a live Redmine.
+- New `tests/test_project_custom_field_values.py` covers the new key, the five
+  existing keys staying exactly as they were, a project whose payload omits
+  `custom_fields` entirely (what Redmine sends when there are none), values
+  arriving as resource objects rather than plain dicts, and no per-project
+  follow-up request.
 - New `tests/test_contact_payload_keys.py` covers the contact serializer against
   the shape the CRM API actually returns -- emails as an array, tags under
   `tag_list`, the plugin's own address field names, and the `custom_fields`,

--- a/docs/tool-reference.md
+++ b/docs/tool-reference.md
@@ -210,9 +210,10 @@ This allows LLM consumers to distinguish trusted tool output from untrusted user
 
 Lists all accessible projects in the Redmine instance.
 
-**Parameters:** None
+**Parameters:**
+- `include_custom_fields` (boolean, optional): Add `custom_fields` to each project. Default: `false`
 
-**Returns:** List of project dictionaries with id, name, identifier, and description
+**Returns:** List of project dictionaries with id, name, identifier, description and created_on, plus `custom_fields` when requested
 
 **Example:**
 ```json
@@ -221,10 +222,36 @@ Lists all accessible projects in the Redmine instance.
     "id": 1,
     "name": "My Project",
     "identifier": "my-project",
-    "description": "Project description"
+    "description": "Project description",
+    "created_on": "2025-01-15T10:30:00"
   }
 ]
 ```
+
+**Example with `include_custom_fields=True`:**
+```json
+[
+  {
+    "id": 1,
+    "name": "My Project",
+    "identifier": "my-project",
+    "description": "Project description",
+    "created_on": "2025-01-15T10:30:00",
+    "custom_fields": [
+      {"id": 12, "name": "Size", "value": "S"}
+    ]
+  }
+]
+```
+
+**Project custom field values:** Redmine renders them on `GET /projects.json`
+unconditionally, so `include_custom_fields=True` adds them with no per-project
+follow-up request. Requires only `view_project`. Each entry is
+`{id, name, value}`, already limited by Redmine to the fields the caller may
+see. This is the only tool that returns project custom field *values*. Project
+custom fields and issue custom fields are separate in Redmine:
+[`list_project_issue_custom_fields`](#list_project_issue_custom_fields) covers
+the latter, and no tool exposes project custom field definitions.
 
 ---
 

--- a/src/redmine_mcp_server/tools/projects.py
+++ b/src/redmine_mcp_server/tools/projects.py
@@ -14,6 +14,7 @@ from .._decorators import ActionMode, action_dispatch
 from .._errors import _handle_redmine_error
 from .._offload import in_thread, offloaded
 from .._serialization import (
+    _custom_fields_to_list,
     _named_ref,
     _safe_isoformat,
     wrap_insecure_content,
@@ -205,24 +206,43 @@ def _membership_to_dict(membership: Any) -> Dict[str, Any]:
 
 @mcp.tool()
 @offloaded
-def list_redmine_projects() -> Union[List[Dict[str, Any]], Dict[str, Any]]:
+def list_redmine_projects(
+    include_custom_fields: bool = False,
+) -> Union[List[Dict[str, Any]], Dict[str, Any]]:
     """
     Lists all accessible projects in Redmine.
+
+    With ``include_custom_fields`` this is the only tool that returns project
+    custom field *values*. Project custom fields and issue custom fields are
+    separate in Redmine: ``list_project_issue_custom_fields`` covers the
+    latter, a different set, and no tool exposes project custom field
+    definitions.
+
+    Args:
+        include_custom_fields: Add ``custom_fields`` to each project. Costs no
+            extra request; opt-in only to keep the default response small.
+
     Returns:
-        A list of dictionaries, each representing a project.
+        A list of dictionaries, each representing a project. With
+        ``include_custom_fields``, each also carries ``custom_fields``, a list
+        of ``{id, name, value}`` entries -- empty if the project has none. On
+        failure, a dict with an ``error`` key.
     """
     try:
         projects = _get_redmine_client().project.all()
-        return [
-            {
+        result: List[Dict[str, Any]] = []
+        for project in projects:
+            entry = {
                 "id": project.id,
                 "name": project.name,
                 "identifier": project.identifier,
                 "description": getattr(project, "description", ""),
                 "created_on": _safe_isoformat(getattr(project, "created_on", None)),
             }
-            for project in projects
-        ]
+            if include_custom_fields:
+                entry["custom_fields"] = _custom_fields_to_list(project)
+            result.append(entry)
+        return result
     except Exception as e:
         return _handle_redmine_error(e, "listing projects")
 

--- a/tests/test_project_custom_field_values.py
+++ b/tests/test_project_custom_field_values.py
@@ -1,0 +1,114 @@
+"""Test cases for project custom field values from list_redmine_projects.
+
+See https://github.com/jztan/redmine-mcp-server/issues/230.
+"""
+
+import os
+import sys
+from unittest.mock import Mock, patch
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from redmine_mcp_server.tools.projects import (  # noqa: E402
+    list_redmine_projects,
+)
+
+# Redmine hands these back as CustomField resources, not dicts, so the fakes
+# below expose them as attributes -- a fake built from plain dicts would pass
+# even if the serializer were bypassed entirely.
+_EXPECTED = [{"id": 12, "name": "Size", "value": "S"}]
+
+
+def _custom_field(id, name, value, **extra):
+    """A stand-in for a python-redmine CustomField resource.
+
+    ``name`` is assigned rather than passed to the constructor: ``Mock(name=)``
+    sets the mock's own name instead of an attribute.
+    """
+    field = Mock(id=id, value=value, **extra)
+    field.name = name
+    return field
+
+
+def _mock_project(project_id=1, custom_fields=None):
+    project = Mock()
+    project.id = project_id
+    project.name = f"Project {project_id}"
+    project.identifier = f"proj-{project_id}"
+    project.description = ""
+    project.created_on = None
+    if custom_fields is None:
+        # Redmine omits the key when a project has no visible values, so the
+        # attribute is absent rather than empty. Mock() would invent it.
+        del project.custom_fields
+    else:
+        project.custom_fields = list(custom_fields)
+    return project
+
+
+@pytest.fixture
+def mock_redmine():
+    with patch("redmine_mcp_server._client.redmine") as mock:
+        yield mock
+
+
+class TestProjectCustomFieldValues:
+    """The values Redmine already sends on GET /projects.json, opt-in."""
+
+    @pytest.mark.asyncio
+    async def test_default_keys_are_unchanged(self, mock_redmine):
+        """The five existing keys are the contract; the flag only adds one."""
+        mock_redmine.project.all.return_value = [
+            _mock_project(custom_fields=[_custom_field(12, "Size", "S")])
+        ]
+        result = await list_redmine_projects()
+        assert set(result[0]) == {
+            "id",
+            "name",
+            "identifier",
+            "description",
+            "created_on",
+        }
+
+    @pytest.mark.asyncio
+    async def test_values_are_serialized_not_passed_through(self, mock_redmine):
+        """Each entry is reduced to id, name and value.
+
+        The resource carries more than that, so returning it unserialized
+        would both leak attributes and fail to encode as JSON.
+        """
+        mock_redmine.project.all.return_value = [
+            _mock_project(
+                custom_fields=[
+                    _custom_field(
+                        12, "Size", "S", field_format="list", internal=object()
+                    )
+                ]
+            )
+        ]
+        result = await list_redmine_projects(include_custom_fields=True)
+        assert result[0]["custom_fields"] == _EXPECTED
+
+    @pytest.mark.asyncio
+    async def test_project_whose_payload_omits_the_key(self, mock_redmine):
+        """Redmine sends no custom_fields key when there are no visible values."""
+        mock_redmine.project.all.return_value = [_mock_project()]
+        result = await list_redmine_projects(include_custom_fields=True)
+        assert result[0]["custom_fields"] == []
+
+    @pytest.mark.asyncio
+    async def test_no_per_project_request(self, mock_redmine):
+        """The values ride along with the list; nothing is fetched per project.
+
+        Distinct values per project, so a serializer that reused one project's
+        entry for every project would fail here too.
+        """
+        mock_redmine.project.all.return_value = [
+            _mock_project(n, custom_fields=[_custom_field(12, "Size", f"S{n}")])
+            for n in (1, 2, 3)
+        ]
+        result = await list_redmine_projects(include_custom_fields=True)
+        assert [p["custom_fields"][0]["value"] for p in result] == ["S1", "S2", "S3"]
+        mock_redmine.project.get.assert_not_called()


### PR DESCRIPTION
## Summary

Redmine renders project custom field values on `GET /projects.json` unconditionally, but `list_redmine_projects` built a fixed five-key dict and dropped them. No other tool returns them either — there is no single-project getter — so a value the server had already fetched was not reachable through this server at all.

This adds one opt-in flag that surfaces data already in the payload. The default output is unchanged and no new scope is required.

Fixes #230

This reuses the `_custom_fields_to_list` helper #227 moved into `_serialization.py`, rather than adding a third copy of the same coercion.

## Changes

- `list_redmine_projects` gains `include_custom_fields`, defaulting to `False`. When set, the values come back with the projects and no per-project follow-up request is made.
- The docstring distinguishes project custom fields from issue custom fields — separate things in Redmine, with only the latter covered by `list_project_issue_custom_fields` and no tool exposing project custom field definitions. It sits above `Args:`, which is the part of a docstring that reaches a calling model.

No new scope: `view_project` is enough, and Redmine has already limited the values to those the caller may see via `Project#visible_custom_field_values`.

## Testing

`uv run pytest -m "not integration" tests/` — 1827 passed, which is what CI runs. `python tests/run_tests.py --all` leaves one failure, `test_ssl_integration.py::test_ssl_cert_file_exists`, which fails identically on `develop` and is deselected by CI.
`uv run black --check src/` and `uv run flake8 src/ tests/ --max-line-length=88` — clean.

New `tests/test_project_custom_field_values.py` (4 tests) covers the new key, the five existing keys staying exactly as they are with the flag off, a project whose payload omits `custom_fields` entirely — what Redmine sends when there are no visible values — and distinct values landing on their own projects with no per-project fetch.

The fakes expose custom fields as attributes rather than plain dicts, because that is what python-redmine hands the serializer. A fixture built from dicts would pass even if the serializer were bypassed; these fail if it is.

Three of the four fail against the parent commit; the fourth is a regression pin on the existing five-key output, so it passes there by design. Verified separately, with real `redminelib` resources, that `custom_fields` is in neither `Project._includes` nor `Project._relations`, so reading it issues no HTTP request.

## Checklist

- [x] `uv run pytest -m "not integration" tests/` passes — 1827. The one `run_tests.py --all` failure is a pre-existing integration case, unchanged from `develop`
- [x] `uv run black --check src/` and `uv run flake8 src/ tests/ --max-line-length=88` are clean
- [x] `CHANGELOG.md` [Unreleased] has a bullet for user-facing changes
- [x] No manual version bumps
- [x] Docs updated where behavior changed: `docs/tool-reference.md`
- [x] Change works with both local and Docker deployments (no deployment surface touched)
