### PR TITLE
fix: build the issue tools' pagination envelope from _pagination_info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Fixed
+- The issue tools build their pagination envelope through the shared
+  `_pagination_info` helper
+  ([#240](https://github.com/jztan/redmine-mcp-server/issues/240)). Three
+  defects go with it. `list_redmine_issues` computed `has_next` from a full
+  page (`len(result) == limit`), which reported one page too many whenever
+  the collection size was an exact multiple of the page size; with the total
+  in hand it is now measured as `offset + limit < total`. It spent a second
+  `limit=1` request on that total, which now reads off the same response the
+  issues came from, so the envelope costs nothing extra. And it capped the
+  request at 100 rows while reporting the requested window, so `limit=250`
+  silently returned 100 issues; the limit is now passed through whole, which
+  python-redmine pages itself in chunks of 100. When a response carries no
+  usable total, `total` is now `null` rather than the invented
+  `offset + count + 1` estimate, and `has_next` falls back to the full-page
+  inference. `search_redmine_issues` now reports `total: null` explicitly
+  (the Search API measures nothing), where it used to omit the key and
+  disagree with every other pagination envelope in the server.
 - Documentation no longer describes `list_redmine_projects` as listing every
   accessible project. Redmine's `ProjectQuery` starts with a `status = 1`
   filter already set, so a call passing no `status` has always answered with

--- a/docs/tool-reference.md
+++ b/docs/tool-reference.md
@@ -757,7 +757,7 @@ List Redmine issues with flexible filtering and pagination support. A general-pu
 - `sort` (string, optional): Sort order (e.g., `"updated_on:desc"`)
 - `limit` (integer, optional): Maximum issues to return. Default: `25`, Max: `1000`
 - `offset` (integer, optional): Number of issues to skip for pagination. Default: `0`
-- `include_pagination_info` (boolean, optional): Return structured response with metadata. Default: `false`
+- `include_pagination_info` (boolean, optional): Return structured response with metadata. Default: `false`. `total` is Redmine's `total_count`, read off the same response the issues came from, so it costs no extra request, and `has_next` is measured from it (`offset + limit < total`) rather than inferred from a full page. When the response carries no usable total (API metadata suppressed via `nometa` or `X-Redmine-Nometa`), `total` is `null`, never an estimate, and `has_next` falls back to the full-page inference
 - `include_custom_fields` (boolean, optional): Add `custom_fields` to each issue. Default: `false` — unlike `get_redmine_issue`, which defaults to `true`, because a list page multiplies the payload
 - `include_relations` (boolean, optional): Add `relations` to each issue. Default: `false`. Each entry is `{id, issue_id, issue_to_id, relation_type, delay}`
 - `fields` (array of strings, optional): List of field names to include in results. Default: all fields
@@ -843,7 +843,7 @@ Search issues using text queries with support for pagination, field selection, a
 - `query` (string, required): Text to search for in issues
 - `limit` (integer, optional): Maximum number of issues to return. Default: `25`, Max: `1000`
 - `offset` (integer, optional): Number of issues to skip for pagination. Default: `0`
-- `include_pagination_info` (boolean, optional): Return structured response with pagination metadata. Default: `false`
+- `include_pagination_info` (boolean, optional): Return structured response with pagination metadata. Default: `false`. The Search API reports no `total_count`, so `total` is always `null` ("not reported") and `has_next` uses the full-page inference: `true` whenever the page came back full, which is only ever optimistic and costs one wasted request at worst
 - `fields` (array of strings, optional): List of field names to include in results. Default: `null` (all fields)
   - Available fields: `id`, `subject`, `description`, `project`, `status`, `priority`, `tracker`, `author`, `assigned_to`, `created_on`, `updated_on`, `custom_fields` — `tracker` is returned by default. Naming `custom_fields` hydrates the results through the issues endpoint, which renders the values; there is no `relations` here, since this tool never requests that include
   - Special values: `["*"]` or `["all"]` for all fields
@@ -890,6 +890,7 @@ search_redmine_issues(
 # {
 #   "issues": [...],
 #   "pagination": {
+#     "total": null,
 #     "limit": 25,
 #     "offset": 0,
 #     "count": 25,

--- a/src/redmine_mcp_server/tools/issues.py
+++ b/src/redmine_mcp_server/tools/issues.py
@@ -40,6 +40,8 @@ from .._serialization import (
     _normalize_tag_list,
     _named_ref,
     _normalize_csv_list,
+    _pagination_info,
+    _payload_int,
     _safe_isoformat,
     wrap_insecure_content,
 )
@@ -1036,11 +1038,18 @@ async def list_redmine_issues(
                 logging.warning(f"Invalid offset {offset}, reset to 0")
                 offset = 0
 
+            if limit is None:
+                limit = 25
+
             # Use python-redmine ResourceSet native pagination
-            # Server-side filtering more efficient than client-side
+            # Server-side filtering more efficient than client-side.
+            # The limit is passed through whole: python-redmine pages a
+            # limit above 100 itself, in chunks of 100, so capping the
+            # request here would silently truncate the rows while the
+            # pagination envelope reported the window actually asked for.
             redmine_filters = {
                 "offset": offset,
-                "limit": min(limit or 25, 100),  # Redmine API max per request
+                "limit": limit,
                 **filters,
             }
 
@@ -1072,48 +1081,23 @@ async def list_redmine_issues(
 
             # Handle metadata response format
             if include_pagination_info:
-                # Get total count from a separate query.
+                # The total rides the response the rows already came from:
+                # python-redmine reads ``total_count`` off the first page's
+                # envelope, and iterating the set above is what populated
+                # it. A response carrying no usable number (raised, or not
+                # an int) reports ``null`` rather than an estimate.
+                total_count = None
                 try:
-                    # Redmine returns the full ``total_count`` in the first page of
-                    # any filtered response, so we only need to fetch a single
-                    # issue to read it. Omitting the limit here would make
-                    # python-redmine's ResourceSet materialize *every* matching
-                    # issue (chunk-by-chunk, dozens of sequential requests for a
-                    # large project) just to compute the count, which can exceed
-                    # the MCP ``tools/call`` timeout.
-                    count_filters = {**filters, "limit": 1, "offset": 0}
-                    # The count query reads total_count off the envelope; it
-                    # has no use for included collections.
-                    count_filters.pop("include", None)
-                    count_query = _get_redmine_client().issue.filter(**count_filters)
-                    # Trigger a single request so total_count is populated.
-                    list(count_query)
-                    total_count = count_query.total_count
-                    logging.debug(f"Got total count from separate query: {total_count}")
+                    total_count = _payload_int(issues.total_count, minimum=0)
                 except Exception as e:
-                    logging.warning(
-                        f"Could not get total count: {e}, using estimated value"
-                    )
-                    # For unknown total, use a conservative estimate
-                    if len(result_issues) == limit:
-                        # If we got a full page, there might be more
-                        total_count = offset + len(result_issues) + 1
-                    else:
-                        # If we got less than requested, this is likely the end
-                        total_count = offset + len(result_issues)
+                    logging.debug(f"No total_count on the response: {e}")
 
-                pagination_info = {
-                    "total": total_count,
-                    "limit": limit,
-                    "offset": offset,
-                    "count": len(result_issues),
-                    "has_next": len(result_issues) == limit,
-                    "has_previous": offset > 0,
-                    "next_offset": (
-                        offset + limit if len(result_issues) == limit else None
-                    ),
-                    "previous_offset": max(0, offset - limit) if offset > 0 else None,
-                }
+                pagination_info = _pagination_info(
+                    limit=limit,
+                    offset=offset,
+                    count=len(result_issues),
+                    total=total_count,
+                )
 
                 result = {"issues": result_issues, "pagination": pagination_info}
 
@@ -1186,7 +1170,7 @@ def search_redmine_issues(
         ... )
         {
             "issues": [...],
-            "pagination": {"limit": 10, "offset": 0, "has_next": True, ...}
+            "pagination": {"total": None, "limit": 10, "has_next": True, ...}
         }
 
         >>> await search_redmine_issues("urgent", fields=["id", "subject", "status"])
@@ -1196,9 +1180,11 @@ def search_redmine_issues(
         [{"id": 1, "subject": "Open bug in my project", ...}, ...]
 
     Note:
-        The Redmine Search API does not provide total_count. Pagination
-        metadata uses conservative estimation: has_next=True if result
-        count equals limit.
+        The Redmine Search API does not provide total_count, so the
+        pagination metadata reports ``total: null`` ("not reported") and
+        ``has_next`` falls back to the full-page inference: true whenever
+        the page came back full, which is only ever optimistic and costs
+        one wasted request at worst.
 
         Search API Limitations: The Search API supports text search with
         scope and open_issues filters only. For advanced filtering by
@@ -1248,6 +1234,7 @@ def search_redmine_issues(
                     empty_result = {
                         "issues": [],
                         "pagination": {
+                            "total": None,
                             "limit": limit,
                             "offset": offset,
                             "count": 0,
@@ -1272,6 +1259,9 @@ def search_redmine_issues(
         if not isinstance(offset, int) or offset < 0:
             logging.warning(f"Invalid offset {offset}, reset to 0")
             offset = 0
+
+        if limit is None:
+            limit = 25
 
         # Pass offset and limit to Redmine Search API
         search_params = {"offset": offset, "limit": limit, **options}
@@ -1308,19 +1298,15 @@ def search_redmine_issues(
 
         # Handle metadata response format
         if include_pagination_info:
-            # Search API doesn't provide total_count
-            # Use conservative estimation
-            pagination_info = {
-                "limit": limit,
-                "offset": offset,
-                "count": len(result_issues),
-                "has_next": len(result_issues) == limit,
-                "has_previous": offset > 0,
-                "next_offset": (
-                    offset + limit if len(result_issues) == limit else None
-                ),
-                "previous_offset": max(0, offset - limit) if offset > 0 else None,
-            }
+            # The Search API reports no total_count, so ``total`` is null
+            # ("not reported") and ``has_next`` falls back to the shared
+            # helper's full-page inference.
+            pagination_info = _pagination_info(
+                limit=limit,
+                offset=offset,
+                count=len(result_issues),
+                total=None,
+            )
 
             result = {"issues": result_issues, "pagination": pagination_info}
 

--- a/tests/test_issue_pagination_helper.py
+++ b/tests/test_issue_pagination_helper.py
@@ -1,0 +1,241 @@
+"""The issue tools' pagination envelope, after migrating to _pagination_info.
+
+Issue #240: `list_redmine_issues` hand-built its pagination keys with two
+defects the shared helper fixes, and `search_redmine_issues` shipped a
+seven-key envelope with no `total` at all.
+
+- `has_next` was inferred from ``len(result) == limit``, which reports one
+  page too many whenever the collection size is an exact multiple of the
+  page size. The helper measures it from the total instead.
+- The total cost a second ``limit=1`` request, although python-redmine's
+  ResourceSet carries ``total_count`` on the response the rows already came
+  from. Reading it there makes the envelope free.
+- When nothing measured the collection, the old code invented an estimate
+  (``offset + count + 1``); the helper reports ``null``, which the docs
+  define as "not reported" rather than a number nothing measured.
+
+The fakes avoid ``Mock`` for the resource set on purpose: a ``Mock`` answers
+``total_count`` whether the response carried one or not, and presence versus
+absence of that number is the thing under test.
+"""
+
+import pytest
+from unittest.mock import Mock, patch
+
+from redmine_mcp_server.tools.issues import (
+    list_redmine_issues,
+    search_redmine_issues,
+)
+from redmine_mcp_server._serialization import _pagination_info
+
+PAGINATION_KEYS = {
+    "total",
+    "limit",
+    "offset",
+    "count",
+    "has_next",
+    "has_previous",
+    "next_offset",
+    "previous_offset",
+}
+
+
+def _mock_issue(issue_id):
+    issue = Mock()
+    issue.id = issue_id
+    issue.subject = f"Issue {issue_id}"
+    issue.description = f"Description for issue {issue_id}"
+    issue.project = Mock(id=1, name="Test Project")
+    issue.status = Mock(id=1, name="New")
+    issue.priority = Mock(id=2, name="Normal")
+    issue.author = Mock(id=10, name="John Doe")
+    issue.assigned_to = Mock(id=20, name="Jane Smith")
+    issue.created_on = None
+    issue.updated_on = None
+    return issue
+
+
+class FakeResourceSet:
+    """Iterable of issues that carries total_count only when told to.
+
+    Mirrors python-redmine's ResourceSet closely enough for these tests:
+    iterating yields the issues, and ``total_count`` either answers the
+    number the response envelope carried or raises, the way an unevaluated
+    or metadata-less set does.
+    """
+
+    def __init__(self, issues, total_count=None):
+        self._issues = list(issues)
+        self._total_count = total_count
+
+    def __iter__(self):
+        return iter(self._issues)
+
+    @property
+    def total_count(self):
+        if self._total_count is None:
+            raise AttributeError("total_count not available")
+        return self._total_count
+
+
+@pytest.fixture
+def mock_redmine():
+    with patch("redmine_mcp_server._client.redmine") as mock:
+        yield mock
+
+
+class TestListIssuesMeasuredHasNext:
+    """`has_next` is measured from the total, not inferred from a full page."""
+
+    @pytest.mark.asyncio
+    async def test_exact_multiple_last_page_is_the_last(self, mock_redmine):
+        """A full last page of an exact-multiple collection has no next.
+
+        total 200, limit 100, offset 100: the inference
+        ``len(result) == limit`` claims a further page; the measurement
+        ``offset + limit < total`` knows there is none.
+        """
+        issues = [_mock_issue(i) for i in range(101, 201)]
+        mock_redmine.issue.filter.return_value = FakeResourceSet(
+            issues, total_count=200
+        )
+
+        result = await list_redmine_issues(
+            project_id=1, limit=100, offset=100, include_pagination_info=True
+        )
+
+        assert result["pagination"]["has_next"] is False
+        assert result["pagination"]["next_offset"] is None
+
+    @pytest.mark.asyncio
+    async def test_middle_page_still_has_next(self, mock_redmine):
+        issues = [_mock_issue(i) for i in range(1, 101)]
+        mock_redmine.issue.filter.return_value = FakeResourceSet(
+            issues, total_count=300
+        )
+
+        result = await list_redmine_issues(
+            project_id=1, limit=100, offset=0, include_pagination_info=True
+        )
+
+        assert result["pagination"]["has_next"] is True
+        assert result["pagination"]["next_offset"] == 100
+
+
+class TestListIssuesTotalCostsNothing:
+    """The total is read off the response the rows came from."""
+
+    @pytest.mark.asyncio
+    async def test_no_second_request_for_the_total(self, mock_redmine):
+        issues = [_mock_issue(i) for i in range(1, 26)]
+        mock_redmine.issue.filter.return_value = FakeResourceSet(
+            issues, total_count=100
+        )
+
+        result = await list_redmine_issues(
+            project_id=1, limit=25, offset=0, include_pagination_info=True
+        )
+
+        assert mock_redmine.issue.filter.call_count == 1
+        assert result["pagination"]["total"] == 100
+
+    @pytest.mark.asyncio
+    async def test_unmeasured_total_is_null_not_an_estimate(self, mock_redmine):
+        """A response carrying no total yields null, not offset+count+1."""
+        issues = [_mock_issue(i) for i in range(1, 26)]
+        mock_redmine.issue.filter.return_value = FakeResourceSet(
+            issues, total_count=None
+        )
+
+        result = await list_redmine_issues(
+            project_id=1, limit=25, offset=0, include_pagination_info=True
+        )
+
+        assert result["pagination"]["total"] is None
+        # Without a total, has_next falls back to the full-page inference.
+        assert result["pagination"]["has_next"] is True
+
+    @pytest.mark.asyncio
+    async def test_unmeasured_total_short_page_is_the_end(self, mock_redmine):
+        issues = [_mock_issue(i) for i in range(1, 6)]
+        mock_redmine.issue.filter.return_value = FakeResourceSet(
+            issues, total_count=None
+        )
+
+        result = await list_redmine_issues(
+            project_id=1, limit=25, offset=0, include_pagination_info=True
+        )
+
+        assert result["pagination"]["total"] is None
+        assert result["pagination"]["has_next"] is False
+
+
+class TestListIssuesRequestedLimitIsSent:
+    """The limit the schema allows is the limit the request carries.
+
+    python-redmine pages a limit above 100 itself, in chunks of 100, so
+    capping the request at 100 silently truncated ``limit=250`` to 100 rows
+    while the envelope reported the requested 250 -- and a measured
+    ``next_offset`` of 250 would then step over the 150 rows never fetched.
+    """
+
+    @pytest.mark.asyncio
+    async def test_limit_above_100_is_passed_through(self, mock_redmine):
+        issues = [_mock_issue(i) for i in range(1, 101)]
+        mock_redmine.issue.filter.return_value = FakeResourceSet(
+            issues, total_count=100
+        )
+
+        await list_redmine_issues(
+            project_id=1, limit=250, offset=0, include_pagination_info=True
+        )
+
+        assert mock_redmine.issue.filter.call_args[1]["limit"] == 250
+
+
+class TestEnvelopeShape:
+    """Both issue tools return the shared helper's key set."""
+
+    @pytest.mark.asyncio
+    async def test_list_envelope_matches_the_shared_helper(self, mock_redmine):
+        issues = [_mock_issue(i) for i in range(1, 4)]
+        mock_redmine.issue.filter.return_value = FakeResourceSet(issues, total_count=3)
+
+        result = await list_redmine_issues(
+            project_id=1, limit=25, offset=0, include_pagination_info=True
+        )
+
+        assert set(result["pagination"].keys()) == PAGINATION_KEYS
+        assert result["pagination"] == _pagination_info(
+            limit=25, offset=0, count=3, total=3
+        )
+
+    @pytest.mark.asyncio
+    async def test_search_envelope_carries_a_null_total(self, mock_redmine):
+        """The search API reports no total, so the envelope says null.
+
+        Previously the search envelope simply omitted the key, so the two
+        issue tools disagreed about the shape a caller had learned.
+        """
+        issues = [_mock_issue(i) for i in range(1, 6)]
+        mock_redmine.issue.search.return_value = issues
+
+        result = await search_redmine_issues(
+            "bug", limit=25, offset=0, include_pagination_info=True
+        )
+
+        assert set(result["pagination"].keys()) == PAGINATION_KEYS
+        assert result["pagination"]["total"] is None
+        assert result["pagination"]["has_next"] is False
+
+    @pytest.mark.asyncio
+    async def test_search_full_page_still_infers_a_next(self, mock_redmine):
+        issues = [_mock_issue(i) for i in range(1, 26)]
+        mock_redmine.issue.search.return_value = issues
+
+        result = await search_redmine_issues(
+            "bug", limit=25, offset=0, include_pagination_info=True
+        )
+
+        assert result["pagination"]["has_next"] is True
+        assert result["pagination"]["next_offset"] == 25

--- a/tests/test_list_issue_custom_fields_and_relations.py
+++ b/tests/test_list_issue_custom_fields_and_relations.py
@@ -231,12 +231,17 @@ class TestIssueRelations:
         assert result[0] == {"id": 1, "custom_fields": _CF}
 
     @pytest.mark.asyncio
-    async def test_count_query_drops_the_include(self, mock_redmine):
-        """The pagination count reads total_count off the envelope."""
+    async def test_pagination_total_needs_no_count_query(self, mock_redmine):
+        """The total reads off the page response; no second request.
+
+        There used to be a separate ``limit=1`` count query (which had to
+        drop the ``include``); since #240 the total comes from the same
+        response the rows did, so the one request keeps its include.
+        """
         mock_redmine.issue.filter.return_value = [_mock_issue(relations=_REL)]
         await list_redmine_issues(
             project_id=1, include_relations=True, include_pagination_info=True
         )
-        count_call = mock_redmine.issue.filter.call_args_list[-1][1]
-        assert count_call["limit"] == 1
-        assert "include" not in count_call
+        assert mock_redmine.issue.filter.call_count == 1
+        only_call = mock_redmine.issue.filter.call_args_list[0][1]
+        assert only_call["include"] == "relations"

--- a/tests/test_list_redmine_issues.py
+++ b/tests/test_list_redmine_issues.py
@@ -322,14 +322,12 @@ class TestListRedmineIssues:
         """Test pagination metadata when include_pagination_info=True."""
         mock_issues = self.create_mock_issues(25)
 
-        # First call returns issues, second call for total count
-        first_call = Mock()
-        first_call.__iter__ = Mock(return_value=iter(mock_issues))
-        second_call = Mock()
-        second_call.__iter__ = Mock(return_value=iter([]))
-        second_call.total_count = 100
+        # One call: the rows and the total ride the same response.
+        page = Mock()
+        page.__iter__ = Mock(return_value=iter(mock_issues))
+        page.total_count = 100
 
-        mock_redmine.issue.filter.side_effect = [first_call, second_call]
+        mock_redmine.issue.filter.return_value = page
 
         result = await list_redmine_issues(
             project_id=1, limit=25, offset=0, include_pagination_info=True
@@ -350,45 +348,37 @@ class TestListRedmineIssues:
         assert pagination["total"] == 100
 
     @pytest.mark.asyncio
-    async def test_pagination_count_query_is_bounded(self, mock_redmine):
-        """Count query must fetch a single issue, not the whole project.
+    async def test_pagination_total_costs_no_extra_request(self, mock_redmine):
+        """The total reads off the page response itself; one request only.
 
-        Regression: without an explicit limit, python-redmine's ResourceSet
-        materializes every matching issue chunk-by-chunk just to compute
-        total_count, which can exceed the MCP tools/call timeout for large
-        projects (e.g. the triage board's Kanban view).
+        This used to be a separate bounded ``limit=1`` count query (whose
+        cost regression this test guarded); since #240 there is no second
+        query at all, so the guard is now on the request count.
         """
         mock_issues = self.create_mock_issues(25)
 
-        first_call = Mock()
-        first_call.__iter__ = Mock(return_value=iter(mock_issues))
-        second_call = Mock()
-        second_call.__iter__ = Mock(return_value=iter([]))
-        second_call.total_count = 100
+        page = Mock()
+        page.__iter__ = Mock(return_value=iter(mock_issues))
+        page.total_count = 100
 
-        mock_redmine.issue.filter.side_effect = [first_call, second_call]
+        mock_redmine.issue.filter.return_value = page
 
         await list_redmine_issues(
             project_id=1, limit=100, offset=0, include_pagination_info=True
         )
 
-        # Two calls: the page query and the total-count query.
-        assert mock_redmine.issue.filter.call_count == 2
-        count_kwargs = mock_redmine.issue.filter.call_args_list[1][1]
-        assert count_kwargs["limit"] == 1
+        assert mock_redmine.issue.filter.call_count == 1
 
     @pytest.mark.asyncio
     async def test_pagination_has_previous_true(self, mock_redmine):
         """Test has_previous=True when offset > 0."""
         mock_issues = self.create_mock_issues(10)
 
-        first_call = Mock()
-        first_call.__iter__ = Mock(return_value=iter(mock_issues))
-        second_call = Mock()
-        second_call.__iter__ = Mock(return_value=iter([]))
-        second_call.total_count = 50
+        page = Mock()
+        page.__iter__ = Mock(return_value=iter(mock_issues))
+        page.total_count = 50
 
-        mock_redmine.issue.filter.side_effect = [first_call, second_call]
+        mock_redmine.issue.filter.return_value = page
 
         result = await list_redmine_issues(
             project_id=1, limit=10, offset=20, include_pagination_info=True
@@ -403,13 +393,11 @@ class TestListRedmineIssues:
         """Test has_next=False when fewer results than limit."""
         mock_issues = self.create_mock_issues(5)
 
-        first_call = Mock()
-        first_call.__iter__ = Mock(return_value=iter(mock_issues))
-        second_call = Mock()
-        second_call.__iter__ = Mock(return_value=iter([]))
-        second_call.total_count = 5
+        page = Mock()
+        page.__iter__ = Mock(return_value=iter(mock_issues))
+        page.total_count = 5
 
-        mock_redmine.issue.filter.side_effect = [first_call, second_call]
+        mock_redmine.issue.filter.return_value = page
 
         result = await list_redmine_issues(
             project_id=1, limit=25, include_pagination_info=True


### PR DESCRIPTION
Closes #240.

`list_redmine_issues` hand-built its pagination keys with three defects, and `search_redmine_issues` shipped a seven-key envelope with no `total` at all. Both now build the envelope through the `_pagination_info` helper that #235 and #239 introduced, so every paginated envelope in the server carries the same eight keys read the same way.

- `has_next` was inferred from `len(result) == limit`, which reports one page too many whenever the collection size is an exact multiple of the page size. With a total in hand it is now measured as `offset + limit < total`. Verified live: a 10-issue project at `offset=8, limit=2` used to report a further page and now does not.
- The total cost a second `limit=1` request per call. python-redmine reads `total_count` off the first page's envelope, and iterating the result set is what populates it, so the total now rides the response the rows already came from and the envelope costs nothing extra.
- The fetch was capped at `min(limit, 100)` while the envelope reported the requested window, so `limit=250` silently returned 100 rows with `has_next: false`. This was latent before and load-bearing after: a measured `next_offset` of 250 would step over the 150 rows never fetched. The limit is now passed through whole, which python-redmine pages itself in chunks of 100, matching what the schema (`le=1000`) has always advertised.
- A response carrying no usable total now reports `total: null` rather than the invented `offset + count + 1` estimate, with `has_next` falling back to the full-page inference so a caller looping on it never stops mid-collection. `search_redmine_issues` reports `total: null` explicitly (the Search API measures nothing), where it used to omit the key.

Tests: new `tests/test_issue_pagination_helper.py` (9 tests; the resource-set fake carries `total_count` only when told to, since presence versus absence of that number is the thing under test). Three existing tests pinning the count-query contract were rewritten to pin the single-request one. Full suite 2050 passed; verified end to end against Redmine 6.1.1 and 7.0.0 sandboxes.
