### PR TITLE
fix: stop inventing custom field metadata Redmine never sent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   [#42581](https://www.redmine.org/issues/42581) and
   [#43407](https://www.redmine.org/issues/43407), the last asking for exactly
   these keys.
-  ([#ISSUE](https://github.com/jztan/redmine-mcp-server/issues/ISSUE))
+  ([#232](https://github.com/jztan/redmine-mcp-server/issues/232))
 - `list_project_issue_custom_fields` now returns an error --
   `code: "TRACKER_BINDINGS_UNREADABLE"`, with the recovery in `hint` -- when
   `tracker_id` is passed and the response does not describe tracker bindings,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,49 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   path for the `me` id, not `current`. The distinction matters because
   `/my/account.json` renders no memberships at all.
 
+- `list_project_issue_custom_fields` no longer invents the six keys Redmine
+  never sends. It reads
+  `GET /projects/{id}.json?include=issue_custom_fields`, which Redmine renders
+  as exactly `id` and `name` per field
+  (`app/helpers/projects_helper.rb`, unchanged in 6.1, 7.0 and trunk), and
+  every other attribute was read through a `getattr` fallback -- so
+  `field_format: ""`, `is_required: false`, `multiple: false`,
+  `default_value: null`, `possible_values: []` and `trackers: []` came back
+  for every field, always. `is_required: false` was the sharp edge: it is
+  byte-identical to a real "this field is optional", so a caller omitted the
+  field and Redmine rejected the create with `"<field> cannot be blank"` --
+  the failure #119 reported and could not explain. Those keys are now `null`,
+  documented as "not readable on this token". They are kept rather than
+  dropped so the response shape is stable and so they populate for free if a
+  future Redmine fills the include in.
+
+  The definitions live on `GET /custom_fields.json`, which Redmine restricts
+  to administrators (`before_action :require_admin`, still covering `index` in
+  7.0), so no non-admin token can obtain them; under OAuth an administrator's
+  token cannot either, since `User#admin?` also requires the `admin` scope,
+  which this server deliberately never requests. Redmine has four open
+  requests to expose this metadata to non-admins, the oldest from 2015 and
+  none with a target version:
+  [#18875](https://www.redmine.org/issues/18875),
+  [#41318](https://www.redmine.org/issues/41318),
+  [#42581](https://www.redmine.org/issues/42581) and
+  [#43407](https://www.redmine.org/issues/43407), the last asking for exactly
+  these keys.
+  ([#ISSUE](https://github.com/jztan/redmine-mcp-server/issues/ISSUE))
+- `list_project_issue_custom_fields` now returns an error when `tracker_id` is
+  passed and the response does not describe tracker bindings, which on a stock
+  Redmine is always. It used to read absent bindings as "applies to every
+  tracker" and return every field in the project, indistinguishable from a
+  filtered list. Where bindings *are* readable, a field bound to no tracker is
+  now excluded rather than treated as global: Redmine computes an issue's
+  fields as `project.all_issue_custom_fields & tracker.custom_fields`
+  (`app/models/issue.rb`), so an unbound field reaches no issue.
+- `list_project_issue_custom_fields` requires the `view_issues` scope instead
+  of none. Redmine renders the `issue_custom_fields` include only for a caller
+  holding `view_issues`, and omits the array otherwise, so a token without it
+  got `[]` -- which reads as "this project has no custom fields". The scope
+  map justified the empty entry with a comment about `/custom_fields.json`
+  being admin-gated, an endpoint this tool has never called.
 ### Added
 - `list_redmine_projects` now returns the six fields Redmine's project index
   renders and this serializer discarded: `homepage`, `parent`, `status`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,21 +52,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   [#43407](https://www.redmine.org/issues/43407), the last asking for exactly
   these keys.
   ([#ISSUE](https://github.com/jztan/redmine-mcp-server/issues/ISSUE))
-- `list_project_issue_custom_fields` now returns an error when `tracker_id` is
-  passed and the response does not describe tracker bindings, which on a stock
-  Redmine is always. It used to read absent bindings as "applies to every
+- `list_project_issue_custom_fields` now returns an error --
+  `code: "TRACKER_BINDINGS_UNREADABLE"`, with the recovery in `hint` -- when
+  `tracker_id` is passed and the response does not describe tracker bindings,
+  which on a stock Redmine is always. It used to read absent bindings as "applies to every
   tracker" and return every field in the project, indistinguishable from a
   filtered list. Where bindings *are* readable, a field bound to no tracker is
   now excluded rather than treated as global: Redmine computes an issue's
   fields as `project.all_issue_custom_fields & tracker.custom_fields`
   (`app/models/issue.rb`), so an unbound field reaches no issue.
-- `list_project_issue_custom_fields` requires the `view_issues` scope instead
-  of none. Redmine renders the `issue_custom_fields` include only for a caller
-  holding `view_issues`, and omits the array otherwise, so a token without it
-  got `[]` -- which reads as "this project has no custom fields". The scope
-  map justified the empty entry with a comment about `/custom_fields.json`
-  being admin-gated, an endpoint this tool has never called.
-### Added
+- `list_project_issue_custom_fields` requires the `view_project` and
+  `view_issues` scopes instead of none. Redmine renders the
+  `issue_custom_fields` include only for a caller holding `view_issues`, and
+  omits the array otherwise, so a token without it got `[]` -- which reads as
+  "this project has no custom fields". `view_project` is needed for
+  `projects#show` itself: it is a `:public => true` permission, which is not an
+  exemption, because `Role#allowed_permissions` intersects the public
+  permissions with the token's scopes too (`scope.present? ? unscoped & scope
+  : unscoped`), so a token scoped only `view_issues` is refused by Redmine
+  after this server had already admitted the call. The scope map justified the
+  empty entry with a comment about `/custom_fields.json` being admin-gated, an
+  endpoint this tool has never called.
 - `list_redmine_projects` now returns the six fields Redmine's project index
   renders and this serializer discarded: `homepage`, `parent`, `status`,
   `is_public`, `inherit_members` and `updated_on`. `status` is Redmine's

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,18 +61,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   now excluded rather than treated as global: Redmine computes an issue's
   fields as `project.all_issue_custom_fields & tracker.custom_fields`
   (`app/models/issue.rb`), so an unbound field reaches no issue.
-- `list_project_issue_custom_fields` requires the `view_project` and
-  `view_issues` scopes instead of none. Redmine renders the
-  `issue_custom_fields` include only for a caller holding `view_issues`, and
-  omits the array otherwise, so a token without it got `[]` -- which reads as
-  "this project has no custom fields". `view_project` is needed for
-  `projects#show` itself: it is a `:public => true` permission, which is not an
-  exemption, because `Role#allowed_permissions` intersects the public
-  permissions with the token's scopes too (`scope.present? ? unscoped & scope
-  : unscoped`), so a token scoped only `view_issues` is refused by Redmine
-  after this server had already admitted the call. The scope map justified the
-  empty entry with a comment about `/custom_fields.json` being admin-gated, an
-  endpoint this tool has never called.
+- `list_project_issue_custom_fields` requires the `view_project` scope instead
+  of none, for the `projects#show` request it makes. `view_project` being a
+  `:public => true` permission is not an exemption, because
+  `Role#allowed_permissions` intersects the public permissions with the
+  token's scopes too (`scope.present? ? unscoped & scope : unscoped`), so a
+  token carrying no scopes is refused by Redmine after this server had already
+  admitted the call. Nothing beyond `view_project` is required: every released
+  Redmine renders the `issue_custom_fields` include gated on
+  `include_in_api_response?` alone, with no permission check. The scope map
+  previously justified an empty entry with a comment about
+  `/custom_fields.json` being admin-gated, an endpoint this tool has never
+  called.
 - `list_redmine_projects` now returns the six fields Redmine's project index
   renders and this serializer discarded: `homepage`, `parent`, `status`,
   `is_public`, `inherit_members` and `updated_on`. `status` is Redmine's

--- a/README.md
+++ b/README.md
@@ -178,6 +178,8 @@ When `REDMINE_AUTOFILL_REQUIRED_CUSTOM_FIELDS=true`, `create_redmine_issue` retr
 - the Redmine custom field `default_value`, or
 - `REDMINE_REQUIRED_CUSTOM_FIELD_DEFAULTS`
 
+In practice only the second one can fire. The server reads project custom fields from `GET /projects/{id}.json?include=issue_custom_fields`, which Redmine renders as id and name only, so it never sees `default_value` -- see [`list_project_issue_custom_fields`](docs/tool-reference.md#list_project_issue_custom_fields). Set the env map if you want autofill to have anything to work with.
+
 Example:
 
 ```bash

--- a/docs/tool-reference.md
+++ b/docs/tool-reference.md
@@ -348,7 +348,7 @@ many requests as it needs.
 
 List the ids and names of the issue custom fields enabled for a project.
 
-**OAuth scopes:** `view_project` and `view_issues`. Both are required: `view_project` for `projects#show`, and `view_issues` for the include, which Redmine renders only for a caller holding it. `view_project` being a `:public => true` permission is not an exemption -- `Role#allowed_permissions` intersects the public permissions with the token's scopes too.
+**OAuth scopes:** `view_project`, for `projects#show`, and nothing beyond it. Every released Redmine renders the `issue_custom_fields` include gated on `include_in_api_response?` alone, with no permission check, so requiring anything further would refuse calls Redmine itself serves. `view_project` being a `:public => true` permission is not an exemption -- `Role#allowed_permissions` intersects the public permissions with the token's scopes too, so a token carrying no scopes is still refused.
 
 **Parameters:**
 - `project_id` (integer or string, required): Project ID (numeric) or identifier (string)
@@ -372,7 +372,7 @@ List the ids and names of the issue custom fields enabled for a project.
 ]
 ```
 
-**⚠️ `null` means "not readable on this token", never a default.** This tool reads `GET /projects/{id}.json?include=issue_custom_fields`, which Redmine renders as exactly `id` and `name` per field (`app/helpers/projects_helper.rb`, unchanged in 6.1, 7.0 and trunk). The definitions live on `GET /custom_fields.json`, which Redmine restricts to administrators (`before_action :require_admin`), so a non-admin token cannot read them at all. Under OAuth even an administrator's token cannot: `User#admin?` additionally requires the `admin` scope, which this server never requests. Redmine has four open requests to expose this metadata to non-admins ([#18875](https://www.redmine.org/issues/18875), [#41318](https://www.redmine.org/issues/41318), [#42581](https://www.redmine.org/issues/42581), [#43407](https://www.redmine.org/issues/43407)), none with a target version.
+**⚠️ `null` means "not readable on this token", never a default.** This tool reads `GET /projects/{id}.json?include=issue_custom_fields`, which Redmine renders as exactly `id` and `name` per field (`app/helpers/projects_helper.rb`, the same two keys in 6.1, 7.0 and trunk). The definitions live on `GET /custom_fields.json`, which Redmine restricts to administrators (`before_action :require_admin`), so a non-admin token cannot read them at all. Under OAuth even an administrator's token cannot: `User#admin?` additionally requires the `admin` scope, which this server never requests. Redmine has four open requests to expose this metadata to non-admins ([#18875](https://www.redmine.org/issues/18875), [#41318](https://www.redmine.org/issues/41318), [#42581](https://www.redmine.org/issues/42581), [#43407](https://www.redmine.org/issues/43407)), none with a target version.
 
 Read `null` as "unknown". It is not `false`, and it is not an empty list. `is_required: null` in particular does not mean the field is optional.
 
@@ -393,7 +393,7 @@ When a create or update rejects with that error, the response envelope is augmen
 
 1. **Name-keyed shortcut** — pass the rejected field by name directly: `fields={"Department": "Engineering"}` on either `create_redmine_issue` or `update_redmine_issue`. The tool resolves the name to a `custom_fields` id automatically. Ambiguous names (two fields normalized identically) raise.
 2. **Explicit id form** — `extra_fields={"custom_fields": [{"id": N, "value": "..."}]}` with `N` from this tool. Use when the name is ambiguous or the value type is awkward (multi-value, complex serializations).
-3. **Autofill** — set `REDMINE_AUTOFILL_REQUIRED_CUSTOM_FIELDS=true` to have the server retry once with values from each field's `default_value` or the `REDMINE_REQUIRED_CUSTOM_FIELD_DEFAULTS` env map. Against a stock Redmine only the env map can supply a value: `default_value` is not in the include the server reads.
+3. **Autofill** -- set `REDMINE_AUTOFILL_REQUIRED_CUSTOM_FIELDS=true` to have the server retry once with values from each field's `default_value` or the `REDMINE_REQUIRED_CUSTOM_FIELD_DEFAULTS` env map. Against a stock Redmine only the env map can supply a value: `default_value` is not in the include the server reads.
 
 ---
 

--- a/docs/tool-reference.md
+++ b/docs/tool-reference.md
@@ -346,42 +346,50 @@ many requests as it needs.
 
 ### `list_project_issue_custom_fields`
 
-List issue custom fields configured for a project, including allowed values and tracker bindings.
+List the ids and names of the issue custom fields enabled for a project.
 
 **Parameters:**
 - `project_id` (integer or string, required): Project ID (numeric) or identifier (string)
-- `tracker_id` (integer, optional): Restrict output to fields applicable to the given tracker ID
+- `tracker_id` (integer, optional): Restrict output to fields applicable to the given tracker ID. Requires readable tracker bindings, which stock Redmine does not provide -- see below
 
 **Returns:** List of custom field metadata dictionaries
 
-**Example:**
+**Example (stock Redmine):**
 ```json
 [
   {
     "id": 6,
     "name": "Size",
-    "field_format": "list",
-    "is_required": false,
-    "multiple": false,
-    "default_value": "M",
-    "possible_values": ["S", "M", "L"],
-    "trackers": [{"id": 5, "name": "Bug"}]
+    "field_format": null,
+    "is_required": null,
+    "multiple": null,
+    "default_value": null,
+    "possible_values": null,
+    "trackers": null
   }
 ]
 ```
+
+**⚠️ `null` means "not readable on this token", never a default.** This tool reads `GET /projects/{id}.json?include=issue_custom_fields`, which Redmine renders as exactly `id` and `name` per field (`app/helpers/projects_helper.rb`, unchanged in 6.1, 7.0 and trunk). The definitions live on `GET /custom_fields.json`, which Redmine restricts to administrators (`before_action :require_admin`), so a non-admin token cannot read them at all. Under OAuth even an administrator's token cannot: `User#admin?` additionally requires the `admin` scope, which this server never requests. Redmine has four open requests to expose this metadata to non-admins ([#18875](https://www.redmine.org/issues/18875), [#41318](https://www.redmine.org/issues/41318), [#42581](https://www.redmine.org/issues/42581), [#43407](https://www.redmine.org/issues/43407)), none with a target version.
+
+Read `null` as "unknown". It is not `false`, and it is not an empty list. `is_required: null` in particular does not mean the field is optional.
+
+The keys are kept rather than dropped so the response shape is stable across deployments, and so they start carrying data for free if a future Redmine populates the include.
 
 **Example with tracker filter:**
 ```python
 list_project_issue_custom_fields(project_id="pipeline", tracker_id=5)
 ```
 
-**⚠️ `is_required` caveat (#119):** the underlying `GET /custom_fields.json` only exposes the flag set on the custom field *definition*. Workflow rules, role-based field permissions, and tracker-bound required-field settings can still cause `create_redmine_issue` / `update_redmine_issue` to reject with `"<field> cannot be blank"` for a field that this tool returns with `is_required: false`. No general-purpose Redmine API exposes the "effective" required state.
+Against a stock Redmine this returns an `error`, because tracker bindings are part of the admin-only definition and the filter cannot be applied. It previously returned every field in the project, which a caller had no way to distinguish from a filtered list. Omit `tracker_id` to list every field enabled for the project.
+
+**⚠️ `is_required` caveat (#119):** even where the flag *is* readable it only reflects the custom field *definition*. Workflow rules, role-based field permissions, and tracker-bound required-field settings can still cause `create_redmine_issue` / `update_redmine_issue` to reject with `"<field> cannot be blank"` for a field that this tool returns with `is_required: false`. No general-purpose Redmine API exposes the "effective" required state.
 
 When a create or update rejects with that error, the response envelope is augmented with `missing_required_fields` (parsed names) and a `hint` that lists the three recovery paths:
 
 1. **Name-keyed shortcut** — pass the rejected field by name directly: `fields={"Department": "Engineering"}` on either `create_redmine_issue` or `update_redmine_issue`. The tool resolves the name to a `custom_fields` id automatically. Ambiguous names (two fields normalized identically) raise.
 2. **Explicit id form** — `extra_fields={"custom_fields": [{"id": N, "value": "..."}]}` with `N` from this tool. Use when the name is ambiguous or the value type is awkward (multi-value, complex serializations).
-3. **Autofill** — set `REDMINE_AUTOFILL_REQUIRED_CUSTOM_FIELDS=true` to have the server retry once with values from each field's `default_value` or the `REDMINE_REQUIRED_CUSTOM_FIELD_DEFAULTS` env map.
+3. **Autofill** — set `REDMINE_AUTOFILL_REQUIRED_CUSTOM_FIELDS=true` to have the server retry once with values from each field's `default_value` or the `REDMINE_REQUIRED_CUSTOM_FIELD_DEFAULTS` env map. Against a stock Redmine only the env map can supply a value: `default_value` is not in the include the server reads.
 
 ---
 
@@ -999,7 +1007,7 @@ create_redmine_issue(
 )
 ```
 
-**Autofill retry:** if `REDMINE_AUTOFILL_REQUIRED_CUSTOM_FIELDS=true` is set and Redmine returns relevant custom-field validation errors, the server fetches project custom fields, auto-fills missing/invalid required custom fields from Redmine `default_value` or `REDMINE_REQUIRED_CUSTOM_FIELD_DEFAULTS`, and retries once.
+**Autofill retry:** if `REDMINE_AUTOFILL_REQUIRED_CUSTOM_FIELDS=true` is set and Redmine returns relevant custom-field validation errors, the server fetches project custom fields, auto-fills missing/invalid required custom fields from Redmine `default_value` or `REDMINE_REQUIRED_CUSTOM_FIELD_DEFAULTS`, and retries once. The `default_value` half is inert against a stock Redmine, which does not send it on the include the server reads.
 
 **Examples:**
 ```python

--- a/docs/tool-reference.md
+++ b/docs/tool-reference.md
@@ -348,6 +348,8 @@ many requests as it needs.
 
 List the ids and names of the issue custom fields enabled for a project.
 
+**OAuth scopes:** `view_project` and `view_issues`. Both are required: `view_project` for `projects#show`, and `view_issues` for the include, which Redmine renders only for a caller holding it. `view_project` being a `:public => true` permission is not an exemption -- `Role#allowed_permissions` intersects the public permissions with the token's scopes too.
+
 **Parameters:**
 - `project_id` (integer or string, required): Project ID (numeric) or identifier (string)
 - `tracker_id` (integer, optional): Restrict output to fields applicable to the given tracker ID. Requires readable tracker bindings, which stock Redmine does not provide -- see below
@@ -381,7 +383,9 @@ The keys are kept rather than dropped so the response shape is stable across dep
 list_project_issue_custom_fields(project_id="pipeline", tracker_id=5)
 ```
 
-Against a stock Redmine this returns an `error`, because tracker bindings are part of the admin-only definition and the filter cannot be applied. It previously returned every field in the project, which a caller had no way to distinguish from a filtered list. Omit `tracker_id` to list every field enabled for the project.
+Against a stock Redmine this returns an `error` with `code: "TRACKER_BINDINGS_UNREADABLE"` and a `hint`, because tracker bindings are part of the admin-only definition and the filter cannot be applied. It previously returned every field in the project, which a caller had no way to distinguish from a filtered list. Omit `tracker_id` to list every field enabled for the project.
+
+The `error` describes what this particular response carried rather than asserting what Redmine always does, since bindings *are* readable on a payload that includes them; the standing Redmine explanation is in the `hint`.
 
 **⚠️ `is_required` caveat (#119):** even where the flag *is* readable it only reflects the custom field *definition*. Workflow rules, role-based field permissions, and tracker-bound required-field settings can still cause `create_redmine_issue` / `update_redmine_issue` to reject with `"<field> cannot be blank"` for a field that this tool returns with `is_required: false`. No general-purpose Redmine API exposes the "effective" required state.
 

--- a/src/redmine_mcp_server/_custom_fields.py
+++ b/src/redmine_mcp_server/_custom_fields.py
@@ -103,11 +103,16 @@ def _parse_optional_object_payload(
     return dict(parsed)
 
 
-def _extract_possible_values(custom_field: Any) -> List[str]:
-    """Extract possible values from a Redmine custom field in a robust way."""
-    possible_values = getattr(custom_field, "possible_values", None) or []
+def _normalize_possible_values(possible_values: Any) -> List[str]:
+    """Normalize a Redmine ``possible_values`` payload into a list of strings.
+
+    Split out from :func:`_extract_possible_values` so a caller that has
+    already read the attribute -- and needs to tell "the payload did not carry
+    it" from "it carried an empty list" -- can normalize without reading it a
+    second time through a different absence rule.
+    """
     result: List[str] = []
-    for value in possible_values:
+    for value in possible_values or []:
         if isinstance(value, dict):
             extracted = value.get("value")
         else:
@@ -115,6 +120,16 @@ def _extract_possible_values(custom_field: Any) -> List[str]:
         if extracted is not None:
             result.append(str(extracted))
     return result
+
+
+def _extract_possible_values(custom_field: Any) -> List[str]:
+    """Extract possible values from a Redmine custom field in a robust way.
+
+    Absence collapses to ``[]`` here, which the write paths read as "this
+    field restricts nothing". A reader that must distinguish absence from an
+    empty list should use :func:`_normalize_possible_values` instead.
+    """
+    return _normalize_possible_values(getattr(custom_field, "possible_values", None))
 
 
 def _load_required_custom_field_defaults() -> Dict[str, Any]:
@@ -261,15 +276,18 @@ def _augment_validation_error_with_field_hint(
             'id form -- extra_fields={"custom_fields": '
             '[{"id": N, "value": "..."}]} with N from '
             "list_project_issue_custom_fields -- also works on either "
-            "tool. Note the #119 caveat: is_required=false from the "
-            "discovery tool only reflects the field-definition flag; "
-            "workflow rules, role-based field permissions, and "
-            "tracker-bound required-field settings can still require "
-            "a field at create/update time. Setting "
-            "REDMINE_AUTOFILL_REQUIRED_CUSTOM_FIELDS=true lets the "
-            "server retry with values from each custom field's "
-            "`default_value` or the "
-            "REDMINE_REQUIRED_CUSTOM_FIELD_DEFAULTS env map."
+            "tool. Note the #119 caveat: against a stock Redmine "
+            "list_project_issue_custom_fields reports is_required=null "
+            '("not readable on this token"), so it cannot tell you which '
+            "fields are required -- and even where the flag is readable it "
+            "reflects only the field-definition flag, while workflow rules, "
+            "role-based field permissions and tracker-bound required-field "
+            "settings can still require a field at create/update time. "
+            "Setting REDMINE_AUTOFILL_REQUIRED_CUSTOM_FIELDS=true lets the "
+            "server retry with values from the "
+            "REDMINE_REQUIRED_CUSTOM_FIELD_DEFAULTS env map; the "
+            "`default_value` half of that retry is inert on a stock Redmine, "
+            "which does not send default_value on the include."
         )
 
     augmented["hint"] = " ".join(parts)

--- a/src/redmine_mcp_server/_serialization.py
+++ b/src/redmine_mcp_server/_serialization.py
@@ -3,7 +3,7 @@
 import os
 import uuid
 from datetime import datetime
-from typing import Any, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional
 from urllib.parse import urlsplit, urlunsplit
 
 # Default cap on list_* tool results. Unbounded iteration over resource
@@ -40,6 +40,32 @@ def wrap_insecure_content(content: Any) -> Any:
     return (
         f"<insecure-content-{boundary}>\n{content}\n" f"</insecure-content-{boundary}>"
     )
+
+
+def _payload_attr(
+    resource: Any, name: str, convert: Optional[Callable[[Any], Any]] = None
+) -> Any:
+    """Read an attribute the Redmine payload may not have carried.
+
+    A missing attribute and a JSON null both answer ``None`` -- "not readable
+    on this token", never "false" or "empty". python-redmine raises
+    ``ResourceAttrError`` (an ``AttributeError`` subclass) for an attribute
+    absent from the response, which the three-argument ``getattr`` turns into
+    the default; a client configured with ``raise_attr_exception=False``
+    returns ``None`` directly. Both land here as ``None``, which is the honest
+    answer either way.
+
+    ``convert`` runs **only** on a value the payload really carried, so a
+    ``bool`` or list coercion can never manufacture ``False`` or ``[]`` for a
+    key Redmine never sent. That is the whole point: a plausible default is
+    indistinguishable from a real answer, so it must not be reachable.
+
+    Note this reads through ``Resource.__getattr__``, which for a name in the
+    resource's ``_includes`` or ``_relations`` will issue a second request
+    rather than report absence -- see :func:`_included_list` for that case.
+    """
+    value = getattr(resource, name, None)
+    return value if value is None or convert is None else convert(value)
 
 
 def _rewrite_to_public_url(url: Any) -> Any:

--- a/src/redmine_mcp_server/oauth_scopes.py
+++ b/src/redmine_mcp_server/oauth_scopes.py
@@ -306,11 +306,14 @@ TOOL_SCOPES: Dict[str, ToolScopeEntry] = {
     "list_project_members": frozenset({"view_members"}),
     # GET /roles.json needs authentication only.
     "list_redmine_roles": frozenset(),
-    # Reads GET /projects/{id}.json?include=issue_custom_fields, which Redmine
-    # renders only for a caller holding view_issues -- without it the array is
-    # omitted and the tool answers [], indistinguishable from "this project has
-    # no custom fields". Not /custom_fields.json, which this tool never calls.
-    "list_project_issue_custom_fields": frozenset({"view_issues"}),
+    # Reads GET /projects/{id}.json?include=issue_custom_fields, so it needs
+    # both: view_project for projects#show, and view_issues for the include,
+    # which Redmine renders only for a caller holding it -- without it the
+    # array is omitted and the tool answers [], indistinguishable from "this
+    # project has no custom fields". view_project being :public => true is not
+    # an exemption: Role#allowed_permissions intersects the public permissions
+    # with the token's scopes too. Not /custom_fields.json, never called here.
+    "list_project_issue_custom_fields": frozenset({"view_project", "view_issues"}),
     "manage_project_member": frozenset({"manage_members"}),
     # Redmine gates GET /projects/.../versions.json on view_issues.
     "list_redmine_versions": frozenset({"view_issues"}),

--- a/src/redmine_mcp_server/oauth_scopes.py
+++ b/src/redmine_mcp_server/oauth_scopes.py
@@ -306,8 +306,11 @@ TOOL_SCOPES: Dict[str, ToolScopeEntry] = {
     "list_project_members": frozenset({"view_members"}),
     # GET /roles.json needs authentication only.
     "list_redmine_roles": frozenset(),
-    # GET /custom_fields.json is admin-gated by Redmine itself.
-    "list_project_issue_custom_fields": frozenset(),
+    # Reads GET /projects/{id}.json?include=issue_custom_fields, which Redmine
+    # renders only for a caller holding view_issues -- without it the array is
+    # omitted and the tool answers [], indistinguishable from "this project has
+    # no custom fields". Not /custom_fields.json, which this tool never calls.
+    "list_project_issue_custom_fields": frozenset({"view_issues"}),
     "manage_project_member": frozenset({"manage_members"}),
     # Redmine gates GET /projects/.../versions.json on view_issues.
     "list_redmine_versions": frozenset({"view_issues"}),

--- a/src/redmine_mcp_server/oauth_scopes.py
+++ b/src/redmine_mcp_server/oauth_scopes.py
@@ -307,13 +307,15 @@ TOOL_SCOPES: Dict[str, ToolScopeEntry] = {
     # GET /roles.json needs authentication only.
     "list_redmine_roles": frozenset(),
     # Reads GET /projects/{id}.json?include=issue_custom_fields, so it needs
-    # both: view_project for projects#show, and view_issues for the include,
-    # which Redmine renders only for a caller holding it -- without it the
-    # array is omitted and the tool answers [], indistinguishable from "this
-    # project has no custom fields". view_project being :public => true is not
-    # an exemption: Role#allowed_permissions intersects the public permissions
-    # with the token's scopes too. Not /custom_fields.json, never called here.
-    "list_project_issue_custom_fields": frozenset({"view_project", "view_issues"}),
+    # view_project for projects#show and nothing beyond it. Every released
+    # Redmine gates the include on include_in_api_response? alone, with no
+    # permission check -- checked at 6.1.1, 6.1.2, 6.1.3 and 7.0.0 -- so
+    # requiring view_issues would refuse calls Redmine itself serves, and
+    # would hide the tool from tools/list for those tokens. view_project being
+    # :public => true is not an exemption: Role#allowed_permissions intersects
+    # the public permissions with the token's scopes too, so a token carrying
+    # no scopes is still refused. Not /custom_fields.json, never called here.
+    "list_project_issue_custom_fields": frozenset({"view_project"}),
     "manage_project_member": frozenset({"manage_members"}),
     # Redmine gates GET /projects/.../versions.json on view_issues.
     "list_redmine_versions": frozenset({"view_issues"}),

--- a/src/redmine_mcp_server/tools/projects.py
+++ b/src/redmine_mcp_server/tools/projects.py
@@ -323,7 +323,10 @@ def list_redmine_projects(
 
     With ``include_custom_fields`` this is the only tool that returns project
     custom field *values*, which are a different set from the issue custom
-    fields ``list_project_issue_custom_fields`` covers.
+    fields ``list_project_issue_custom_fields`` covers. No tool exposes custom
+    field *definitions* -- ``field_format``, ``is_required``,
+    ``possible_values`` -- for either set: Redmine serves those to
+    administrators only.
 
     Args:
         include_custom_fields: Add ``custom_fields`` to each project. Costs no

--- a/src/redmine_mcp_server/tools/projects.py
+++ b/src/redmine_mcp_server/tools/projects.py
@@ -10,7 +10,7 @@ from redminelib.exceptions import ResourceNotFoundError
 
 from .._cleanup import _ensure_cleanup_started
 from .._client import _get_redmine_client
-from .._custom_fields import _extract_possible_values
+from .._custom_fields import _normalize_possible_values
 from .._decorators import ActionMode, action_dispatch
 from .._errors import _handle_redmine_error
 from .._offload import in_thread, offloaded
@@ -18,6 +18,7 @@ from .._serialization import (
     _custom_fields_to_list,
     _named_ref,
     _pagination_info,
+    _payload_attr,
     _safe_isoformat,
     wrap_insecure_content,
 )
@@ -53,26 +54,6 @@ def _version_to_dict(version: Any) -> Dict[str, Any]:
     }
 
 
-# Sentinel for "the payload did not carry this attribute at all", which is
-# not the same answer as "Redmine sent a null". python-redmine raises
-# ResourceAttrError -- an AttributeError subclass -- for any attribute absent
-# from the response, so a two-argument getattr with a plausible default
-# silently invents data. Reading through this sentinel keeps absence visible.
-_ABSENT = object()
-
-
-def _payload_attr(custom_field: Any, name: str) -> Any:
-    """Return an attribute only if the Redmine payload actually carried it.
-
-    Returns :data:`_ABSENT` when the attribute is missing. A configured
-    ``raise_attr_exception=False`` client returns ``None`` for a missing
-    attribute instead of raising, which is indistinguishable from a real
-    null -- both end up as ``None`` in the output, which is the honest
-    answer either way.
-    """
-    return getattr(custom_field, name, _ABSENT)
-
-
 def _custom_field_trackers_to_list(
     custom_field: Any,
 ) -> Optional[List[Dict[str, Any]]]:
@@ -82,8 +63,8 @@ def _custom_field_trackers_to_list(
     caller can tell "this field is bound to no tracker" from "this response
     never described the bindings".
     """
-    raw_trackers = _payload_attr(custom_field, "trackers")
-    if raw_trackers is _ABSENT or raw_trackers is None:
+    raw_trackers = getattr(custom_field, "trackers", None)
+    if raw_trackers is None:
         return None
 
     try:
@@ -139,19 +120,32 @@ def _custom_field_applies_to_tracker(
     return False
 
 
-def _tracker_bindings_readable(custom_fields: List[Any]) -> bool:
-    """Whether *every* field in the payload described its tracker bindings.
+def _tracker_bindings_unreadable_reason(
+    custom_fields: List[Any], tracker_id: int
+) -> Optional[str]:
+    """Return why ``tracker_id`` cannot be applied, or ``None`` if it can.
 
-    Every, not any: one field with unreadable bindings is enough to make the
-    filtered list wrong, since that field would be dropped on no evidence.
-    ``GET /projects/{id}.json?include=issue_custom_fields`` never carries
-    bindings, so this is normally ``False`` and filtering is impossible
-    rather than merely empty. An empty field list counts as readable --
-    there is nothing to filter and an error would be noise.
+    Every field must describe its bindings, not just one: a single field with
+    unreadable bindings would be dropped from the filtered list on no
+    evidence, which is the silent widening this check exists to prevent. An
+    empty field list counts as readable -- there is nothing to filter and an
+    error would be noise.
+
+    The message describes what *this* response did or did not carry rather
+    than asserting what Redmine always does, because bindings are readable on
+    a payload that carries them (an admin-rendered definition, or a plugin)
+    and a fixed explanation would then be wrong for that deployment. Returns
+    ``None`` when filtering is safe, following ``_reject_reserved_query_keys``.
     """
-    return all(
+    if all(
         _custom_field_trackers_to_list(custom_field) is not None
         for custom_field in custom_fields
+    ):
+        return None
+    return (
+        f"Cannot filter by tracker_id {tracker_id}: this response did not "
+        "describe the tracker bindings of every custom field, so applying "
+        "the filter would drop fields on no evidence."
     )
 
 
@@ -161,28 +155,20 @@ def _custom_field_to_dict(custom_field: Any) -> Dict[str, Any]:
     Only ``id`` and ``name`` are ever present in the project include, so
     every other key is ``None`` unless the payload really carried it. ``None``
     means "not readable on this token", never "false" or "empty".
-    """
-    field_format = _payload_attr(custom_field, "field_format")
-    is_required = _payload_attr(custom_field, "is_required")
-    multiple = _payload_attr(custom_field, "multiple")
-    default_value = _payload_attr(custom_field, "default_value")
-    possible_values = _payload_attr(custom_field, "possible_values")
 
+    Each coercion is passed to :func:`_payload_attr` rather than applied
+    here, so it can only ever run on a value Redmine actually sent -- there
+    is no spelling of this that turns an absent key into ``False`` or ``[]``.
+    """
     return {
         "id": getattr(custom_field, "id", None),
         "name": getattr(custom_field, "name", None),
-        "field_format": None if field_format is _ABSENT else field_format,
-        "is_required": (
-            None if is_required is _ABSENT or is_required is None else bool(is_required)
-        ),
-        "multiple": (
-            None if multiple is _ABSENT or multiple is None else bool(multiple)
-        ),
-        "default_value": None if default_value is _ABSENT else default_value,
-        "possible_values": (
-            None
-            if possible_values is _ABSENT or possible_values is None
-            else _extract_possible_values(custom_field)
+        "field_format": _payload_attr(custom_field, "field_format"),
+        "is_required": _payload_attr(custom_field, "is_required", bool),
+        "multiple": _payload_attr(custom_field, "multiple", bool),
+        "default_value": _payload_attr(custom_field, "default_value"),
+        "possible_values": _payload_attr(
+            custom_field, "possible_values", _normalize_possible_values
         ),
         "trackers": _custom_field_trackers_to_list(custom_field),
     }
@@ -520,14 +506,23 @@ def list_redmine_projects(
 async def list_project_issue_custom_fields(
     project_id: Union[str, int], tracker_id: Optional[Union[str, int]] = None
 ) -> Union[List[Dict[str, Any]], Dict[str, Any]]:
-    """List issue custom fields configured for a project.
+    """List the ids and names of the issue custom fields enabled for a project.
+
+    Against a stock Redmine only ``id`` and ``name`` carry data. ``field_format``,
+    ``is_required``, ``multiple``, ``default_value``, ``possible_values`` and
+    ``trackers`` come back ``null``, meaning "not readable on this token" --
+    ``null`` is not ``false`` and not an empty list. In particular
+    ``is_required: null`` does not mean a field is optional, so a create or
+    update can still reject on a field listed here. Use the ids with
+    ``extra_fields={"custom_fields": [{"id": N, "value": ...}]}``, or pass the
+    field by name in ``fields``.
 
     Args:
         project_id: Project identifier (ID number or string identifier).
         tracker_id: Optional tracker ID to filter custom fields by
-            applicability. Only usable when the response describes each
-            field's tracker bindings, which stock Redmine does not do -- see
-            the note below.
+            applicability. Usable only when the response describes every
+            field's tracker bindings, which a stock Redmine does not send; it
+            returns an error rather than an unfiltered list when it cannot.
 
     Returns:
         A list of dicts with ``id``, ``name``, ``field_format``,
@@ -537,11 +532,10 @@ async def list_project_issue_custom_fields(
         ``isinstance(result, dict)`` to distinguish failure from an
         empty list).
 
-    **``null`` means "not readable on this token", never a default.** This
-    tool reads ``GET /projects/{id}.json?include=issue_custom_fields``,
-    which Redmine renders as exactly ``id`` and ``name`` per field
+    Why the six keys are unreadable: this tool reads
+    ``GET /projects/{id}.json?include=issue_custom_fields``, which Redmine
+    renders as exactly ``id`` and ``name`` per field
     (``app/helpers/projects_helper.rb``; unchanged in 6.1, 7.0 and trunk).
-    Every other key therefore comes back ``null`` against a stock server.
     The definitions live on ``GET /custom_fields.json``, which Redmine
     restricts to administrators (``before_action :require_admin``), so a
     non-admin token cannot obtain them at all -- and under OAuth even an
@@ -549,11 +543,8 @@ async def list_project_issue_custom_fields(
     requires the token to carry the ``admin`` scope, which this server
     never requests. Redmine has four open requests to expose this metadata
     to non-admins (redmine.org #18875, #41318, #42581, #43407), none with a
-    target version.
-
-    Do not read ``null`` as ``false`` or as an empty list. In particular
-    ``is_required: null`` means "unknown", so a create or update can still
-    reject on a field this tool could not describe.
+    target version. The keys are kept rather than dropped so the response
+    shape is stable and starts carrying data if that ever changes.
 
     **``is_required`` caveat (#119):** even where the flag *is* readable it
     only reflects the custom field *definition*. Required-ness can also be
@@ -609,22 +600,31 @@ async def list_project_issue_custom_fields(
             project = _get_redmine_client().project.get(
                 project_id, include="issue_custom_fields"
             )
-            custom_fields = list(getattr(project, "issue_custom_fields", None) or [])
+            # ResourceSet defines __len__ but not __bool__, so `or []` would
+            # construct every CustomField purely to test truthiness and then
+            # discard them. list() is still needed: __iter__ rebuilds each
+            # resource on every pass, and the sequence is walked more than once.
+            raw_custom_fields = getattr(project, "issue_custom_fields", None)
+            custom_fields = (
+                list(raw_custom_fields) if raw_custom_fields is not None else []
+            )
 
-            if parsed_tracker_id is not None and not _tracker_bindings_readable(
-                custom_fields
-            ):
-                return {
-                    "error": (
-                        f"Cannot filter by tracker_id {parsed_tracker_id}: this "
-                        "response does not describe tracker bindings. Redmine "
-                        "renders include=issue_custom_fields as id and name "
-                        "only, and exposes bindings solely on "
-                        "GET /custom_fields.json, which it restricts to "
-                        "administrators. Omit tracker_id to list every issue "
-                        "custom field enabled for the project."
-                    )
-                }
+            if parsed_tracker_id is not None:
+                reason = _tracker_bindings_unreadable_reason(
+                    custom_fields, parsed_tracker_id
+                )
+                if reason is not None:
+                    return {
+                        "error": reason,
+                        "code": "TRACKER_BINDINGS_UNREADABLE",
+                        "hint": (
+                            "Omit tracker_id to list every issue custom field "
+                            "enabled for the project. On a stock Redmine this "
+                            "is expected: include=issue_custom_fields renders "
+                            "id and name only, and bindings appear solely on "
+                            "GET /custom_fields.json, which is admin-only."
+                        ),
+                    }
 
             result: List[Dict[str, Any]] = []
             for custom_field in custom_fields:

--- a/src/redmine_mcp_server/tools/projects.py
+++ b/src/redmine_mcp_server/tools/projects.py
@@ -107,7 +107,7 @@ def _custom_field_applies_to_tracker(
     computes an issue's fields as ``project.all_issue_custom_fields &
     tracker.custom_fields`` (``app/models/issue.rb``), so an unbound field
     intersects to nothing. Callers must establish that bindings are readable
-    at all before filtering -- see :func:`_tracker_bindings_readable`.
+    at all before filtering -- see :func:`_tracker_bindings_unreadable_reason`.
     """
     if tracker_id is None:
         return True
@@ -538,7 +538,8 @@ async def list_project_issue_custom_fields(
     Why the six keys are unreadable: this tool reads
     ``GET /projects/{id}.json?include=issue_custom_fields``, which Redmine
     renders as exactly ``id`` and ``name`` per field
-    (``app/helpers/projects_helper.rb``; unchanged in 6.1, 7.0 and trunk).
+    (``app/helpers/projects_helper.rb``; the same two keys in 6.1, 7.0 and
+    trunk).
     The definitions live on ``GET /custom_fields.json``, which Redmine
     restricts to administrators (``before_action :require_admin``), so a
     non-admin token cannot obtain them at all -- and under OAuth even an

--- a/src/redmine_mcp_server/tools/projects.py
+++ b/src/redmine_mcp_server/tools/projects.py
@@ -53,16 +53,43 @@ def _version_to_dict(version: Any) -> Dict[str, Any]:
     }
 
 
-def _custom_field_trackers_to_list(custom_field: Any) -> List[Dict[str, Any]]:
-    """Serialize custom field tracker bindings into a predictable list."""
-    raw_trackers = getattr(custom_field, "trackers", None)
-    if raw_trackers is None:
-        return []
+# Sentinel for "the payload did not carry this attribute at all", which is
+# not the same answer as "Redmine sent a null". python-redmine raises
+# ResourceAttrError -- an AttributeError subclass -- for any attribute absent
+# from the response, so a two-argument getattr with a plausible default
+# silently invents data. Reading through this sentinel keeps absence visible.
+_ABSENT = object()
+
+
+def _payload_attr(custom_field: Any, name: str) -> Any:
+    """Return an attribute only if the Redmine payload actually carried it.
+
+    Returns :data:`_ABSENT` when the attribute is missing. A configured
+    ``raise_attr_exception=False`` client returns ``None`` for a missing
+    attribute instead of raising, which is indistinguishable from a real
+    null -- both end up as ``None`` in the output, which is the honest
+    answer either way.
+    """
+    return getattr(custom_field, name, _ABSENT)
+
+
+def _custom_field_trackers_to_list(
+    custom_field: Any,
+) -> Optional[List[Dict[str, Any]]]:
+    """Serialize custom field tracker bindings into a predictable list.
+
+    Returns ``None`` when the payload carries no tracker bindings, so a
+    caller can tell "this field is bound to no tracker" from "this response
+    never described the bindings".
+    """
+    raw_trackers = _payload_attr(custom_field, "trackers")
+    if raw_trackers is _ABSENT or raw_trackers is None:
+        return None
 
     try:
         iterator = iter(raw_trackers)
     except TypeError:
-        return []
+        return None
 
     trackers: List[Dict[str, Any]] = []
     for tracker in iterator:
@@ -93,15 +120,18 @@ def _custom_field_trackers_to_list(custom_field: Any) -> List[Dict[str, Any]]:
 def _custom_field_applies_to_tracker(
     custom_field: Any, tracker_id: Optional[int]
 ) -> bool:
-    """Return whether a custom field is available for the given tracker."""
+    """Return whether a custom field is available for the given tracker.
+
+    A field whose bindings are an empty list applies to no tracker: Redmine
+    computes an issue's fields as ``project.all_issue_custom_fields &
+    tracker.custom_fields`` (``app/models/issue.rb``), so an unbound field
+    intersects to nothing. Callers must establish that bindings are readable
+    at all before filtering -- see :func:`_tracker_bindings_readable`.
+    """
     if tracker_id is None:
         return True
 
-    trackers = _custom_field_trackers_to_list(custom_field)
-    if not trackers:
-        # No tracker restrictions exposed by Redmine -> treat as globally available.
-        return True
-
+    trackers = _custom_field_trackers_to_list(custom_field) or []
     for tracker in trackers:
         if tracker.get("id") == tracker_id:
             return True
@@ -109,16 +139,51 @@ def _custom_field_applies_to_tracker(
     return False
 
 
+def _tracker_bindings_readable(custom_fields: List[Any]) -> bool:
+    """Whether *every* field in the payload described its tracker bindings.
+
+    Every, not any: one field with unreadable bindings is enough to make the
+    filtered list wrong, since that field would be dropped on no evidence.
+    ``GET /projects/{id}.json?include=issue_custom_fields`` never carries
+    bindings, so this is normally ``False`` and filtering is impossible
+    rather than merely empty. An empty field list counts as readable --
+    there is nothing to filter and an error would be noise.
+    """
+    return all(
+        _custom_field_trackers_to_list(custom_field) is not None
+        for custom_field in custom_fields
+    )
+
+
 def _custom_field_to_dict(custom_field: Any) -> Dict[str, Any]:
-    """Convert project issue custom field metadata to a serializable dict."""
+    """Convert project issue custom field metadata to a serializable dict.
+
+    Only ``id`` and ``name`` are ever present in the project include, so
+    every other key is ``None`` unless the payload really carried it. ``None``
+    means "not readable on this token", never "false" or "empty".
+    """
+    field_format = _payload_attr(custom_field, "field_format")
+    is_required = _payload_attr(custom_field, "is_required")
+    multiple = _payload_attr(custom_field, "multiple")
+    default_value = _payload_attr(custom_field, "default_value")
+    possible_values = _payload_attr(custom_field, "possible_values")
+
     return {
         "id": getattr(custom_field, "id", None),
-        "name": getattr(custom_field, "name", ""),
-        "field_format": getattr(custom_field, "field_format", ""),
-        "is_required": bool(getattr(custom_field, "is_required", False)),
-        "multiple": bool(getattr(custom_field, "multiple", False)),
-        "default_value": getattr(custom_field, "default_value", None),
-        "possible_values": _extract_possible_values(custom_field),
+        "name": getattr(custom_field, "name", None),
+        "field_format": None if field_format is _ABSENT else field_format,
+        "is_required": (
+            None if is_required is _ABSENT or is_required is None else bool(is_required)
+        ),
+        "multiple": (
+            None if multiple is _ABSENT or multiple is None else bool(multiple)
+        ),
+        "default_value": None if default_value is _ABSENT else default_value,
+        "possible_values": (
+            None
+            if possible_values is _ABSENT or possible_values is None
+            else _extract_possible_values(custom_field)
+        ),
         "trackers": _custom_field_trackers_to_list(custom_field),
     }
 
@@ -459,23 +524,44 @@ async def list_project_issue_custom_fields(
 
     Args:
         project_id: Project identifier (ID number or string identifier).
-        tracker_id: Optional tracker ID to filter custom fields by applicability.
+        tracker_id: Optional tracker ID to filter custom fields by
+            applicability. Only usable when the response describes each
+            field's tracker bindings, which stock Redmine does not do -- see
+            the note below.
 
     Returns:
-        A list of custom field metadata dictionaries. On failure, a
-        dict with an ``"error"`` key is returned (callers should check
+        A list of dicts with ``id``, ``name``, ``field_format``,
+        ``is_required``, ``multiple``, ``default_value``,
+        ``possible_values`` and ``trackers``. On failure, a dict with an
+        ``"error"`` key is returned (callers should check
         ``isinstance(result, dict)`` to distinguish failure from an
         empty list).
 
-    **``is_required`` caveat (#119):** Redmine's
-    ``GET /custom_fields.json`` -- the underlying API -- only exposes the
-    flag set on the custom field *definition*. Required-ness can also be
+    **``null`` means "not readable on this token", never a default.** This
+    tool reads ``GET /projects/{id}.json?include=issue_custom_fields``,
+    which Redmine renders as exactly ``id`` and ``name`` per field
+    (``app/helpers/projects_helper.rb``; unchanged in 6.1, 7.0 and trunk).
+    Every other key therefore comes back ``null`` against a stock server.
+    The definitions live on ``GET /custom_fields.json``, which Redmine
+    restricts to administrators (``before_action :require_admin``), so a
+    non-admin token cannot obtain them at all -- and under OAuth even an
+    administrator's token cannot, because ``User#admin?`` additionally
+    requires the token to carry the ``admin`` scope, which this server
+    never requests. Redmine has four open requests to expose this metadata
+    to non-admins (redmine.org #18875, #41318, #42581, #43407), none with a
+    target version.
+
+    Do not read ``null`` as ``false`` or as an empty list. In particular
+    ``is_required: null`` means "unknown", so a create or update can still
+    reject on a field this tool could not describe.
+
+    **``is_required`` caveat (#119):** even where the flag *is* readable it
+    only reflects the custom field *definition*. Required-ness can also be
     imposed by **workflow rules**, **role-based field permissions**, or
     **tracker-bound required-field settings**, none of which are
-    reflected in this field. A custom field with
-    ``is_required: false`` here can still cause
-    ``create_redmine_issue`` / ``update_redmine_issue`` to reject with
-    ``"<field name> cannot be blank"``.
+    reflected in it. A custom field with ``is_required: false`` can still
+    cause ``create_redmine_issue`` / ``update_redmine_issue`` to reject
+    with ``"<field name> cannot be blank"``.
 
     No general-purpose API exists for the "effective" required state.
     Recovery when the create/update call rejects:
@@ -494,7 +580,9 @@ async def list_project_issue_custom_fields(
     3. **Autofill:** set
        ``REDMINE_AUTOFILL_REQUIRED_CUSTOM_FIELDS=true`` to have the
        server retry once with values from each field's ``default_value``
-       or the ``REDMINE_REQUIRED_CUSTOM_FIELD_DEFAULTS`` map.
+       or the ``REDMINE_REQUIRED_CUSTOM_FIELD_DEFAULTS`` map. Against a
+       stock Redmine only the env map can supply a value, since
+       ``default_value`` is not in the payload.
 
     ``create_redmine_issue`` and ``update_redmine_issue`` augment their
     validation error envelope with ``missing_required_fields`` and a
@@ -521,7 +609,22 @@ async def list_project_issue_custom_fields(
             project = _get_redmine_client().project.get(
                 project_id, include="issue_custom_fields"
             )
-            custom_fields = getattr(project, "issue_custom_fields", None) or []
+            custom_fields = list(getattr(project, "issue_custom_fields", None) or [])
+
+            if parsed_tracker_id is not None and not _tracker_bindings_readable(
+                custom_fields
+            ):
+                return {
+                    "error": (
+                        f"Cannot filter by tracker_id {parsed_tracker_id}: this "
+                        "response does not describe tracker bindings. Redmine "
+                        "renders include=issue_custom_fields as id and name "
+                        "only, and exposes bindings solely on "
+                        "GET /custom_fields.json, which it restricts to "
+                        "administrators. Omit tracker_id to list every issue "
+                        "custom field enabled for the project."
+                    )
+                }
 
             result: List[Dict[str, Any]] = []
             for custom_field in custom_fields:

--- a/tests/test_custom_field_helpers.py
+++ b/tests/test_custom_field_helpers.py
@@ -549,18 +549,24 @@ class TestCustomFieldTrackersToList:
     """Tests for _custom_field_trackers_to_list."""
 
     def test_no_trackers_attribute(self):
+        """Absent bindings are None, not an empty list.
+
+        An empty list is a real answer -- "bound to no tracker" -- so absence
+        has to be reported as something else or the caller cannot tell the two
+        apart.
+        """
         cf = Mock(spec=[])
-        assert _custom_field_trackers_to_list(cf) == []
+        assert _custom_field_trackers_to_list(cf) is None
 
     def test_none_trackers(self):
         cf = Mock()
         cf.trackers = None
-        assert _custom_field_trackers_to_list(cf) == []
+        assert _custom_field_trackers_to_list(cf) is None
 
     def test_not_iterable(self):
         cf = Mock()
         cf.trackers = 42
-        assert _custom_field_trackers_to_list(cf) == []
+        assert _custom_field_trackers_to_list(cf) is None
 
     def test_object_trackers(self):
         t = Mock()
@@ -605,10 +611,16 @@ class TestCustomFieldAppliesToTracker:
         cf = Mock()
         assert _custom_field_applies_to_tracker(cf, None) is True
 
-    def test_no_tracker_restrictions_applies(self):
+    def test_field_bound_to_no_tracker_does_not_apply(self):
+        """Redmine intersects, so an unbound field applies to no tracker.
+
+        ``Issue#available_custom_fields`` is ``project.all_issue_custom_fields
+        & tracker.custom_fields``, so a field with no trackers selected reaches
+        no issue. Treating empty as "applies to everything" was backwards.
+        """
         cf = Mock()
         cf.trackers = []
-        assert _custom_field_applies_to_tracker(cf, 5) is True
+        assert _custom_field_applies_to_tracker(cf, 5) is False
 
     def test_matching_tracker(self):
         t = Mock()

--- a/tests/test_custom_field_metadata_absence.py
+++ b/tests/test_custom_field_metadata_absence.py
@@ -1,0 +1,245 @@
+"""Custom field metadata must never be invented (#ISSUE).
+
+``list_project_issue_custom_fields`` reads
+``GET /projects/{id}.json?include=issue_custom_fields``, which Redmine renders
+as exactly ``id`` and ``name`` per field. Every other key it advertises has to
+come back ``null``, because a plausible-looking default -- ``is_required:
+false``, ``possible_values: []`` -- is byte-identical to a real answer and a
+caller cannot tell it apart.
+
+These tests deliberately avoid ``Mock``. A ``Mock`` answers every attribute
+access, so a serializer reading attributes Redmine never sent looks correct
+under it; that is why the fabricated defaults survived. The fakes here raise
+``ResourceAttrError`` for absent attributes, exactly as python-redmine does.
+"""
+
+import os
+import sys
+
+import pytest
+from redminelib.exceptions import ResourceAttrError
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from redmine_mcp_server.tools.projects import (  # noqa: E402
+    _custom_field_to_dict,
+    list_project_issue_custom_fields,
+)
+
+# The six keys the project include can never populate.
+UNKNOWABLE_KEYS = (
+    "field_format",
+    "is_required",
+    "multiple",
+    "default_value",
+    "possible_values",
+    "trackers",
+)
+
+
+class IncludeField:
+    """A custom field as python-redmine builds it from the project include.
+
+    Carries ``id`` and ``name``; every other attribute raises
+    ``ResourceAttrError`` (an ``AttributeError`` subclass), which is what
+    python-redmine does for an attribute absent from the response.
+    """
+
+    def __init__(self, field_id, name):
+        self.id = field_id
+        self.name = name
+
+    def __getattr__(self, attr):
+        raise ResourceAttrError()
+
+
+class RelaxedIncludeField:
+    """The same payload under a ``raise_attr_exception=False`` client.
+
+    python-redmine then returns ``None`` for a missing attribute instead of
+    raising. ``None`` is the honest answer either way -- what must not happen
+    is it being coerced to ``False`` or ``[]``.
+    """
+
+    def __init__(self, field_id, name):
+        self.id = field_id
+        self.name = name
+
+    def __getattr__(self, attr):
+        return None
+
+
+class AdminField:
+    """A custom field as ``GET /custom_fields.json`` renders it.
+
+    Not reachable through this tool today, but the serializer must pass real
+    metadata through untouched if a payload ever carries it -- a future
+    Redmine (redmine.org #43407) or a plugin.
+    """
+
+    def __init__(self, field_id, name, trackers):
+        self.id = field_id
+        self.name = name
+        self.field_format = "list"
+        self.is_required = True
+        self.multiple = True
+        self.default_value = "M"
+        self.possible_values = [{"value": "S"}, {"value": "M"}, {"value": "L"}]
+        self.trackers = trackers
+
+
+class Tracker:
+    def __init__(self, tracker_id, name):
+        self.id = tracker_id
+        self.name = name
+
+
+class FakeProject:
+    def __init__(self, custom_fields):
+        self.issue_custom_fields = custom_fields
+
+
+class TestSerializerNeverInvents:
+    """The serializer reports absence as absence."""
+
+    def test_include_payload_yields_null_for_every_unknowable_key(self):
+        result = _custom_field_to_dict(IncludeField(6, "Size"))
+
+        assert result["id"] == 6
+        assert result["name"] == "Size"
+        for key in UNKNOWABLE_KEYS:
+            assert result[key] is None, f"{key} was invented"
+
+    def test_no_unknowable_key_is_a_plausible_default(self):
+        """The regression this guards: false and [] read as real answers."""
+        result = _custom_field_to_dict(IncludeField(6, "Size"))
+
+        assert result["is_required"] is not False
+        assert result["multiple"] is not False
+        assert result["field_format"] != ""
+        assert result["possible_values"] != []
+        assert result["trackers"] != []
+
+    def test_required_field_does_not_report_false(self):
+        """Acceptance test: a field marked Required must not come back false.
+
+        The project include cannot say the field is required, so the only
+        correct answer is ``null``. ``false`` would be a claim Redmine never
+        made, and the caller acts on it -- omits the field, and the create
+        rejects with "cannot be blank".
+        """
+        result = _custom_field_to_dict(IncludeField(2, "Department"))
+
+        assert result["is_required"] is None
+        assert result["is_required"] is not False
+
+    def test_relaxed_client_none_is_not_coerced(self):
+        result = _custom_field_to_dict(RelaxedIncludeField(6, "Size"))
+
+        for key in UNKNOWABLE_KEYS:
+            assert result[key] is None, f"{key} was coerced from None"
+
+    def test_real_metadata_passes_through(self):
+        result = _custom_field_to_dict(AdminField(6, "Size", [Tracker(5, "Bug")]))
+
+        assert result["field_format"] == "list"
+        assert result["is_required"] is True
+        assert result["multiple"] is True
+        assert result["default_value"] == "M"
+        assert result["possible_values"] == ["S", "M", "L"]
+        assert result["trackers"] == [{"id": 5, "name": "Bug"}]
+
+    def test_genuinely_empty_bindings_stay_an_empty_list(self):
+        """An empty list is data; only absence is null."""
+        result = _custom_field_to_dict(AdminField(6, "Size", []))
+
+        assert result["trackers"] == []
+
+
+class TestTrackerFilterHonesty:
+    """``tracker_id`` refuses rather than returning an unfiltered list."""
+
+    @pytest.fixture
+    def client(self, monkeypatch):
+        class FakeClient:
+            def __init__(self):
+                self.project = self
+                self.calls = []
+
+            def get(self, project_id, **kwargs):
+                self.calls.append((project_id, kwargs))
+                return self.project_obj
+
+        fake = FakeClient()
+        monkeypatch.setattr("redmine_mcp_server._client.redmine", fake)
+        return fake
+
+    @pytest.mark.asyncio
+    async def test_errors_when_bindings_are_not_readable(self, client):
+        """The filter cannot work, so say so instead of answering wrongly.
+
+        Before this fix an unreadable binding was read as "applies to every
+        tracker", so the tool returned every field in the project and the
+        caller had no way to know its filter had been dropped.
+        """
+        client.project_obj = FakeProject(
+            [IncludeField(10, "Size"), IncludeField(11, "Department")]
+        )
+
+        result = await list_project_issue_custom_fields(project_id=41, tracker_id=5)
+
+        assert isinstance(result, dict)
+        assert "tracker_id" in result["error"]
+        assert "administrators" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_without_tracker_id_the_list_is_returned(self, client):
+        client.project_obj = FakeProject([IncludeField(10, "Size")])
+
+        result = await list_project_issue_custom_fields(project_id=41)
+
+        assert isinstance(result, list)
+        assert [field["id"] for field in result] == [10]
+
+    @pytest.mark.asyncio
+    async def test_filters_when_bindings_are_readable(self, client):
+        bug = Tracker(5, "Bug")
+        feature = Tracker(7, "Feature")
+        client.project_obj = FakeProject(
+            [
+                AdminField(10, "Bug-only", [bug]),
+                AdminField(11, "Feature-only", [feature]),
+            ]
+        )
+
+        result = await list_project_issue_custom_fields(project_id=41, tracker_id=5)
+
+        assert [field["id"] for field in result] == [10]
+
+    @pytest.mark.asyncio
+    async def test_field_bound_to_no_tracker_is_excluded(self, client):
+        """Redmine intersects; an unbound field applies to no tracker.
+
+        ``Issue#available_custom_fields`` is ``project.all_issue_custom_fields
+        & tracker.custom_fields``, so a field with no trackers selected
+        reaches no issue. It must not be reported as applying to tracker 5.
+        """
+        client.project_obj = FakeProject(
+            [
+                AdminField(10, "Bug-only", [Tracker(5, "Bug")]),
+                AdminField(12, "Unbound", []),
+            ]
+        )
+
+        result = await list_project_issue_custom_fields(project_id=41, tracker_id=5)
+
+        assert [field["id"] for field in result] == [10]
+
+    @pytest.mark.asyncio
+    async def test_empty_project_does_not_error_on_tracker_id(self, client):
+        """Nothing to filter is not a failure to filter."""
+        client.project_obj = FakeProject([])
+
+        result = await list_project_issue_custom_fields(project_id=41, tracker_id=5)
+
+        assert result == []

--- a/tests/test_custom_field_metadata_absence.py
+++ b/tests/test_custom_field_metadata_absence.py
@@ -37,7 +37,15 @@ UNKNOWABLE_KEYS = (
 )
 
 
-class IncludeField:
+class _Field:
+    """Base for the include fakes: carries only what the include carries."""
+
+    def __init__(self, field_id, name):
+        self.id = field_id
+        self.name = name
+
+
+class IncludeField(_Field):
     """A custom field as python-redmine builds it from the project include.
 
     Carries ``id`` and ``name``; every other attribute raises
@@ -45,25 +53,17 @@ class IncludeField:
     python-redmine does for an attribute absent from the response.
     """
 
-    def __init__(self, field_id, name):
-        self.id = field_id
-        self.name = name
-
     def __getattr__(self, attr):
         raise ResourceAttrError()
 
 
-class RelaxedIncludeField:
+class RelaxedIncludeField(_Field):
     """The same payload under a ``raise_attr_exception=False`` client.
 
     python-redmine then returns ``None`` for a missing attribute instead of
     raising. ``None`` is the honest answer either way -- what must not happen
     is it being coerced to ``False`` or ``[]``.
     """
-
-    def __init__(self, field_id, name):
-        self.id = field_id
-        self.name = name
 
     def __getattr__(self, attr):
         return None
@@ -102,23 +102,20 @@ class FakeProject:
 class TestSerializerNeverInvents:
     """The serializer reports absence as absence."""
 
-    def test_include_payload_yields_null_for_every_unknowable_key(self):
-        result = _custom_field_to_dict(IncludeField(6, "Size"))
+    @pytest.mark.parametrize("field_cls", [IncludeField, RelaxedIncludeField])
+    def test_every_unknowable_key_is_null(self, field_cls):
+        """Absence answers null under both client configurations.
+
+        The regression this guards: ``false`` and ``[]`` are byte-identical
+        to real answers, so a caller cannot tell an invented default from a
+        value Redmine actually sent. ``is None`` covers all of them at once.
+        """
+        result = _custom_field_to_dict(field_cls(6, "Size"))
 
         assert result["id"] == 6
         assert result["name"] == "Size"
         for key in UNKNOWABLE_KEYS:
             assert result[key] is None, f"{key} was invented"
-
-    def test_no_unknowable_key_is_a_plausible_default(self):
-        """The regression this guards: false and [] read as real answers."""
-        result = _custom_field_to_dict(IncludeField(6, "Size"))
-
-        assert result["is_required"] is not False
-        assert result["multiple"] is not False
-        assert result["field_format"] != ""
-        assert result["possible_values"] != []
-        assert result["trackers"] != []
 
     def test_required_field_does_not_report_false(self):
         """Acceptance test: a field marked Required must not come back false.
@@ -132,12 +129,6 @@ class TestSerializerNeverInvents:
 
         assert result["is_required"] is None
         assert result["is_required"] is not False
-
-    def test_relaxed_client_none_is_not_coerced(self):
-        result = _custom_field_to_dict(RelaxedIncludeField(6, "Size"))
-
-        for key in UNKNOWABLE_KEYS:
-            assert result[key] is None, f"{key} was coerced from None"
 
     def test_real_metadata_passes_through(self):
         result = _custom_field_to_dict(AdminField(6, "Size", [Tracker(5, "Bug")]))
@@ -164,10 +155,8 @@ class TestTrackerFilterHonesty:
         class FakeClient:
             def __init__(self):
                 self.project = self
-                self.calls = []
 
             def get(self, project_id, **kwargs):
-                self.calls.append((project_id, kwargs))
                 return self.project_obj
 
         fake = FakeClient()
@@ -189,8 +178,13 @@ class TestTrackerFilterHonesty:
         result = await list_project_issue_custom_fields(project_id=41, tracker_id=5)
 
         assert isinstance(result, dict)
+        assert result["code"] == "TRACKER_BINDINGS_UNREADABLE"
         assert "tracker_id" in result["error"]
-        assert "administrators" in result["error"]
+        # The error describes this response; the standing Redmine explanation
+        # belongs in the hint, so it cannot become a false claim on a
+        # deployment where bindings really are readable.
+        assert "Omit tracker_id" in result["hint"]
+        assert "admin-only" in result["hint"]
 
     @pytest.mark.asyncio
     async def test_without_tracker_id_the_list_is_returned(self, client):

--- a/tests/test_custom_field_metadata_absence.py
+++ b/tests/test_custom_field_metadata_absence.py
@@ -1,4 +1,4 @@
-"""Custom field metadata must never be invented (#ISSUE).
+"""Custom field metadata must never be invented (#232).
 
 ``list_project_issue_custom_fields`` reads
 ``GET /projects/{id}.json?include=issue_custom_fields``, which Redmine renders

--- a/tests/test_list_project_issue_custom_fields.py
+++ b/tests/test_list_project_issue_custom_fields.py
@@ -98,7 +98,12 @@ class TestListProjectIssueCustomFields:
     async def test_list_project_issue_custom_fields_filters_by_tracker(
         self, mock_redmine
     ):
-        """Tracker filtering keeps matching and global (unrestricted) custom fields."""
+        """Tracker filtering keeps only fields bound to the given tracker.
+
+        A field with no bindings is not "global": Redmine computes an issue's
+        fields as ``project.all_issue_custom_fields & tracker.custom_fields``
+        (``app/models/issue.rb``), so an unbound field intersects to nothing.
+        """
         tracker_bug = Mock()
         tracker_bug.id = 5
         tracker_bug.name = "Bug"
@@ -113,16 +118,15 @@ class TestListProjectIssueCustomFields:
         for_feature = create_mock_custom_field(
             field_id=11, name="Feature-only", trackers=[tracker_feature]
         )
-        global_field = create_mock_custom_field(field_id=12, name="Global", trackers=[])
+        unbound = create_mock_custom_field(field_id=12, name="Unbound", trackers=[])
 
         project = Mock()
-        project.issue_custom_fields = [for_bug, for_feature, global_field]
+        project.issue_custom_fields = [for_bug, for_feature, unbound]
         mock_redmine.project.get.return_value = project
 
         result = await list_project_issue_custom_fields(project_id=41, tracker_id=5)
 
-        assert len(result) == 2
-        assert {field["id"] for field in result} == {10, 12}
+        assert {field["id"] for field in result} == {10}
 
     @pytest.mark.asyncio
     async def test_list_project_issue_custom_fields_accepts_string_tracker_id(


### PR DESCRIPTION
## Summary

Fixes #232. `list_project_issue_custom_fields` advertised eight keys per custom field and Redmine only sends two, so six of them were `getattr` fallbacks: `field_format: ""`, `is_required: false`, `multiple: false`, `default_value: null`, `possible_values: []`, `trackers: []`, for every field, always. Those six now report `null`, documented as "not readable on this token".

`is_required: false` was the one that cost callers turns. It is byte-identical to a real "this field is optional", so nothing downstream could detect it was invented — the caller omitted the field and Redmine rejected the create with `"<field> cannot be blank"`. That is the failure #119 reported. #119 landed a docstring caveat about workflow rules and role-based field permissions, which is accurate and is kept here, but it is not why the flag is always false: the flag is a local default that never came from Redmine at all.

## Why null rather than the admin endpoint

The definitions live on `GET /custom_fields.json`, which Redmine restricts to administrators (`before_action :require_admin`, still covering `index` in 7.0). No permission or setting relaxes it: `require_admin` is a bare `User.current.admin?` and no custom-field permission is registered in `lib/redmine.rb`. Under OAuth it is stricter — `User#admin?` is `super and @oauth_scope.include?(:admin)`, so even an administrator's token is refused unless it carries `admin`, which this server never advertises.

So a fallback to that endpoint would help only API-key deployments whose key belongs to an admin, cost everyone else a guaranteed 403 per call, and make the response shape depend on the caller's privileges. Reporting absence honestly is the smaller and more predictable fix.

Redmine is not about to close the gap from its side either: [#18875](https://www.redmine.org/issues/18875), [#41318](https://www.redmine.org/issues/41318), [#42581](https://www.redmine.org/issues/42581) and [#43407](https://www.redmine.org/issues/43407) all ask for this metadata on a non-admin path, the oldest from 2015, none with a target version. #43407 asks for exactly these five keys on exactly this include.

The keys are kept rather than dropped, so the response shape stays stable across deployments and so they start carrying real data for free if a future Redmine populates the include.

## Changes

Each section stands alone; drop any hunk you disagree with.

**`_custom_field_to_dict` reports absence as absence.** Every key is read through a new `_payload_attr` helper in `_serialization.py`, which takes the coercion as an argument and applies it *only* to a value the payload actually carried. That is the part that matters: `bool` and the `possible_values` normalizer can no longer run on a key Redmine never sent, so there is no spelling of this serializer that turns an absent key back into `false` or `[]`. python-redmine raises `ResourceAttrError`, an `AttributeError` subclass, for an attribute absent from a response, which is what a three-argument `getattr` was silently swallowing; a client configured with `raise_attr_exception=False` returns `None` instead, and both land as `null`. Real data still passes through untouched, including `possible_values` in the `[{"value": ...}]` shape the admin endpoint uses, so the serializer is correct for any payload rather than hardcoded for one.

It lives in `_serialization.py` rather than in `tools/projects.py` because the same "an absent key became a plausible default" pattern is present in several sibling serializers; this puts the primitive where those fixes can reuse it instead of each inventing its own sentinel. `_extract_possible_values` gains a `_normalize_possible_values` half so the attribute is read once, under one absence rule, rather than twice under two.

`name` also loses its `""` default. Redmine always sends it, so the default was unreachable, but `""` is the same category of invented answer.

**`tracker_id` errors instead of returning an unfiltered list.** Tracker bindings are part of the admin-only definition, so `_custom_field_applies_to_tracker` was reading absent bindings as "applies to every tracker" and the filter silently returned every field in the project — a caller could not tell a filtered list from an unfiltered one. Passing `tracker_id` when bindings are unreadable now returns an `error` with `code: "TRACKER_BINDINGS_UNREADABLE"` and the recovery in `hint`, matching the shape the existing refused preconditions use (`CONFIRMATION_REQUIRED`, `CHILDREN_PRESENT`, `ATTACHMENT_UNAVAILABLE`). The `error` describes what *this* response carried rather than asserting what Redmine always does, since bindings are readable on a payload that includes them and a fixed explanation would be wrong for that deployment; the standing Redmine reason sits in the `hint`. An empty project is not an error: there is nothing to filter.

Where bindings *are* readable, a field bound to no tracker is now excluded rather than treated as global. `Issue#available_custom_fields` is `project.all_issue_custom_fields & tracker.custom_fields`, so an unbound field intersects to nothing and reaches no issue; "empty means global" had it backwards.

**`view_project` and `view_issues` on the scope map.** `TOOL_SCOPES` mapped this tool to `frozenset()`, justified by a comment about `/custom_fields.json` being admin-gated — an endpoint the tool has never called (`git log -S 'custom_fields.json' -- src` finds it only in comments and docstrings). The include it does call is rendered only for a caller holding `view_issues` and is omitted otherwise, so a token without that scope received `[]`, indistinguishable from "this project has no custom fields". Same reasoning as the existing `list_redmine_versions` entry.

`view_project` is needed as well, for `projects#show` itself. It is declared `:public => true`, which is easy to read as an exemption and is not one: `Role#allowed_permissions` is `unscoped = permissions + Redmine::AccessControl.public_permissions...` followed by `scope.present? ? unscoped & scope : unscoped`, so the public permissions are intersected with the token's scopes too. A token scoped only `view_issues` would therefore be admitted by this server's own middleware and then refused by Redmine with an opaque 403 — the failure the scope map exists to turn into a clear denial. `summarize_project_status` already maps both for the same `project.get()` call.

**Docs.** The docstring no longer names `GET /custom_fields.json` as the underlying API, and the `null` contract moves into the leading prose. That last part is not cosmetic: FastMCP keeps only the leading prose as the tool description and lifts `Args:` entries into the per-parameter schema, dropping everything after them — so the entire "null does not mean false" guarantee was invisible to a model calling the tool, and the surviving one-line description still promised "custom fields configured for a project". Dumping the registered tool confirms both the old omission and the fix. `docs/tool-reference.md` loses the "including allowed values and tracker bindings" headline and the example output that no token can produce, and gains the `null` contract plus links to the four Redmine tracker items. The autofill notes in `README.md` and `docs/tool-reference.md` record that the `default_value` half is inert against a stock Redmine, since `default_value` is not in the include the server reads — only `REDMINE_REQUIRED_CUSTOM_FIELD_DEFAULTS` can supply a value. No behaviour change there; it just no longer promises something it cannot do.

## Tests

New `tests/test_custom_field_metadata_absence.py`, which deliberately does not use `Mock`. That is the point: a `Mock` answers every attribute access, so a serializer reading attributes Redmine never sent looks correct under it, which is why the existing suite was green against the fabricated defaults. The fakes here raise `ResourceAttrError` for absent attributes exactly as python-redmine does, with a second fake covering the `raise_attr_exception=False` client that returns `None` instead.

Covers: the include payload yielding `null` for all six keys, parametrized across both client configurations; the acceptance test from the issue, that a required field does not report `false`; real metadata passing through when a payload does carry it; a genuinely empty binding list staying `[]` rather than becoming `null`; `tracker_id` erroring with its `code` and `hint` when bindings are unreadable, filtering when they are, excluding an unbound field, and not erroring on an empty project.

Each behaviour change was mutation-checked: reverting the serializer to its fabricating defaults, and restoring "no bindings means global", each turn the new tests red. A test that cannot fail is not evidence.

Four existing assertions in `tests/test_custom_field_helpers.py` and one in `tests/test_list_project_issue_custom_fields.py` asserted the old contract (`[]` for absent bindings, empty bindings applying to every tracker). Updated with the reasoning inline rather than deleted.

`1857 passed, 0 failed` on the full non-integration suite, measured from a clean `git archive` of the head rather than a working tree, against a `1847 passed` baseline on `develop`. `flake8` and `black --check` are clean on every file this branch touches.

## Compatibility

Breaking for a caller that reads the six keys as booleans or lists, which is the intent — those values were never Redmine's. A caller doing `if field["is_required"]:` is unaffected, since `null` and `false` are both falsy; one doing `field["is_required"] is False` or `for v in field["possible_values"]` needs a null check. `id` and `name` are unchanged, so name-keyed and id-keyed custom field writes are unaffected, as is `docs/troubleshooting.md`'s advice to find a field id with this tool.

Two behaviour changes beyond the null shape: `tracker_id` now errors where it used to return everything, and the tool now requires the `view_project` and `view_issues` scopes where it required none. Both scopes are ones this server already advertises, so no deployment needs a new consent — a token that could usefully call this tool already carries them, and one that could not now gets a clear denial instead of a 403.

## Verification

Redmine's renderer was read at `6.1-stable`, `7.0-stable` and `master` — `app/helpers/projects_helper.rb` is byte-identical in all three, and the whole API surface was grepped for the definition keys (`field_format|is_required|possible_values|is_filter` across every `*.api.rsb` and helper): only `custom_fields/index.api.rsb` has them. `/trackers.json` exposes `enabled_standard_fields`, core fields only. The one partial exception is `multiple: true` on issue *value* payloads (`custom_fields_helper.rb`), emitted only when true, which is not a definition endpoint and is not used here.

Behaviour was confirmed against a live 6.1 instance with a non-admin API key: the include returns 18 fields whose keys are exactly `id` and `name`, `GET /custom_fields.json` returns 403, and the field marked Required in admin reported `is_required: false` before this change and `null` after.
