### PR TITLE
feat: return the caller's project memberships from get_current_user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `get_current_user` can return the caller's project memberships via
+  `include_memberships=True`, as `[{id, project: {id, name}, roles: [{id,
+  name}]}]` using Redmine's own keys. A role inherited from a group
+  membership carries `inherited: true`, the key being absent for a direct
+  role exactly as Redmine renders it. Previously nothing answered "which
+  projects do I hold, with which roles": `list_project_members` costs one
+  request per project. The include rides the existing
+  `GET /users/current.json` call, so this adds no request and needs no new
+  scope -- Redmine gates neither the endpoint nor the memberships block on
+  a permission, and already narrows the list to projects visible to the
+  caller. `groups`, the other include python-redmine accepts here, is
+  deliberately not offered: Redmine gates that block on the caller being an
+  admin, so a non-admin would get a 200 with the key missing, which is
+  indistinguishable from belonging to no groups
+  ([#ISSUE](https://github.com/jztan/redmine-mcp-server/issues/ISSUE)).
+
+### Fixed
+- `get_current_user` docs said the tool resolves to `GET /my/account.json`.
+  It resolves to `GET /users/current.json`; python-redmine only rewrites the
+  path for the `me` id, not `current`. The distinction matters because
+  `/my/account.json` renders no memberships at all.
 
 ## [2.12.0] - 2026-08-22
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   deliberately not offered: Redmine gates that block on the caller being an
   admin, so a non-admin would get a 200 with the key missing, which is
   indistinguishable from belonging to no groups
-  ([#ISSUE](https://github.com/jztan/redmine-mcp-server/issues/ISSUE)).
+  ([#236](https://github.com/jztan/redmine-mcp-server/issues/236)).
 
 ### Fixed
 - `get_current_user` docs said the tool resolves to `GET /my/account.json`.

--- a/docs/tool-reference.md
+++ b/docs/tool-reference.md
@@ -1661,11 +1661,16 @@ list_redmine_users(name="alice")
 
 ### `get_current_user`
 
-Retrieve the currently authenticated user's profile. Resolves to `GET /my/account.json`, so works for any authenticated user (not admin-only). Useful when a user asks the LLM to do something "for me" — the LLM can call this to resolve the current user's ID.
+Retrieve the currently authenticated user's profile. Resolves to `GET /users/current.json`, and works for any authenticated user (not admin-only) — Redmine exempts the `show` action from its admin filter and resolves the `current` id behind a plain login check. Useful when a user asks the LLM to do something "for me" — the LLM can call this to resolve the current user's ID.
 
-**Parameters:** None.
+With `include_memberships` it also answers "which projects am I a member of, and with which roles" in the same request. The alternative is `list_project_members` once per project.
 
-**Returns:** Dict with `id, login, firstname, lastname, mail, admin, created_on, last_login_on`.
+**Parameters:**
+- `include_memberships` (boolean, optional): Add `memberships` to the response. Default `false`. Costs no extra request — the include rides the same call.
+
+**Returns:** Dict with `id, login, firstname, lastname, mail, admin, created_on, last_login_on`. With `include_memberships`, also `memberships`: a list of `{id, project: {id, name}, roles: [{id, name}]}` entries, empty when the caller holds none. A role inherited from a group membership carries `inherited: true`; Redmine omits the key for a direct role, and so does this tool. Redmine limits the list to projects visible to the caller.
+
+Groups are deliberately not offered as an include: Redmine gates that block on the caller being an admin, so a non-admin would get a success response with the key simply missing — indistinguishable from "belongs to no groups".
 
 **Example:**
 ```json
@@ -1678,6 +1683,25 @@ Retrieve the currently authenticated user's profile. Resolves to `GET /my/accoun
   "admin": false,
   "created_on": "2025-01-15T10:00:00",
   "last_login_on": "2026-04-16T09:30:00"
+}
+```
+
+**Example** (`include_memberships=True`):
+```json
+{
+  "id": 5,
+  "login": "alice",
+  "admin": false,
+  "memberships": [
+    {
+      "id": 12,
+      "project": {"id": 1, "name": "Website"},
+      "roles": [
+        {"id": 3, "name": "Developer"},
+        {"id": 4, "name": "Manager", "inherited": true}
+      ]
+    }
+  ]
 }
 ```
 

--- a/docs/tool-reference.md
+++ b/docs/tool-reference.md
@@ -1668,7 +1668,7 @@ With `include_memberships` it also answers "which projects am I a member of, and
 **Parameters:**
 - `include_memberships` (boolean, optional): Add `memberships` to the response. Default `false`. Costs no extra request — the include rides the same call.
 
-**Returns:** Dict with `id, login, firstname, lastname, mail, admin, created_on, last_login_on`. With `include_memberships`, also `memberships`: a list of `{id, project: {id, name}, roles: [{id, name}]}` entries, empty when the caller holds none. A role inherited from a group membership carries `inherited: true`; Redmine omits the key for a direct role, and so does this tool. Redmine limits the list to projects visible to the caller.
+**Returns:** Dict with `id, login, firstname, lastname, mail, admin, created_on, last_login_on`. With `include_memberships`, also `memberships`: a list of `{id, project: {id, name}, roles: [{id, name}]}` entries. A role inherited from a group membership carries `inherited: true`; Redmine omits the key for a direct role, and so does this tool. Redmine limits the list to projects visible to the caller, which covers active and closed projects but not archived ones -- so an empty list means "holds none that are visible", not necessarily "holds none".
 
 Groups are deliberately not offered as an include: Redmine gates that block on the caller being an admin, so a non-admin would get a success response with the key simply missing — indistinguishable from "belongs to no groups".
 

--- a/src/redmine_mcp_server/_http_routes.py
+++ b/src/redmine_mcp_server/_http_routes.py
@@ -119,11 +119,10 @@ async def _probe_redmine_legacy() -> tuple[str, str | None]:
     # Use httpx directly against /users/current.json.
     # This endpoint works on Redmine 3.x and later (/my/account.json is
     # not reliably available on older instances).
-    # Kept on httpx so this health check stays independent of the client and
-    # its configuration -- not because the endpoint needs admin. It does not:
-    # `show` is exempt from `require_admin`, `find_user` resolves `current`
-    # behind a bare `require_login`, and `Principal.visible`'s non-admin
-    # branch matches `id = user.id`, so a caller always sees their own record.
+    # Deliberately not via the client: this probe's job is to validate the
+    # credentials and config the client is built from. Not because the
+    # endpoint needs admin -- see the `get_current_user` note in
+    # `oauth_scopes.py`.
     url = REDMINE_URL.rstrip("/") + "/users/current.json"
     try:
         if REDMINE_API_KEY:

--- a/src/redmine_mcp_server/_http_routes.py
+++ b/src/redmine_mcp_server/_http_routes.py
@@ -119,8 +119,11 @@ async def _probe_redmine_legacy() -> tuple[str, str | None]:
     # Use httpx directly against /users/current.json.
     # This endpoint works on Redmine 3.x and later (/my/account.json is
     # not reliably available on older instances).
-    # redminelib's user.get('current') is NOT used here because it requires
-    # admin rights on some Redmine setups.
+    # Kept on httpx so this health check stays independent of the client and
+    # its configuration -- not because the endpoint needs admin. It does not:
+    # `show` is exempt from `require_admin`, `find_user` resolves `current`
+    # behind a bare `require_login`, and `Principal.visible`'s non-admin
+    # branch matches `id = user.id`, so a caller always sees their own record.
     url = REDMINE_URL.rstrip("/") + "/users/current.json"
     try:
         if REDMINE_API_KEY:

--- a/src/redmine_mcp_server/oauth_scopes.py
+++ b/src/redmine_mcp_server/oauth_scopes.py
@@ -351,6 +351,14 @@ TOOL_SCOPES: Dict[str, ToolScopeEntry] = {
     "list_redmine_issue_priorities": frozenset(),
     # GET /users.json is admin-gated by Redmine itself.
     "list_redmine_users": frozenset(),
+    # GET /users/current.json is exempt from UsersController's require_admin
+    # filter and resolves 'current' behind a bare require_login, so any token
+    # may call it. include_memberships does not change that: the memberships
+    # block in app/views/users/show.api.rsb has no permission check, and
+    # Redmine already narrows the list with Project.visible_condition for the
+    # caller. view_members would be the wrong scope to require -- it gates
+    # GET /projects/:id/memberships.json, i.e. reading who else is a member,
+    # and demanding it would deny a call Redmine itself allows.
     "get_current_user": frozenset(),
     # --- meta ---
     "get_mcp_server_info": frozenset(),

--- a/src/redmine_mcp_server/tools/enumeration.py
+++ b/src/redmine_mcp_server/tools/enumeration.py
@@ -12,7 +12,12 @@ from pydantic import Field
 from .._client import _get_redmine_client
 from .._errors import _handle_redmine_error
 from .._offload import offloaded
-from .._serialization import _iter_capped, _safe_isoformat
+from .._serialization import (
+    _included_list,
+    _iter_capped,
+    _named_ref,
+    _safe_isoformat,
+)
 from ..server import mcp
 
 
@@ -180,28 +185,134 @@ def list_redmine_users(
         return _handle_redmine_error(e, "listing users")
 
 
+def _membership_roles_to_list(raw_roles: Any) -> List[Dict[str, Any]]:
+    """Serialize the ``roles`` array of one user-show membership entry.
+
+    Redmine renders each role as ``{id, name}`` and merges ``inherited =>
+    true`` onto it when the role arrives through a group membership
+    (``app/views/users/show.api.rsb``). It omits the key otherwise, so the
+    key is mirrored only when present -- a hard-coded ``inherited: false``
+    would be a claim Redmine never made, and it is the one field that tells
+    "I hold Manager here" apart from "a group I am in does".
+    """
+    if not isinstance(raw_roles, list):
+        return []
+
+    roles: List[Dict[str, Any]] = []
+    for role in raw_roles:
+        if not isinstance(role, dict):
+            continue
+        entry: Dict[str, Any] = {
+            "id": role.get("id"),
+            "name": role.get("name", ""),
+        }
+        if "inherited" in role:
+            entry["inherited"] = role["inherited"]
+        roles.append(entry)
+    return roles
+
+
+def _current_user_memberships(user: Any) -> List[Dict[str, Any]]:
+    """Serialize the caller's ``include=memberships`` payload.
+
+    Read through ``_included_list``, never ``user.memberships``: for a name
+    in ``User._includes`` python-redmine's ``Resource.__getattr__`` pops the
+    key from the decoded payload and, finding it absent, calls
+    ``refresh(itself=False, include=attr)`` -- a second HTTP request for data
+    the first response already carried
+    (``redminelib/resources/base.py``). Passing the include on the original
+    ``get`` and reading the payload keeps it at one request.
+
+    Deliberately not ``tools.projects._membership_to_dict``, because the two
+    payloads are different shapes:
+
+    - That helper reads resource attributes with ``getattr``; these entries
+      are decoded payload dicts, on which ``getattr`` would silently yield
+      ``{"id": None, "name": ""}``.
+    - It emits ``user`` and ``group``. Redmine's user-show renderer emits
+      neither -- the user is the caller, implicitly -- so both would come
+      back ``None``, indistinguishable from a membership naming no principal.
+    - It flattens roles to ``{id, name}`` and so would drop ``inherited``.
+
+    Widening the shared helper to cover all three would change
+    ``list_project_members`` output, which has its own callers and belongs in
+    its own change.
+    """
+    memberships: List[Dict[str, Any]] = []
+    for membership in _included_list(user, "memberships"):
+        if not isinstance(membership, dict):
+            continue
+        memberships.append(
+            {
+                "id": membership.get("id"),
+                "project": _named_ref(membership.get("project")),
+                "roles": _membership_roles_to_list(membership.get("roles")),
+            }
+        )
+    return memberships
+
+
 @mcp.tool()
 @offloaded
-def get_current_user() -> Dict[str, Any]:
+def get_current_user(include_memberships: bool = False) -> Dict[str, Any]:
     """Retrieve the currently authenticated user's profile.
 
-    Resolves to ``GET /my/account.json`` under the hood. Works for any
-    authenticated user (not admin-only). Useful when an LLM needs to
+    Resolves to ``GET /users/current.json`` under the hood. Works for any
+    authenticated user (not admin-only): Redmine's ``UsersController``
+    exempts ``show`` from ``require_admin`` and resolves the ``current``
+    id behind a bare ``require_login``. Useful when an LLM needs to
     identify "me" — for example, when a user says "log 2h on this issue
     for me", the LLM can call this tool to get the current user's ID.
+
+    With ``include_memberships`` it also answers "which projects am I a
+    member of, and with which roles" in that same request. The only other
+    way to get that is ``list_project_members`` once per project.
+
+    Args:
+        include_memberships: Add ``memberships`` to the response. Costs no
+            extra request -- the include rides the same call -- so this is
+            opt-in only to keep the default response small.
 
     Returns:
         A dictionary with ``id``, ``login``, ``firstname``, ``lastname``,
         ``mail``, ``admin`` (bool), ``created_on``, and ``last_login_on``.
-        On failure, a dict with an ``"error"`` key.
+        With ``include_memberships``, also ``memberships``: a list of
+        ``{id, project: {id, name}, roles: [{id, name}]}`` entries, empty
+        when the caller holds none. A role inherited from a group
+        membership carries ``inherited: true``; the key is absent
+        otherwise, mirroring Redmine. Redmine limits the list to projects
+        visible to the caller. On failure, a dict with an ``"error"`` key.
 
     Example:
-        >>> await get_current_user()
-        {"id": 5, "login": "alice", "firstname": "Alice", ..., "admin": False}
+        >>> await get_current_user(include_memberships=True)
+        {
+            "id": 5, "login": "alice", "admin": False,
+            "memberships": [
+                {
+                    "id": 12,
+                    "project": {"id": 1, "name": "Website"},
+                    "roles": [
+                        {"id": 3, "name": "Developer"},
+                        {"id": 4, "name": "Manager", "inherited": True}
+                    ]
+                }
+            ]
+        }
     """
     try:
-        user = _get_redmine_client().user.get("current")
-        return {
+        # Only ``memberships`` is exposed, not a free-text ``include``
+        # passthrough. python-redmine's ``User._includes`` also accepts
+        # ``groups``, but Redmine gates that block on ``User.current.admin?``
+        # (``app/views/users/show.api.rsb``), so a non-admin asking for
+        # groups gets a 200 with the key simply missing -- byte-identical to
+        # "belongs to no groups". The memberships block carries no such
+        # check; Redmine only filters it by project visibility.
+        if include_memberships:
+            user = _get_redmine_client().user.get("current", include="memberships")
+        else:
+            user = _get_redmine_client().user.get("current")
+
+        result: Dict[str, Any] = {
             "id": getattr(user, "id", None),
             "login": getattr(user, "login", ""),
             "firstname": getattr(user, "firstname", ""),
@@ -211,6 +322,9 @@ def get_current_user() -> Dict[str, Any]:
             "created_on": _safe_isoformat(getattr(user, "created_on", None)),
             "last_login_on": _safe_isoformat(getattr(user, "last_login_on", None)),
         }
+        if include_memberships:
+            result["memberships"] = _current_user_memberships(user)
+        return result
     except Exception as e:
         return _handle_redmine_error(e, "fetching current user")
 

--- a/src/redmine_mcp_server/tools/enumeration.py
+++ b/src/redmine_mcp_server/tools/enumeration.py
@@ -200,13 +200,10 @@ def _membership_roles_to_list(raw_roles: Any) -> List[Dict[str, Any]]:
 
     roles: List[Dict[str, Any]] = []
     for role in raw_roles:
-        if not isinstance(role, dict):
+        entry = _named_ref(role)
+        if entry is None:
             continue
-        entry: Dict[str, Any] = {
-            "id": role.get("id"),
-            "name": role.get("name", ""),
-        }
-        if "inherited" in role:
+        if isinstance(role, dict) and "inherited" in role:
             entry["inherited"] = role["inherited"]
         roles.append(entry)
     return roles
@@ -215,13 +212,9 @@ def _membership_roles_to_list(raw_roles: Any) -> List[Dict[str, Any]]:
 def _current_user_memberships(user: Any) -> List[Dict[str, Any]]:
     """Serialize the caller's ``include=memberships`` payload.
 
-    Read through ``_included_list``, never ``user.memberships``: for a name
-    in ``User._includes`` python-redmine's ``Resource.__getattr__`` pops the
-    key from the decoded payload and, finding it absent, calls
-    ``refresh(itself=False, include=attr)`` -- a second HTTP request for data
-    the first response already carried
-    (``redminelib/resources/base.py``). Passing the include on the original
-    ``get`` and reading the payload keeps it at one request.
+    Read through ``_included_list``, never ``user.memberships``: the
+    attribute re-fetches when the payload key is absent, and returns a
+    ``ResourceSet`` rather than the payload shape. See ``_included_list``.
 
     Deliberately not ``tools.projects._membership_to_dict``, because the two
     payloads are different shapes:
@@ -268,6 +261,14 @@ def get_current_user(include_memberships: bool = False) -> Dict[str, Any]:
     member of, and with which roles" in that same request. The only other
     way to get that is ``list_project_members`` once per project.
 
+    Each membership is ``{id, project: {id, name}, roles: [{id, name}]}``.
+    A role held through a group carries ``inherited: true``; Redmine omits
+    the key for a role held directly, and so does this tool -- so test for
+    the key, do not expect ``inherited: false``. Redmine limits the list to
+    projects visible to the caller, which covers active and closed projects
+    but not archived ones: an empty list means none visible, not
+    necessarily none held.
+
     Args:
         include_memberships: Add ``memberships`` to the response. Costs no
             extra request -- the include rides the same call -- so this is
@@ -276,14 +277,8 @@ def get_current_user(include_memberships: bool = False) -> Dict[str, Any]:
     Returns:
         A dictionary with ``id``, ``login``, ``firstname``, ``lastname``,
         ``mail``, ``admin`` (bool), ``created_on``, and ``last_login_on``.
-        With ``include_memberships``, also ``memberships``: a list of
-        ``{id, project: {id, name}, roles: [{id, name}]}`` entries. A role
-        inherited from a group membership carries ``inherited: true``; the
-        key is absent otherwise, mirroring Redmine. Redmine limits the list
-        to projects visible to the caller -- active and closed ones, not
-        archived -- so an empty list means the caller holds none that are
-        visible, not necessarily none at all. On failure, a dict with an
-        ``"error"`` key.
+        With ``include_memberships``, also ``memberships``, as described
+        above. On failure, a dict with an ``"error"`` key.
 
     Example:
         >>> await get_current_user(include_memberships=True)
@@ -302,13 +297,10 @@ def get_current_user(include_memberships: bool = False) -> Dict[str, Any]:
         }
     """
     try:
-        # Only ``memberships`` is exposed, not a free-text ``include``
-        # passthrough. python-redmine's ``User._includes`` also accepts
-        # ``groups``, but Redmine gates that block on ``User.current.admin?``
-        # (``app/views/users/show.api.rsb``), so a non-admin asking for
-        # groups gets a 200 with the key simply missing -- byte-identical to
-        # "belongs to no groups". The memberships block carries no such
-        # check; Redmine only filters it by project visibility.
+        # Only ``memberships`` is exposed, not a free-text ``include``.
+        # ``User._includes`` also accepts ``groups``, which Redmine gates on
+        # ``User.current.admin?`` -- a non-admin would get a 200 with the key
+        # simply missing, indistinguishable from "belongs to no groups".
         if include_memberships:
             user = _get_redmine_client().user.get("current", include="memberships")
         else:

--- a/src/redmine_mcp_server/tools/enumeration.py
+++ b/src/redmine_mcp_server/tools/enumeration.py
@@ -277,11 +277,13 @@ def get_current_user(include_memberships: bool = False) -> Dict[str, Any]:
         A dictionary with ``id``, ``login``, ``firstname``, ``lastname``,
         ``mail``, ``admin`` (bool), ``created_on``, and ``last_login_on``.
         With ``include_memberships``, also ``memberships``: a list of
-        ``{id, project: {id, name}, roles: [{id, name}]}`` entries, empty
-        when the caller holds none. A role inherited from a group
-        membership carries ``inherited: true``; the key is absent
-        otherwise, mirroring Redmine. Redmine limits the list to projects
-        visible to the caller. On failure, a dict with an ``"error"`` key.
+        ``{id, project: {id, name}, roles: [{id, name}]}`` entries. A role
+        inherited from a group membership carries ``inherited: true``; the
+        key is absent otherwise, mirroring Redmine. Redmine limits the list
+        to projects visible to the caller -- active and closed ones, not
+        archived -- so an empty list means the caller holds none that are
+        visible, not necessarily none at all. On failure, a dict with an
+        ``"error"`` key.
 
     Example:
         >>> await get_current_user(include_memberships=True)

--- a/src/redmine_mcp_server/tools/enumeration.py
+++ b/src/redmine_mcp_server/tools/enumeration.py
@@ -251,9 +251,7 @@ def get_current_user(include_memberships: bool = False) -> Dict[str, Any]:
     """Retrieve the currently authenticated user's profile.
 
     Resolves to ``GET /users/current.json`` under the hood. Works for any
-    authenticated user (not admin-only): Redmine's ``UsersController``
-    exempts ``show`` from ``require_admin`` and resolves the ``current``
-    id behind a bare ``require_login``. Useful when an LLM needs to
+    authenticated user, not admin-only. Useful when an LLM needs to
     identify "me" — for example, when a user says "log 2h on this issue
     for me", the LLM can call this tool to get the current user's ID.
 
@@ -297,6 +295,11 @@ def get_current_user(include_memberships: bool = False) -> Dict[str, Any]:
         }
     """
     try:
+        # Not admin-gated: ``UsersController`` exempts ``show`` from
+        # ``require_admin`` and resolves the ``current`` id behind a bare
+        # ``require_login``. Stated here rather than in the docstring, whose
+        # leading prose ships in every ``tools/list``; see also the
+        # ``get_current_user`` note in ``oauth_scopes.py``.
         # Only ``memberships`` is exposed, not a free-text ``include``.
         # ``User._includes`` also accepts ``groups``, which Redmine gates on
         # ``User.current.admin?`` -- a non-admin would get a 200 with the key

--- a/src/redmine_mcp_server/tools/meta.py
+++ b/src/redmine_mcp_server/tools/meta.py
@@ -47,10 +47,17 @@ async def _fetch_current_user_info() -> Optional[Dict[str, Any]]:
     Resolves who ``assigned_to_id="me"`` maps to — crucial when a shared
     or robot API key is in use, where "me" is not the human operator.
 
-    Uses ``GET /users/current.json`` via async httpx — works on Redmine 3.x
+    Uses ``GET /users/current.json`` via async httpx -- works on Redmine 3.x
     and later. ``/my/account.json`` is not reliably available on older
-    Redmine instances. redminelib's ``user.get('current')`` is not used
-    because it requires admin rights on some setups.
+    Redmine instances.
+
+    This predates the async client and stays on httpx to avoid a blocking
+    call here; it is not because the endpoint needs admin. It does not:
+    ``UsersController`` exempts ``show`` from ``require_admin``, ``find_user``
+    resolves ``current`` behind a bare ``require_login``, and
+    ``Principal.visible``'s non-admin branch matches ``id = user.id``, so a
+    caller always sees their own record. ``user.get('current')`` reaches the
+    same URL -- ``get_current_user`` uses it.
     """
     try:
         import httpx

--- a/src/redmine_mcp_server/tools/meta.py
+++ b/src/redmine_mcp_server/tools/meta.py
@@ -47,17 +47,14 @@ async def _fetch_current_user_info() -> Optional[Dict[str, Any]]:
     Resolves who ``assigned_to_id="me"`` maps to — crucial when a shared
     or robot API key is in use, where "me" is not the human operator.
 
-    Uses ``GET /users/current.json`` via async httpx -- works on Redmine 3.x
+    Uses ``GET /users/current.json`` via async httpx — works on Redmine 3.x
     and later. ``/my/account.json`` is not reliably available on older
     Redmine instances.
 
-    This predates the async client and stays on httpx to avoid a blocking
-    call here; it is not because the endpoint needs admin. It does not:
-    ``UsersController`` exempts ``show`` from ``require_admin``, ``find_user``
-    resolves ``current`` behind a bare ``require_login``, and
-    ``Principal.visible``'s non-admin branch matches ``id = user.id``, so a
-    caller always sees their own record. ``user.get('current')`` reaches the
-    same URL -- ``get_current_user`` uses it.
+    This duplicates ``get_current_user`` and has not been consolidated with
+    it; that is the only reason it is a separate path, not any permission
+    difference. The endpoint is not admin-gated -- see the
+    ``get_current_user`` note in ``oauth_scopes.py`` for why.
     """
     try:
         import httpx

--- a/tests/test_current_user_memberships.py
+++ b/tests/test_current_user_memberships.py
@@ -1,5 +1,5 @@
 """``get_current_user(include_memberships=True)`` returns the caller's
-project memberships in one request (#ISSUE).
+project memberships in one request (#236).
 
 Before this, nothing exposed "which projects do I hold, with which roles":
 ``get_current_user`` hand-built eight profile keys and ``list_project_members``

--- a/tests/test_current_user_memberships.py
+++ b/tests/test_current_user_memberships.py
@@ -1,0 +1,366 @@
+"""``get_current_user(include_memberships=True)`` returns the caller's
+project memberships in one request (#ISSUE).
+
+Before this, nothing exposed "which projects do I hold, with which roles":
+``get_current_user`` hand-built eight profile keys and ``list_project_members``
+answers one project per call.
+
+Two things these tests pin down:
+
+- The include rides the original ``user.get("current")`` call. python-redmine
+  lists ``memberships`` in ``User._includes``, so reading
+  ``user.memberships`` without the include makes ``Resource.__getattr__``
+  call ``refresh(itself=False, include=...)`` -- a second HTTP request for
+  data the first response could have carried.
+- The default response is unchanged, key for key.
+
+These tests avoid ``Mock`` for the user object. A ``Mock`` answers every
+attribute access, so a serializer reading keys Redmine never sent looks
+correct under it, and a lazy ``.memberships`` read would silently succeed.
+``FakeUser`` raises ``ResourceAttrError`` for absent attributes exactly as
+python-redmine does, and records any lazy read instead of satisfying it.
+"""
+
+import os
+import sys
+
+import pytest
+from redminelib.exceptions import AuthError, ForbiddenError, ResourceAttrError
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from redmine_mcp_server.tools.enumeration import get_current_user  # noqa: E402
+
+# The eight keys the tool has always returned, in order. The default response
+# must stay exactly this -- existing callers index into it.
+PROFILE_KEYS = [
+    "id",
+    "login",
+    "firstname",
+    "lastname",
+    "mail",
+    "admin",
+    "created_on",
+    "last_login_on",
+]
+
+PROFILE_PAYLOAD = {
+    "id": 5,
+    "login": "alice",
+    "firstname": "Alice",
+    "lastname": "A",
+    "mail": "alice@example.com",
+    "admin": False,
+    "created_on": None,
+    "last_login_on": None,
+}
+
+# One membership as Redmine's app/views/users/show.api.rsb renders it: id,
+# project as {id, name}, roles as {id, name} with inherited => true merged on
+# when the role arrives through a group membership. No user/group key -- the
+# user is the caller.
+MEMBERSHIPS_PAYLOAD = [
+    {
+        "id": 12,
+        "project": {"id": 1, "name": "Website"},
+        "roles": [
+            {"id": 3, "name": "Developer"},
+            {"id": 4, "name": "Manager", "inherited": True},
+        ],
+    },
+    {
+        "id": 19,
+        "project": {"id": 7, "name": "Infrastructure"},
+        "roles": [{"id": 5, "name": "Reporter"}],
+    },
+]
+
+
+class FakeUser:
+    """A python-redmine ``User`` as ``user.get("current", ...)`` returns one.
+
+    ``raw()`` is python-redmine's accessor for the decoded payload, which is
+    where an ``include=`` collection lands. Attributes absent from the payload
+    raise ``ResourceAttrError`` (an ``AttributeError`` subclass, so a 3-arg
+    ``getattr`` falls back to its default), matching python-redmine under its
+    default ``raise_attr_exception=True``.
+
+    Reading ``memberships`` or ``groups`` as an attribute is recorded in
+    ``lazy_reads`` and answered with an empty list rather than the payload:
+    python-redmine would issue a second HTTP request there, so a non-empty
+    ``lazy_reads`` is the regression itself.
+    """
+
+    def __init__(self, payload):
+        self.__dict__["_payload"] = dict(payload)
+        self.__dict__["lazy_reads"] = []
+
+    def raw(self):
+        return self.__dict__["_payload"]
+
+    def __getattr__(self, attr):
+        if attr.startswith("_"):
+            raise AttributeError(attr)
+        if attr in ("memberships", "groups"):
+            self.__dict__["lazy_reads"].append(attr)
+            return []
+        payload = self.__dict__["_payload"]
+        if attr in payload:
+            return payload[attr]
+        raise ResourceAttrError()
+
+
+class FakeClient:
+    """Records every ``user.get`` call so the include can be asserted on."""
+
+    def __init__(self, user=None, error=None):
+        self.user = self
+        self.calls = []
+        self._user_obj = user
+        self._error = error
+
+    def get(self, resource_id, **kwargs):
+        self.calls.append((resource_id, kwargs))
+        if self._error is not None:
+            raise self._error
+        return self._user_obj
+
+
+@pytest.fixture
+def client_factory(monkeypatch):
+    def _install(user=None, error=None):
+        fake = FakeClient(user=user, error=error)
+        monkeypatch.setattr("redmine_mcp_server._client.redmine", fake)
+        return fake
+
+    return _install
+
+
+class TestIncludeRidesTheSameRequest:
+    """The anti-regression for the second-request bug."""
+
+    @pytest.mark.asyncio
+    async def test_include_is_passed_to_the_client_call(self, client_factory):
+        user = FakeUser({**PROFILE_PAYLOAD, "memberships": MEMBERSHIPS_PAYLOAD})
+        fake = client_factory(user=user)
+
+        result = await get_current_user(include_memberships=True)
+
+        assert fake.calls == [("current", {"include": "memberships"})]
+        assert "error" not in result
+
+    @pytest.mark.asyncio
+    async def test_memberships_are_read_from_the_payload_not_the_attribute(
+        self, client_factory
+    ):
+        """Reading ``user.memberships`` is what costs the extra round trip."""
+        user = FakeUser({**PROFILE_PAYLOAD, "memberships": MEMBERSHIPS_PAYLOAD})
+        client_factory(user=user)
+
+        result = await get_current_user(include_memberships=True)
+
+        assert user.lazy_reads == []
+        assert [m["id"] for m in result["memberships"]] == [12, 19]
+
+    @pytest.mark.asyncio
+    async def test_only_one_request_is_made(self, client_factory):
+        user = FakeUser({**PROFILE_PAYLOAD, "memberships": MEMBERSHIPS_PAYLOAD})
+        fake = client_factory(user=user)
+
+        await get_current_user(include_memberships=True)
+
+        assert len(fake.calls) == 1
+
+
+class TestMembershipSerialization:
+    """Redmine's own keys, nothing renamed and nothing added."""
+
+    @pytest.mark.asyncio
+    async def test_uses_redmine_keys(self, client_factory):
+        user = FakeUser({**PROFILE_PAYLOAD, "memberships": MEMBERSHIPS_PAYLOAD})
+        client_factory(user=user)
+
+        result = await get_current_user(include_memberships=True)
+
+        assert result["memberships"] == [
+            {
+                "id": 12,
+                "project": {"id": 1, "name": "Website"},
+                "roles": [
+                    {"id": 3, "name": "Developer"},
+                    {"id": 4, "name": "Manager", "inherited": True},
+                ],
+            },
+            {
+                "id": 19,
+                "project": {"id": 7, "name": "Infrastructure"},
+                "roles": [{"id": 5, "name": "Reporter"}],
+            },
+        ]
+
+    @pytest.mark.asyncio
+    async def test_inherited_is_preserved_on_the_role(self, client_factory):
+        """Redmine merges ``inherited`` onto the role, not the membership.
+
+        It is what separates "I hold Manager here" from "a group I am in
+        does", so it cannot be dropped.
+        """
+        user = FakeUser({**PROFILE_PAYLOAD, "memberships": MEMBERSHIPS_PAYLOAD})
+        client_factory(user=user)
+
+        result = await get_current_user(include_memberships=True)
+        roles = result["memberships"][0]["roles"]
+
+        assert roles[1]["inherited"] is True
+        assert "inherited" not in result["memberships"][0]
+
+    @pytest.mark.asyncio
+    async def test_a_direct_role_carries_no_inherited_key(self, client_factory):
+        """Redmine omits the key for a direct role; ``false`` would be
+        a claim it never made."""
+        user = FakeUser({**PROFILE_PAYLOAD, "memberships": MEMBERSHIPS_PAYLOAD})
+        client_factory(user=user)
+
+        result = await get_current_user(include_memberships=True)
+
+        assert result["memberships"][0]["roles"][0] == {
+            "id": 3,
+            "name": "Developer",
+        }
+        assert "inherited" not in result["memberships"][1]["roles"][0]
+
+    @pytest.mark.asyncio
+    async def test_no_user_or_group_key_is_emitted(self, client_factory):
+        """The user is the caller, implicitly. ``list_project_members``
+        emits ``user``/``group``; the user-show renderer emits neither, and
+        a ``None`` there would read as a membership naming no principal."""
+        user = FakeUser({**PROFILE_PAYLOAD, "memberships": MEMBERSHIPS_PAYLOAD})
+        client_factory(user=user)
+
+        result = await get_current_user(include_memberships=True)
+
+        for membership in result["memberships"]:
+            assert set(membership) == {"id", "project", "roles"}
+
+    @pytest.mark.asyncio
+    async def test_membership_with_no_roles(self, client_factory):
+        user = FakeUser(
+            {
+                **PROFILE_PAYLOAD,
+                "memberships": [
+                    {"id": 3, "project": {"id": 2, "name": "Docs"}, "roles": []}
+                ],
+            }
+        )
+        client_factory(user=user)
+
+        result = await get_current_user(include_memberships=True)
+
+        assert result["memberships"] == [
+            {"id": 3, "project": {"id": 2, "name": "Docs"}, "roles": []}
+        ]
+
+    @pytest.mark.asyncio
+    async def test_profile_keys_are_still_present_alongside(self, client_factory):
+        user = FakeUser({**PROFILE_PAYLOAD, "memberships": MEMBERSHIPS_PAYLOAD})
+        client_factory(user=user)
+
+        result = await get_current_user(include_memberships=True)
+
+        assert list(result) == PROFILE_KEYS + ["memberships"]
+
+
+class TestNoMemberships:
+    @pytest.mark.asyncio
+    async def test_empty_list_when_the_user_holds_none(self, client_factory):
+        user = FakeUser({**PROFILE_PAYLOAD, "memberships": []})
+        client_factory(user=user)
+
+        result = await get_current_user(include_memberships=True)
+
+        assert result["memberships"] == []
+        assert user.lazy_reads == []
+
+    @pytest.mark.asyncio
+    async def test_key_absent_from_the_payload_reads_as_empty(self, client_factory):
+        """Redmine omits the array when ``@memberships`` is blank. Reporting
+        that as empty is honest; re-fetching to find out is the bug."""
+        user = FakeUser(dict(PROFILE_PAYLOAD))
+        client_factory(user=user)
+
+        result = await get_current_user(include_memberships=True)
+
+        assert result["memberships"] == []
+        assert user.lazy_reads == []
+
+
+class TestDefaultResponseUnchanged:
+    """The flag defaults off and the old response is byte-identical."""
+
+    @pytest.mark.asyncio
+    async def test_default_returns_exactly_the_eight_profile_keys(self, client_factory):
+        user = FakeUser({**PROFILE_PAYLOAD, "memberships": MEMBERSHIPS_PAYLOAD})
+        client_factory(user=user)
+
+        result = await get_current_user()
+
+        assert list(result) == PROFILE_KEYS
+        assert result == PROFILE_PAYLOAD
+        assert "memberships" not in result
+
+    @pytest.mark.asyncio
+    async def test_default_sends_no_include(self, client_factory):
+        """No include means no query parameter, as before this change."""
+        user = FakeUser({**PROFILE_PAYLOAD, "memberships": MEMBERSHIPS_PAYLOAD})
+        fake = client_factory(user=user)
+
+        await get_current_user()
+
+        assert fake.calls == [("current", {})]
+
+    @pytest.mark.asyncio
+    async def test_default_never_touches_the_lazy_attribute(self, client_factory):
+        user = FakeUser({**PROFILE_PAYLOAD, "memberships": MEMBERSHIPS_PAYLOAD})
+        client_factory(user=user)
+
+        await get_current_user()
+
+        assert user.lazy_reads == []
+
+
+class TestGroupsAreNotOffered:
+    @pytest.mark.asyncio
+    async def test_no_free_text_include_parameter(self, client_factory):
+        """python-redmine accepts ``groups`` too, but Redmine gates that
+        block on ``User.current.admin?``, so a non-admin gets a 200 with the
+        key missing -- indistinguishable from "belongs to no groups". The
+        tool exposes memberships specifically rather than passing an
+        arbitrary include through."""
+        import inspect
+
+        params = inspect.signature(get_current_user).parameters
+
+        assert "include" not in params
+        assert "include_memberships" in params
+        assert params["include_memberships"].default is False
+
+
+class TestErrorEnvelope:
+    @pytest.mark.asyncio
+    async def test_auth_error_with_memberships(self, client_factory):
+        client_factory(error=AuthError())
+
+        result = await get_current_user(include_memberships=True)
+
+        assert isinstance(result, dict)
+        assert "error" in result
+        assert "memberships" not in result
+
+    @pytest.mark.asyncio
+    async def test_forbidden_error_without_memberships(self, client_factory):
+        client_factory(error=ForbiddenError())
+
+        result = await get_current_user()
+
+        assert isinstance(result, dict)
+        assert "error" in result


### PR DESCRIPTION
## Summary

Fixes #236. `get_current_user` took no arguments and could not return the caller's memberships, so "which projects do I hold, and with which roles" cost one `list_project_members` call per project. `include_memberships=True` now answers it in the same request that was already being made — the include rides the existing `GET /users/current.json`, so it adds no round trip. Default is unchanged, so no existing caller moves.

Each entry is `{id, project: {id, name}, roles: [{id, name}]}`, using Redmine's own keys. A role held through a group carries `inherited: true`; Redmine omits the key for a directly held role and so does this, rather than asserting a `false` Redmine never sent.

## Why this is safe for a non-admin token

Checked against 6.1-stable, and 7.0-stable and master are byte-identical for both files, so none of this is version-contingent.

`app/views/users/show.api.rsb` gates the memberships block on `include_in_api_response?('memberships') && @memberships` and nothing else. The action is reachable: `UsersController` has `before_action :require_admin, :except => :show` and `accept_api_auth :show`, and `find_user(false)` resolves `params[:id] == 'current'` behind a bare `require_login`. The `visible?` check in `show` passes too — `Principal.visible`'s non-admin branch matches `id = user.id`, commented "self and members of visible projects". Redmine also narrows `@memberships` with `Project.visible_condition(User.current)`, which for `current` is a no-op against their own memberships.

Worth stating explicitly because two comments in this repo asserted the opposite — that `user.get('current')` "requires admin rights on some Redmine setups". That is not true of stock Redmine, and both comments are corrected here to say what actually keeps those two call sites on httpx.

## Why a boolean and not an `include` passthrough

python-redmine's `User._includes` also accepts `groups`, but Redmine gates that block on `User.current.admin?`. A non-admin asking for groups would get a 200 with the key simply missing — indistinguishable from "belongs to no groups", which is a wrong answer rather than a refusal. Exposing `memberships` specifically avoids handing callers a footgun, and it matches the established split in this codebase: per-include booleans on the python-redmine-backed core tools (`include_watchers`, `include_relations`, `include_custom_fields`), free-text `include` only on the plugin endpoints reached through `engine.request`.

It also cannot proliferate. `User._includes` is exactly `['memberships', 'groups']`, so with `groups` deliberately out, this tool is at its terminal state with one flag.

## The include goes on the original call, not through the lazy attribute

`memberships` is in `_includes`, so `user.memberships` already resolves — but `Resource.__getattr__` handles a missing payload key by calling `refresh(itself=False, include=attr)`, a second request, and to `/users/<id>.json` rather than `/users/current.json` since it re-resolves from `internal_id`. Reading the payload through the existing `_included_list` helper keeps it at one request unconditionally, and returns the payload shape rather than a `ResourceSet`.

I measured this rather than assuming it: one HTTP request on all three paths — flag on with the key present, flag on with the key absent, and flag off. The eight profile `getattr` reads cost nothing, including `admin`, which Redmine omits for a non-admin and which lands on `ResourceAttrError`, an `AttributeError` subclass the three-argument `getattr` absorbs without triggering a refresh.

## Notes on the serializer

A local serializer rather than reusing `tools/projects.py::_membership_to_dict`, because the two Redmine renderers genuinely differ: the user-show one emits no `user`/`group` (the user is the caller, implicitly), so that helper would return two always-null keys, and it flattens roles in a way that drops `inherited`. Roles go through the shared `_named_ref` for the `{id, name}` half, so the display-name policy from #109 has one home.

## Docs

The caller-facing contract — the entry shape, the `inherited`-key rule, and that an empty list means "none visible" rather than "none held" (Redmine's visibility condition covers active and closed projects, not archived) — is stated **above** the `Args:` block, not under `Returns:`. FastMCP exposes only the text above `Args:` plus the per-parameter descriptions, so anything a caller needs has to live in one of those two places or it never reaches the model.

What is *not* above `Args:` is deliberate too. The derivation behind "not admin-only" — `UsersController` exempting `show` from `require_admin`, `find_user(false)` resolving `current` behind a bare `require_login` — is maintainer rationale a caller cannot act on, and the leading prose ships inlined in every `tools/list`. The claim stays in the docstring; the mechanism sits in a comment beside the call, where `oauth_scopes.py` already records the same thing. That cut the shipped description from 1,100 characters to 964.

The docstring also stops naming `GET /my/account.json` as the endpoint. python-redmine's `User.query_one` is `/users/{}.json`, so the call is `GET /users/current.json`. That mattered rather than being cosmetic: `app/views/my/account.api.rsb` renders no memberships block at all, so on the endpoint the docstring named, this feature would have been impossible.

## Tests

New `tests/test_current_user_memberships.py`. The fakes deliberately avoid `Mock` for the user object: a `Mock` answers every attribute, so a lazy `.memberships` read would pass silently — which is the specific regression these tests exist to catch. The fake records lazy reads instead.

Covers the include actually reaching the client call, the entry shape with Redmine's keys, `inherited` preserved on a role and absent on a direct one, no `user`/`group` keys emitted, a user with no memberships, one request only, the default response staying exactly the eight profile keys, and the error envelope.

`1864 passed, 89 deselected` on the full non-integration suite, from a `1847 passed` baseline on `develop`. `flake8 src/ --max-line-length=88` and `black --check src/ --line-length=88` both clean.

## Compatibility

Additive. The flag defaults to false and the default response is byte-identical to today's eight keys. The scope map entry stays `frozenset()`: the endpoint is not admin-gated, the memberships block carries no permission check, and Redmine already filters the list to the caller's visible projects. `view_members` would be the wrong scope to require — it gates reading *who else* is a member of a project, so demanding it would refuse a call Redmine itself allows.
