### PR TITLE
feat: expose only allow-listed tools via REDMINE_MCP_ALLOW_TOOLS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `REDMINE_MCP_ALLOW_TOOLS` (and `REDMINE_MCP_ALLOW_TOOLS_FILE`) expose only
+  the named tools; everything else is hidden from `tools/list` and rejected
+  by `call_tool`. The pass runs after plugin visibility and only ever
+  disables, so a listed tool whose plugin flag is off stays hidden. Unknown
+  names are ignored with a startup warning. Granularity is whole tools --
+  per-action control on `manage_X` tools remains `REDMINE_MCP_READ_ONLY`'s
+  job, and the two compose, so an allow list containing write tools with
+  read-only off is how selective write access is expressed.
+  ([#255](https://github.com/jztan/redmine-mcp-server/issues/255))
+
 ### Fixed
 - `get_redmine_attachment` no longer hardcodes `http://` in the download
   `uri` and no longer appends default ports. The scheme now honors a new
@@ -19,6 +30,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Contributors
 - @andilem reported the TLS download URI bug with a precise diagnosis and
   fix proposal ([#252](https://github.com/jztan/redmine-mcp-server/issues/252))
+- @andilem proposed and implemented the tool allow list
+  ([#255](https://github.com/jztan/redmine-mcp-server/issues/255))
 
 ## [2.13.0] - 2026-08-29
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - `REDMINE_MCP_ALLOW_TOOLS` (and `REDMINE_MCP_ALLOW_TOOLS_FILE`) expose only
-  the named tools; everything else is hidden from `tools/list` and rejected
-  by `call_tool`. The pass runs after plugin visibility and only ever
-  disables, so a listed tool whose plugin flag is off stays hidden. Unknown
-  names are ignored with a startup warning. Granularity is whole tools --
-  per-action control on `manage_X` tools remains `REDMINE_MCP_READ_ONLY`'s
-  job, and the two compose, so an allow list containing write tools with
-  read-only off is how selective write access is expressed.
+  the named tools; everything else is hidden from `tools/list` and refused by
+  `call_tool` with a `TOOL_NOT_ALLOWED` envelope. Enforced by middleware, so
+  the restriction reads no server internals and cannot fail open. It runs
+  alongside plugin visibility and only ever narrows, so a listed tool whose
+  plugin flag is off stays hidden. A variable that is set but names no tool
+  refuses to start; names matching no tool are warned about at startup.
+  Granularity is whole tools -- per-action control on `manage_X` tools
+  remains `REDMINE_MCP_READ_ONLY`'s job, and the two compose, so an allow
+  list containing write tools with read-only off is how selective write
+  access is expressed.
   ([#255](https://github.com/jztan/redmine-mcp-server/issues/255))
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -154,6 +154,8 @@ The server runs on `http://localhost:8000` with the MCP endpoint at `/mcp`, heal
 | `REDMINE_SSL_CLIENT_CERT` | No | – | Path to client certificate for mutual TLS |
 | `REDMINE_TIMEOUT` | No | `30` | Whole seconds to wait for a Redmine HTTP response before failing the call. Applied as a connect timeout of at most 10s plus a read timeout of the full value. Set to `0` to wait indefinitely, which restores the previous behavior and can hang the request. |
 | `REDMINE_MCP_READ_ONLY` | No | `false` | Block all write operations (create/update/delete) when set to `true` |
+| `REDMINE_MCP_ALLOW_TOOLS` | No | – | Expose only these tools (comma-separated names). Unset exposes all. Narrows the surface only: a listed tool whose plugin flag is off stays hidden. Whole tools, so per-action control on `manage_X` remains `REDMINE_MCP_READ_ONLY`'s job. Unknown names are ignored with a startup warning ([details](docs/tool-reference.md#tool-allow-list)) |
+| `REDMINE_MCP_ALLOW_TOOLS_FILE` | No | – | Path to a file with one allowed tool name per line (`#` starts a comment). Used only when `REDMINE_MCP_ALLOW_TOOLS` is unset |
 | `REDMINE_OAUTH_SCOPE_ENFORCEMENT` | No | `on` | OAuth modes only: deny tool calls whose access token lacks the tool's Redmine permission scopes, and filter `tools/list` accordingly. Set to `off` temporarily while re-consenting older tokens ([details](docs/oauth-setup.md#scope-enforcement)) |
 | `REDMINE_OAUTH_DISCOVERY_AS` | No | `redmine` | OAuth modes only: which authorization server discovery advertises. `redmine` names your Redmine; `self` advertises this server (issuer = `REDMINE_MCP_BASE_URL`) and serves RFC 8414 metadata at its own canonical well-known location, which clients that probe there need, Cursor among them ([details](docs/oauth-setup.md#cursor-and-self-as-discovery)) |
 | `REDMINE_MCP_SCOPES` | No | – | OAuth modes only: advertise a subset of scopes in discovery, matching the permissions your Redmine OAuth Application actually enables. Avoids `invalid_scope` at consent when a client requests the full advertised list |
@@ -608,6 +610,8 @@ flag. Tags also needs the `view_issue_tags`, `create_issue_tags`, and
 `edit_issue_tags` permissions on the Redmine server.
 
 ## Available Tools
+
+A deployment can expose a subset of these with `REDMINE_MCP_ALLOW_TOOLS`; everything else disappears from `tools/list`.
 
 This MCP server provides 45 core tools for interacting with Redmine, plus 13 plugin tools that are listed only when the matching `REDMINE_*_ENABLED` flag is set (58 in total), and 1 operator tool exposed by `REDMINE_MCP_EXPOSE_ADMIN_TOOLS=true` (maximum of 59). A client connected to a vanilla Redmine sees just the 45 core tools. For full documentation of every tool, see the [Tool Reference](./docs/tool-reference.md).
 

--- a/README.md
+++ b/README.md
@@ -154,8 +154,8 @@ The server runs on `http://localhost:8000` with the MCP endpoint at `/mcp`, heal
 | `REDMINE_SSL_CLIENT_CERT` | No | – | Path to client certificate for mutual TLS |
 | `REDMINE_TIMEOUT` | No | `30` | Whole seconds to wait for a Redmine HTTP response before failing the call. Applied as a connect timeout of at most 10s plus a read timeout of the full value. Set to `0` to wait indefinitely, which restores the previous behavior and can hang the request. |
 | `REDMINE_MCP_READ_ONLY` | No | `false` | Block all write operations (create/update/delete) when set to `true` |
-| `REDMINE_MCP_ALLOW_TOOLS` | No | – | Expose only these tools (comma-separated names). Unset exposes all. Narrows the surface only: a listed tool whose plugin flag is off stays hidden. Whole tools, so per-action control on `manage_X` remains `REDMINE_MCP_READ_ONLY`'s job. Unknown names are ignored with a startup warning ([details](docs/tool-reference.md#tool-allow-list)) |
-| `REDMINE_MCP_ALLOW_TOOLS_FILE` | No | – | Path to a file with one allowed tool name per line (`#` starts a comment). Used only when `REDMINE_MCP_ALLOW_TOOLS` is unset |
+| `REDMINE_MCP_ALLOW_TOOLS` | No | – | Expose only these tools (comma-separated names). Unset exposes all; set but naming no tool refuses to start. Narrows the surface only: a listed tool whose plugin flag is off stays hidden. Whole tools, so per-action control on `manage_X` remains `REDMINE_MCP_READ_ONLY`'s job. Names matching no tool are warned about at startup ([details](docs/tool-reference.md#tool-allow-list)) |
+| `REDMINE_MCP_ALLOW_TOOLS_FILE` | No | – | Path to a file with one allowed tool name per line (`#` starts a comment). Used when `REDMINE_MCP_ALLOW_TOOLS` is unset or empty |
 | `REDMINE_OAUTH_SCOPE_ENFORCEMENT` | No | `on` | OAuth modes only: deny tool calls whose access token lacks the tool's Redmine permission scopes, and filter `tools/list` accordingly. Set to `off` temporarily while re-consenting older tokens ([details](docs/oauth-setup.md#scope-enforcement)) |
 | `REDMINE_OAUTH_DISCOVERY_AS` | No | `redmine` | OAuth modes only: which authorization server discovery advertises. `redmine` names your Redmine; `self` advertises this server (issuer = `REDMINE_MCP_BASE_URL`) and serves RFC 8414 metadata at its own canonical well-known location, which clients that probe there need, Cursor among them ([details](docs/oauth-setup.md#cursor-and-self-as-discovery)) |
 | `REDMINE_MCP_SCOPES` | No | – | OAuth modes only: advertise a subset of scopes in discovery, matching the permissions your Redmine OAuth Application actually enables. Avoids `invalid_scope` at consent when a client requests the full advertised list |
@@ -611,7 +611,7 @@ flag. Tags also needs the `view_issue_tags`, `create_issue_tags`, and
 
 ## Available Tools
 
-A deployment can expose a subset of these with `REDMINE_MCP_ALLOW_TOOLS`; everything else disappears from `tools/list`.
+A deployment can expose a subset of these with `REDMINE_MCP_ALLOW_TOOLS`; everything else disappears from `tools/list` and is refused by `call_tool`.
 
 This MCP server provides 45 core tools for interacting with Redmine, plus 13 plugin tools that are listed only when the matching `REDMINE_*_ENABLED` flag is set (58 in total), and 1 operator tool exposed by `REDMINE_MCP_EXPOSE_ADMIN_TOOLS=true` (maximum of 59). A client connected to a vanilla Redmine sees just the 45 core tools. For full documentation of every tool, see the [Tool Reference](./docs/tool-reference.md).
 

--- a/docs/tool-reference.md
+++ b/docs/tool-reference.md
@@ -187,6 +187,46 @@ When enabled, the following tools return an error instead of executing
 
 All read tools (`get_redmine_issue`, `list_redmine_issues`, `list_redmine_projects`, etc.) continue to work normally. The admin-gated `cleanup_attachment_files` tool (when registered via `REDMINE_MCP_EXPOSE_ADMIN_TOOLS=true`) is also unaffected — it performs local filesystem cleanup, not Redmine mutations.
 
+### Tool Allow List
+
+Expose only the tools a deployment actually needs by naming them in
+`REDMINE_MCP_ALLOW_TOOLS`:
+
+```bash
+# In .env file
+REDMINE_MCP_ALLOW_TOOLS=get_redmine_issue,list_redmine_issues,search_redmine_issues,list_subtasks,get_private_notes,get_current_user
+```
+
+Or, for longer lists, one name per line in a file (`#` starts a comment):
+
+```bash
+REDMINE_MCP_ALLOW_TOOLS_FILE=/etc/redmine-mcp/allowed-tools.txt
+```
+
+`REDMINE_MCP_ALLOW_TOOLS` takes precedence when both are set. Leaving both
+unset exposes every tool, as before.
+
+Tools outside the list disappear from `tools/list` and `call_tool` rejects
+them, the same mechanism the plugin flags use. Three properties are worth
+knowing:
+
+- **It only narrows.** The pass runs after plugin visibility and never
+  enables anything, so a tool that is on the allow list but hidden by its
+  plugin flag stays hidden. Listing `manage_deal` does not substitute for
+  `REDMINE_DEALS_ENABLED=true`.
+- **Granularity is whole tools.** A `manage_X(action=...)` tool is allowed or
+  denied as a unit. To allow its read actions while blocking its writes, use
+  `REDMINE_MCP_READ_ONLY` (see [Read-Only Mode](#read-only-mode)) — the two
+  compose, and an allow list that includes write tools with read-only off is
+  how selective write access is expressed.
+- **Unknown names are ignored, loudly.** A name that matches no registered
+  tool produces a startup warning naming it, so a typo does not quietly fail
+  to expose a tool. A list whose names are *all* unknown is still honoured
+  and exposes nothing.
+
+Because this is enforced by the server rather than the client, it holds for
+every user of a shared deployment.
+
 ### Prompt Injection Protection
 
 All user-controlled content returned from Redmine (issue descriptions, journal notes, wiki page text, search excerpts, version descriptions) is automatically wrapped in unique boundary tags:

--- a/docs/tool-reference.md
+++ b/docs/tool-reference.md
@@ -203,26 +203,40 @@ Or, for longer lists, one name per line in a file (`#` starts a comment):
 REDMINE_MCP_ALLOW_TOOLS_FILE=/etc/redmine-mcp/allowed-tools.txt
 ```
 
-`REDMINE_MCP_ALLOW_TOOLS` takes precedence when both are set. Leaving both
-unset exposes every tool, as before.
+`REDMINE_MCP_ALLOW_TOOLS` takes precedence when it names at least one tool.
+Leaving both unset exposes every tool, as before; setting the variable to a
+value that names no tool at all (`""`, `","`) is a misconfiguration the
+server refuses to start on rather than guess about. An empty variable with
+`REDMINE_MCP_ALLOW_TOOLS_FILE` set falls through to the file, so a
+`docker-compose.yml` that renders an unset `${REDMINE_MCP_ALLOW_TOOLS}` as
+the empty string does not shadow it.
 
-Tools outside the list disappear from `tools/list` and `call_tool` rejects
-them, the same mechanism the plugin flags use. Three properties are worth
-knowing:
+Tools outside the list disappear from `tools/list` and `call_tool` refuses
+them with a `TOOL_NOT_ALLOWED` envelope. Enforcement is middleware, in the
+shape of the OAuth scope check: `on_list_tools` filters the list the
+framework hands it and `on_call_tool` checks the name it is given. Both work
+on data passed in, so there is no registry to read and nothing that widens
+the surface if FastMCP moves its internals — an allow list that fails open is
+worse than none, because the operator believes a restriction is in force
+while it is not.
 
-- **It only narrows.** The pass runs after plugin visibility and never
-  enables anything, so a tool that is on the allow list but hidden by its
-  plugin flag stays hidden. Listing `manage_deal` does not substitute for
-  `REDMINE_DEALS_ENABLED=true`.
+Three properties are worth knowing:
+
+- **It only narrows.** The middleware runs alongside plugin visibility rather
+  than replacing it and never enables anything, so a tool that is on the
+  allow list but hidden by its plugin flag stays hidden. Listing
+  `manage_deal` does not substitute for `REDMINE_DEALS_ENABLED=true`.
 - **Granularity is whole tools.** A `manage_X(action=...)` tool is allowed or
   denied as a unit. To allow its read actions while blocking its writes, use
   `REDMINE_MCP_READ_ONLY` (see [Read-Only Mode](#read-only-mode)) — the two
   compose, and an allow list that includes write tools with read-only off is
   how selective write access is expressed.
-- **Unknown names are ignored, loudly.** A name that matches no registered
-  tool produces a startup warning naming it, so a typo does not quietly fail
-  to expose a tool. A list whose names are *all* unknown is still honoured
-  and exposes nothing.
+- **A name matching no tool is warned about, not honoured.** Startup logs a
+  warning naming it, so a typo does not quietly fail to expose a tool. The
+  warning is best-effort — it reads a private FastMCP registry to tell a
+  misspelling from a real name and stays quiet if that ever moves — and it
+  never decides what is exposed. A list whose names are all misspelled
+  exposes nothing.
 
 Because this is enforced by the server rather than the client, it holds for
 every user of a shared deployment.

--- a/src/redmine_mcp_server/_env.py
+++ b/src/redmine_mcp_server/_env.py
@@ -130,30 +130,34 @@ def _admin_tools_enabled() -> bool:
 def get_allowed_tools() -> set[str] | None:
     """Tool names an operator allow-lists, or ``None`` when unrestricted.
 
-    Reads ``REDMINE_MCP_ALLOW_TOOLS`` (comma-separated). When that is unset,
-    falls back to ``REDMINE_MCP_ALLOW_TOOLS_FILE`` (one name per line, ``#``
-    starts a comment) -- the same env-var-wins-over-file precedence as
-    :func:`get_secret`.
+    Reads ``REDMINE_MCP_ALLOW_TOOLS`` (comma-separated), falling back to
+    ``REDMINE_MCP_ALLOW_TOOLS_FILE`` (one name per line, ``#`` starts a
+    comment) -- the same env-var-wins-over-file precedence as
+    :func:`get_secret`, and branching on truthiness for the same reason.
+    ``docker-compose`` renders an unset ``${VAR}`` as the empty string, so an
+    empty variable has to mean "not set" or it would shadow a perfectly good
+    file.
 
-    Returns ``None`` when neither is set, so callers can distinguish "no
-    allow list configured" from "configured but empty". A configured but
-    empty list comes back as an empty set for the caller to reject.
+    Returns ``None`` when neither carries anything, so callers can tell "no
+    allow list configured" from "configured but empty". A variable holding
+    only separators comes back as an empty set: that is not an unset value but
+    a garbled one, and the caller rejects it rather than guessing.
     """
     raw = os.getenv("REDMINE_MCP_ALLOW_TOOLS")
-    if raw is None:
-        file_name = os.getenv("REDMINE_MCP_ALLOW_TOOLS_FILE")
-        if not file_name:
-            return None
-        try:
-            raw_lines = Path(file_name).read_text(encoding="utf-8").splitlines()
-        except OSError as exc:
-            raise RuntimeError(
-                "Could not read tool allow list from "
-                f"REDMINE_MCP_ALLOW_TOOLS_FILE ({file_name}): {exc}"
-            ) from exc
-        entries = [line.split("#", 1)[0] for line in raw_lines]
-    else:
-        entries = raw.split(",")
+    if raw:
+        return {entry.strip() for entry in raw.split(",") if entry.strip()}
+
+    file_name = os.getenv("REDMINE_MCP_ALLOW_TOOLS_FILE")
+    if not file_name:
+        return None
+    try:
+        raw_lines = Path(file_name).read_text(encoding="utf-8").splitlines()
+    except OSError as exc:
+        raise RuntimeError(
+            "Could not read tool allow list from "
+            f"REDMINE_MCP_ALLOW_TOOLS_FILE ({file_name}): {exc}"
+        ) from exc
+    entries = [line.split("#", 1)[0] for line in raw_lines]
     return {entry.strip() for entry in entries if entry.strip()}
 
 

--- a/src/redmine_mcp_server/_env.py
+++ b/src/redmine_mcp_server/_env.py
@@ -127,6 +127,36 @@ def _admin_tools_enabled() -> bool:
     return _is_true_env("REDMINE_MCP_EXPOSE_ADMIN_TOOLS", "false")
 
 
+def get_allowed_tools() -> set[str] | None:
+    """Tool names an operator allow-lists, or ``None`` when unrestricted.
+
+    Reads ``REDMINE_MCP_ALLOW_TOOLS`` (comma-separated). When that is unset,
+    falls back to ``REDMINE_MCP_ALLOW_TOOLS_FILE`` (one name per line, ``#``
+    starts a comment) -- the same env-var-wins-over-file precedence as
+    :func:`get_secret`.
+
+    Returns ``None`` when neither is set, so callers can distinguish "no
+    allow list configured" from "configured but empty". A configured but
+    empty list comes back as an empty set for the caller to reject.
+    """
+    raw = os.getenv("REDMINE_MCP_ALLOW_TOOLS")
+    if raw is None:
+        file_name = os.getenv("REDMINE_MCP_ALLOW_TOOLS_FILE")
+        if not file_name:
+            return None
+        try:
+            raw_lines = Path(file_name).read_text(encoding="utf-8").splitlines()
+        except OSError as exc:
+            raise RuntimeError(
+                "Could not read tool allow list from "
+                f"REDMINE_MCP_ALLOW_TOOLS_FILE ({file_name}): {exc}"
+            ) from exc
+        entries = [line.split("#", 1)[0] for line in raw_lines]
+    else:
+        entries = raw.split(",")
+    return {entry.strip() for entry in entries if entry.strip()}
+
+
 def _get_int_env(var_name: str, default: int) -> int:
     """Parse an integer environment variable, falling back to default."""
     try:

--- a/src/redmine_mcp_server/_tool_allow_list.py
+++ b/src/redmine_mcp_server/_tool_allow_list.py
@@ -1,0 +1,87 @@
+"""Expose only the tools an operator allow-lists.
+
+``REDMINE_MCP_ALLOW_TOOLS`` (or ``REDMINE_MCP_ALLOW_TOOLS_FILE``) names the
+tools a deployment offers. At startup ``main.py`` calls
+:func:`apply_tool_allow_list` right after :func:`apply_plugin_visibility`,
+and every tool outside the list is hidden with the same FastMCP visibility
+transforms: it vanishes from ``tools/list`` and ``call_tool`` rejects it.
+
+The pass only ever *disables*. It never enables a listed tool, so a tool
+that is both on the allow list and hidden by its plugin flag stays hidden --
+the allow list narrows the surface, it cannot widen it. That also means the
+pass has to run again after any change to plugin visibility, which is what
+the unit tests do.
+
+Granularity is whole tools. A ``manage_X(action=...)`` tool is allowed or
+denied as a unit; restricting it to its read actions is what
+``REDMINE_MCP_READ_ONLY`` is for.
+"""
+
+import logging
+from typing import Any, Set
+
+from ._env import get_allowed_tools
+
+logger = logging.getLogger(__name__)
+
+_TOOL_KEY_PREFIX = "tool:"
+
+
+def registered_tool_names(mcp: Any) -> Set[str]:
+    """Every tool name registered on ``mcp``, whether enabled or not.
+
+    FastMCP exposes no synchronous enumeration -- ``list_tools`` and friends
+    are all coroutines, and this pass runs synchronously at import time next
+    to :func:`apply_plugin_visibility`. So it reads the local provider's
+    component registry, whose keys are ``"tool:<name>@<version>"``.
+    """
+    components = getattr(getattr(mcp, "_local_provider", None), "_components", None)
+    if components is None:  # pragma: no cover - guards a FastMCP API change
+        logger.warning(
+            "Cannot enumerate registered tools; tool allow list not applied. "
+            "This build of FastMCP does not expose the component registry "
+            "where it is expected."
+        )
+        return set()
+    return {
+        key[len(_TOOL_KEY_PREFIX) :].split("@", 1)[0]
+        for key in components
+        if key.startswith(_TOOL_KEY_PREFIX)
+    }
+
+
+def apply_tool_allow_list(mcp: Any) -> Set[str] | None:
+    """Hide every tool outside the configured allow list.
+
+    Returns the set of allowed names that actually exist, or ``None`` when no
+    allow list is configured (all tools stay as plugin visibility left them).
+    """
+    allowed = get_allowed_tools()
+    if allowed is None:
+        return None
+
+    if not allowed:
+        logger.warning(
+            "REDMINE_MCP_ALLOW_TOOLS is set but names no tools; ignoring it "
+            "and exposing the full tool surface. Remove the variable to make "
+            "that explicit, or name the tools to expose."
+        )
+        return None
+
+    registered = registered_tool_names(mcp)
+    if not registered:
+        return None
+
+    unknown = sorted(allowed - registered)
+    if unknown:
+        logger.warning(
+            "REDMINE_MCP_ALLOW_TOOLS names %d unknown tool(s), ignored: %s. "
+            "Check for typos -- a misspelled name does not expose a tool.",
+            len(unknown),
+            ", ".join(unknown),
+        )
+
+    hidden = registered - allowed
+    if hidden:
+        mcp.disable(names=hidden)
+    return allowed & registered

--- a/src/redmine_mcp_server/_tool_allow_list.py
+++ b/src/redmine_mcp_server/_tool_allow_list.py
@@ -1,47 +1,92 @@
 """Expose only the tools an operator allow-lists.
 
 ``REDMINE_MCP_ALLOW_TOOLS`` (or ``REDMINE_MCP_ALLOW_TOOLS_FILE``) names the
-tools a deployment offers. At startup ``main.py`` calls
-:func:`apply_tool_allow_list` right after :func:`apply_plugin_visibility`,
-and every tool outside the list is hidden with the same FastMCP visibility
-transforms: it vanishes from ``tools/list`` and ``call_tool`` rejects it.
+tools a deployment offers. Everything else disappears from ``tools/list`` and
+``call_tool`` refuses it.
 
-The pass only ever *disables*. It never enables a listed tool, so a tool
-that is both on the allow list and hidden by its plugin flag stays hidden --
-the allow list narrows the surface, it cannot widen it. That also means the
-pass has to run again after any change to plugin visibility, which is what
-the unit tests do.
+Enforced by middleware, in the shape of :mod:`._scope_middleware`:
+``on_list_tools`` filters whatever list it is handed and ``on_call_tool``
+checks the name it is given. Both work on data the framework passes in, so
+there is no registry to read and nothing that can widen the surface if FastMCP
+moves its internals. That property is the point -- an allow list that fails
+open is worse than none, because the operator believes a restriction is in
+force while it is not.
+
+The list narrows only. It runs alongside plugin visibility rather than
+replacing it, so a listed tool whose plugin flag is off stays hidden:
+allow-listing ``manage_deal`` does not substitute for
+``REDMINE_DEALS_ENABLED=true``.
 
 Granularity is whole tools. A ``manage_X(action=...)`` tool is allowed or
 denied as a unit; restricting it to its read actions is what
-``REDMINE_MCP_READ_ONLY`` is for.
+``REDMINE_MCP_READ_ONLY`` is for, and the two compose.
+
+The typo warning is separate and deliberately best-effort. It reads the local
+provider's component registry -- private API -- to tell a misspelled name from
+a real one, and stays quiet if that registry ever moves. A warning that
+misfires costs nothing; enforcement never depends on it.
 """
 
 import logging
-from typing import Any, Set
+from typing import Any, Optional, Set
+
+from fastmcp.server.middleware import Middleware
 
 from ._env import get_allowed_tools
+from ._tool_error_middleware import build_error_tool_result
 
 logger = logging.getLogger(__name__)
 
 _TOOL_KEY_PREFIX = "tool:"
 
+# Tools that exist but are registered only under a flag, so a correctly
+# spelled name can be absent from the registry. Allow-listing one of these
+# with its flag off is a no-op, not a typo, and must not be reported as one.
+CONDITIONALLY_REGISTERED = frozenset({"cleanup_attachment_files"})
+
+
+def _denial_payload(tool_name: str) -> dict[str, Any]:
+    return {
+        "error": f"Tool {tool_name!r} is not on this deployment's allow list.",
+        "hint": (
+            "The operator restricted the exposed tools with "
+            "REDMINE_MCP_ALLOW_TOOLS. Ask them to add it if you need it."
+        ),
+        "code": "TOOL_NOT_ALLOWED",
+    }
+
+
+class ToolAllowListMiddleware(Middleware):
+    """Hide and refuse every tool outside the configured allow list."""
+
+    def __init__(self, allowed: frozenset[str]) -> None:
+        self._allowed = allowed
+
+    @property
+    def allowed(self) -> frozenset[str]:
+        return self._allowed
+
+    async def on_list_tools(self, context, call_next):
+        tools = await call_next(context)
+        return [tool for tool in tools if tool.name in self._allowed]
+
+    async def on_call_tool(self, context, call_next):
+        tool_name = context.message.name
+        if tool_name not in self._allowed:
+            logger.info("Denying %r: not on the tool allow list.", tool_name)
+            return await build_error_tool_result(context, _denial_payload(tool_name))
+        return await call_next(context)
+
 
 def registered_tool_names(mcp: Any) -> Set[str]:
-    """Every tool name registered on ``mcp``, whether enabled or not.
+    """Every tool name registered on ``mcp``, or an empty set if unknowable.
 
-    FastMCP exposes no synchronous enumeration -- ``list_tools`` and friends
-    are all coroutines, and this pass runs synchronously at import time next
-    to :func:`apply_plugin_visibility`. So it reads the local provider's
-    component registry, whose keys are ``"tool:<name>@<version>"``.
+    Best-effort and private-API: FastMCP exposes no synchronous enumeration,
+    and this runs at import time. Used only to spot typos, never to decide
+    what is exposed -- so an empty result costs a warning, not a restriction.
     """
     components = getattr(getattr(mcp, "_local_provider", None), "_components", None)
-    if components is None:  # pragma: no cover - guards a FastMCP API change
-        logger.warning(
-            "Cannot enumerate registered tools; tool allow list not applied. "
-            "This build of FastMCP does not expose the component registry "
-            "where it is expected."
-        )
+    if components is None:
         return set()
     return {
         key[len(_TOOL_KEY_PREFIX) :].split("@", 1)[0]
@@ -50,38 +95,41 @@ def registered_tool_names(mcp: Any) -> Set[str]:
     }
 
 
-def apply_tool_allow_list(mcp: Any) -> Set[str] | None:
-    """Hide every tool outside the configured allow list.
-
-    Returns the set of allowed names that actually exist, or ``None`` when no
-    allow list is configured (all tools stay as plugin visibility left them).
-    """
-    allowed = get_allowed_tools()
-    if allowed is None:
-        return None
-
-    if not allowed:
-        logger.warning(
-            "REDMINE_MCP_ALLOW_TOOLS is set but names no tools; ignoring it "
-            "and exposing the full tool surface. Remove the variable to make "
-            "that explicit, or name the tools to expose."
-        )
-        return None
-
+def warn_about_unknown_names(mcp: Any, allowed: Set[str]) -> None:
+    """Log the allow-listed names this server does not have."""
     registered = registered_tool_names(mcp)
     if not registered:
-        return None
-
-    unknown = sorted(allowed - registered)
+        logger.debug(
+            "Cannot enumerate registered tools, so allow-listed names are not "
+            "checked for typos. The allow list itself is unaffected."
+        )
+        return
+    unknown = sorted(allowed - registered - CONDITIONALLY_REGISTERED)
     if unknown:
         logger.warning(
-            "REDMINE_MCP_ALLOW_TOOLS names %d unknown tool(s), ignored: %s. "
-            "Check for typos -- a misspelled name does not expose a tool.",
+            "REDMINE_MCP_ALLOW_TOOLS names %d tool(s) this server does not "
+            "have, ignored: %s. Check for typos.",
             len(unknown),
             ", ".join(unknown),
         )
 
-    hidden = registered - allowed
-    if hidden:
-        mcp.disable(names=hidden)
-    return allowed & registered
+
+def build_tool_allow_list(mcp: Any) -> Optional[ToolAllowListMiddleware]:
+    """Return the middleware for the configured allow list, or ``None``.
+
+    ``None`` means no allow list is configured and every tool stays exposed,
+    as before. A configured but empty list raises: it cannot be what an
+    operator meant, and treating it as "expose everything" would turn a
+    misconfiguration into a silently wider surface.
+    """
+    allowed = get_allowed_tools()
+    if allowed is None:
+        return None
+    if not allowed:
+        raise RuntimeError(
+            "REDMINE_MCP_ALLOW_TOOLS is set but names no tools. Remove the "
+            "variable to expose every tool, or name the tools to expose. "
+            "Refusing to start rather than guess."
+        )
+    warn_about_unknown_names(mcp, allowed)
+    return ToolAllowListMiddleware(frozenset(allowed))

--- a/src/redmine_mcp_server/main.py
+++ b/src/redmine_mcp_server/main.py
@@ -38,6 +38,7 @@ from ._mount import (  # noqa: E402
 logger = logging.getLogger(__name__)
 
 from ._plugin_visibility import apply_plugin_visibility  # noqa: E402
+from ._tool_allow_list import apply_tool_allow_list  # noqa: E402
 
 # Hide plugin-gated tools whose plugin flag is off. Runs once at import,
 # after every tool module has registered and after load_dotenv (the first
@@ -48,6 +49,17 @@ if _hidden:
     logger.info(
         "Plugin tool families hidden from tools/list (flag off): %s",
         ", ".join(_hidden),
+    )
+
+# Narrow the surface to REDMINE_MCP_ALLOW_TOOLS, if configured. Runs after
+# plugin visibility and only ever disables, so a listed tool whose plugin
+# flag is off stays hidden.
+TOOL_ALLOW_LIST = apply_tool_allow_list(mcp)
+if TOOL_ALLOW_LIST is not None:
+    logger.info(
+        "Tool allow list active: %d tool(s) exposed (%s)",
+        len(TOOL_ALLOW_LIST),
+        ", ".join(sorted(TOOL_ALLOW_LIST)),
     )
 
 REDMINE_AUTH_MODE = os.environ.get("REDMINE_AUTH_MODE", "legacy").lower()

--- a/src/redmine_mcp_server/main.py
+++ b/src/redmine_mcp_server/main.py
@@ -38,7 +38,7 @@ from ._mount import (  # noqa: E402
 logger = logging.getLogger(__name__)
 
 from ._plugin_visibility import apply_plugin_visibility  # noqa: E402
-from ._tool_allow_list import apply_tool_allow_list  # noqa: E402
+from ._tool_allow_list import build_tool_allow_list  # noqa: E402
 
 # Hide plugin-gated tools whose plugin flag is off. Runs once at import,
 # after every tool module has registered and after load_dotenv (the first
@@ -51,15 +51,17 @@ if _hidden:
         ", ".join(_hidden),
     )
 
-# Narrow the surface to REDMINE_MCP_ALLOW_TOOLS, if configured. Runs after
-# plugin visibility and only ever disables, so a listed tool whose plugin
-# flag is off stays hidden.
-TOOL_ALLOW_LIST = apply_tool_allow_list(mcp)
+# Narrow the surface to REDMINE_MCP_ALLOW_TOOLS, if configured. Middleware
+# rather than a visibility pass, so it filters whatever list the framework
+# hands it and cannot widen the surface if FastMCP moves its internals.
+TOOL_ALLOW_LIST = build_tool_allow_list(mcp)
 if TOOL_ALLOW_LIST is not None:
+    mcp.add_middleware(TOOL_ALLOW_LIST)
     logger.info(
-        "Tool allow list active: %d tool(s) exposed (%s)",
-        len(TOOL_ALLOW_LIST),
-        ", ".join(sorted(TOOL_ALLOW_LIST)),
+        "Tool allow list active: %d name(s) allowed (%s). Plugin flags still "
+        "apply, so a listed tool whose flag is off stays hidden.",
+        len(TOOL_ALLOW_LIST.allowed),
+        ", ".join(sorted(TOOL_ALLOW_LIST.allowed)),
     )
 
 REDMINE_AUTH_MODE = os.environ.get("REDMINE_AUTH_MODE", "legacy").lower()

--- a/tests/test_tool_allow_list.py
+++ b/tests/test_tool_allow_list.py
@@ -1,11 +1,11 @@
-"""Only allow-listed tools are exposed, and the list can never widen."""
+"""Only allow-listed tools are exposed, and the list cannot widen."""
 
+import json
 import os
 from unittest.mock import patch
 
 import pytest
-from fastmcp import Client
-from fastmcp.exceptions import ToolError
+from fastmcp import Client, FastMCP
 
 from redmine_mcp_server import server as _server
 from redmine_mcp_server import tools  # noqa: F401  -- triggers @mcp.tool
@@ -15,8 +15,11 @@ from redmine_mcp_server._plugin_visibility import (
     enable_all_plugin_tools,
 )
 from redmine_mcp_server._tool_allow_list import (
-    apply_tool_allow_list,
+    CONDITIONALLY_REGISTERED,
+    ToolAllowListMiddleware,
+    build_tool_allow_list,
     registered_tool_names,
+    warn_about_unknown_names,
 )
 
 ALLOWED = {"get_redmine_issue", "list_redmine_issues", "get_current_user"}
@@ -35,9 +38,10 @@ ALL_ON = {var: "true" for var in ALL_OFF}
 
 @pytest.fixture(autouse=True)
 def _restore_surface():
-    """Undo whatever a test hid, so later tests see the full surface."""
+    """Detach whatever a test attached and unhide what it hid."""
+    before = list(_server.mcp.middleware)
     yield
-    _server.mcp.enable(components={"tool"})
+    _server.mcp.middleware[:] = before
     enable_all_plugin_tools(_server.mcp)
 
 
@@ -47,9 +51,33 @@ def _no_ambient_allow_list(monkeypatch):
     monkeypatch.delenv("REDMINE_MCP_ALLOW_TOOLS_FILE", raising=False)
 
 
-async def _listed() -> set:
-    async with Client(_server.mcp) as client:
+def _attach(allowed) -> None:
+    _server.mcp.add_middleware(ToolAllowListMiddleware(frozenset(allowed)))
+
+
+async def _listed(mcp=None) -> set:
+    async with Client(mcp or _server.mcp) as client:
         return {t.name for t in await client.list_tools()}
+
+
+def _warnings(caplog) -> str:
+    return "\n".join(r.getMessage() for r in caplog.records if r.levelno >= 30)
+
+
+def _isolated(allowed) -> FastMCP:
+    """A server of stand-in tools, so calls stay off the network."""
+    mcp = FastMCP("allow-list-test")
+    mcp.add_middleware(ToolAllowListMiddleware(frozenset(allowed)))
+
+    @mcp.tool()
+    async def get_redmine_issue(issue_id: int) -> dict:
+        return {"issue": issue_id}
+
+    @mcp.tool()
+    async def list_time_entries() -> dict:
+        return {"entries": []}
+
+    return mcp
 
 
 # --- env parsing -------------------------------------------------------
@@ -66,7 +94,7 @@ def test_comma_separated_names_are_trimmed(monkeypatch):
     assert get_allowed_tools() == {"get_redmine_issue", "list_redmine_issues"}
 
 
-def test_configured_but_empty_is_an_empty_set(monkeypatch):
+def test_a_variable_of_only_separators_is_configured_but_empty(monkeypatch):
     monkeypatch.setenv("REDMINE_MCP_ALLOW_TOOLS", "  ,  ")
     assert get_allowed_tools() == set()
 
@@ -89,6 +117,20 @@ def test_env_var_wins_over_file(monkeypatch, tmp_path):
     assert get_allowed_tools() == {"get_redmine_issue"}
 
 
+def test_an_empty_variable_does_not_shadow_the_file(monkeypatch, tmp_path):
+    """docker-compose renders an unset ${VAR} as the empty string."""
+    listing = tmp_path / "allow.txt"
+    listing.write_text("list_redmine_issues\n", encoding="utf-8")
+    monkeypatch.setenv("REDMINE_MCP_ALLOW_TOOLS_FILE", str(listing))
+    monkeypatch.setenv("REDMINE_MCP_ALLOW_TOOLS", "")
+    assert get_allowed_tools() == {"list_redmine_issues"}
+
+
+def test_an_empty_variable_with_no_file_means_unset(monkeypatch):
+    monkeypatch.setenv("REDMINE_MCP_ALLOW_TOOLS", "")
+    assert get_allowed_tools() is None
+
+
 def test_unreadable_file_fails_loudly(monkeypatch, tmp_path):
     monkeypatch.setenv(
         "REDMINE_MCP_ALLOW_TOOLS_FILE", str(tmp_path / "does-not-exist.txt")
@@ -97,7 +139,90 @@ def test_unreadable_file_fails_loudly(monkeypatch, tmp_path):
         get_allowed_tools()
 
 
-# --- enumeration -------------------------------------------------------
+# --- construction ------------------------------------------------------
+
+
+def test_no_allow_list_builds_no_middleware():
+    assert build_tool_allow_list(_server.mcp) is None
+
+
+def test_a_configured_but_empty_list_refuses_to_start(monkeypatch):
+    """Starting wide open is the one outcome the operator did not ask for."""
+    monkeypatch.setenv("REDMINE_MCP_ALLOW_TOOLS", "  ,  ")
+    with pytest.raises(RuntimeError, match="names no tools"):
+        build_tool_allow_list(_server.mcp)
+
+
+def test_build_returns_middleware_holding_the_names(monkeypatch):
+    monkeypatch.setenv("REDMINE_MCP_ALLOW_TOOLS", ",".join(sorted(ALLOWED)))
+    middleware = build_tool_allow_list(_server.mcp)
+    assert isinstance(middleware, ToolAllowListMiddleware)
+    assert middleware.allowed == frozenset(ALLOWED)
+
+
+# --- enforcement -------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_only_listed_tools_are_exposed():
+    _attach(ALLOWED)
+    assert await _listed() == ALLOWED
+
+
+@pytest.mark.asyncio
+async def test_without_the_middleware_the_surface_is_untouched():
+    assert "list_time_entries" in await _listed()
+
+
+@pytest.mark.asyncio
+async def test_a_listed_tool_is_callable():
+    async with Client(_isolated({"get_redmine_issue"})) as client:
+        result = await client.call_tool("get_redmine_issue", {"issue_id": 7})
+    assert result.structured_content == {"issue": 7}
+
+
+@pytest.mark.asyncio
+async def test_an_unlisted_tool_is_refused_even_though_it_exists():
+    async with Client(_isolated({"get_redmine_issue"})) as client:
+        result = await client.call_tool("list_time_entries", {})
+    payload = json.loads(result.content[0].text)
+    assert payload["code"] == "TOOL_NOT_ALLOWED"
+    assert "list_time_entries" in payload["error"]
+    assert "REDMINE_MCP_ALLOW_TOOLS" in payload["hint"]
+
+
+@pytest.mark.asyncio
+async def test_a_hidden_tool_cannot_be_reached_by_name():
+    """tools/list is cosmetic; call_tool is the boundary."""
+    mcp = _isolated({"get_redmine_issue"})
+    assert await _listed(mcp) == {"get_redmine_issue"}
+    async with Client(mcp) as client:
+        result = await client.call_tool("list_time_entries", {})
+    assert json.loads(result.content[0].text)["code"] == "TOOL_NOT_ALLOWED"
+
+
+# --- the property the review asked for ---------------------------------
+
+
+@pytest.mark.asyncio
+async def test_enforcement_does_not_read_the_component_registry():
+    """The registry is private API; if it moves, the list must still hold.
+
+    Computing the complement and disabling it meant an unreadable registry
+    exposed every tool. Filtering the list the framework hands over has no
+    such failure mode, and this pins that down.
+    """
+    _attach(ALLOWED)
+    with patch(
+        "redmine_mcp_server._tool_allow_list.registered_tool_names", return_value=set()
+    ):
+        assert await _listed() == ALLOWED
+
+
+@pytest.mark.asyncio
+async def test_an_all_unknown_list_exposes_nothing_rather_than_everything():
+    _attach({"nope", "nope2"})
+    assert await _listed() == set()
 
 
 def test_registered_tool_names_covers_the_known_surface():
@@ -113,120 +238,70 @@ def test_registered_tool_names_survives_a_missing_registry():
     assert registered_tool_names(Bare()) == set()
 
 
-# --- applying ----------------------------------------------------------
-
-
-@pytest.mark.asyncio
-async def test_only_listed_tools_are_exposed():
-    with patch.dict(
-        os.environ, {**ALL_OFF, "REDMINE_MCP_ALLOW_TOOLS": ",".join(ALLOWED)}
-    ):
-        apply_plugin_visibility(_server.mcp)
-        applied = apply_tool_allow_list(_server.mcp)
-    assert applied == ALLOWED
-    assert await _listed() == ALLOWED
-
-
-@pytest.mark.asyncio
-async def test_unlisted_tool_is_not_callable():
-    with patch.dict(
-        os.environ, {**ALL_OFF, "REDMINE_MCP_ALLOW_TOOLS": ",".join(ALLOWED)}
-    ):
-        apply_plugin_visibility(_server.mcp)
-        apply_tool_allow_list(_server.mcp)
-    async with Client(_server.mcp) as client:
-        with pytest.raises(ToolError):
-            await client.call_tool("list_time_entries", {})
-
-
-@pytest.mark.asyncio
-async def test_no_allow_list_leaves_the_surface_alone():
-    with patch.dict(os.environ, ALL_OFF):
-        apply_plugin_visibility(_server.mcp)
-        assert apply_tool_allow_list(_server.mcp) is None
-    listed = await _listed()
-    assert "list_time_entries" in listed
-    assert "manage_deal" not in listed  # plugin visibility still applies
-
-
-@pytest.mark.asyncio
-async def test_empty_allow_list_is_ignored_rather_than_hiding_everything(caplog):
-    with patch.dict(os.environ, {**ALL_OFF, "REDMINE_MCP_ALLOW_TOOLS": "  "}):
-        apply_plugin_visibility(_server.mcp)
-        with caplog.at_level("WARNING"):
-            assert apply_tool_allow_list(_server.mcp) is None
-    assert "names no tools" in caplog.text
-    assert "list_redmine_issues" in await _listed()
-
-
 # --- intersection with plugin flags ------------------------------------
 
 
 @pytest.mark.asyncio
 async def test_allow_list_cannot_re_enable_a_plugin_gated_tool():
-    """A listed tool whose plugin flag is off stays hidden."""
-    with patch.dict(
-        os.environ,
-        {**ALL_OFF, "REDMINE_MCP_ALLOW_TOOLS": "get_redmine_issue,manage_deal"},
-    ):
+    with patch.dict(os.environ, ALL_OFF):
         apply_plugin_visibility(_server.mcp)
-        applied = apply_tool_allow_list(_server.mcp)
-    assert "manage_deal" in applied  # it is registered, so it is "applied"
+    _attach({"get_redmine_issue", "manage_deal"})
     listed = await _listed()
     assert "get_redmine_issue" in listed
-    assert "manage_deal" not in listed  # but the plugin flag still wins
+    assert "manage_deal" not in listed  # the plugin flag still wins
 
 
 @pytest.mark.asyncio
 async def test_plugin_flag_on_plus_allow_list_exposes_the_plugin_tool():
-    with patch.dict(
-        os.environ,
-        {**ALL_ON, "REDMINE_MCP_ALLOW_TOOLS": "get_redmine_issue,manage_deal"},
-    ):
+    with patch.dict(os.environ, ALL_ON):
         apply_plugin_visibility(_server.mcp)
-        apply_tool_allow_list(_server.mcp)
+    _attach({"get_redmine_issue", "manage_deal"})
     assert await _listed() == {"get_redmine_issue", "manage_deal"}
 
 
 @pytest.mark.asyncio
-async def test_reapplying_after_a_flag_flip_keeps_the_list_narrow():
-    """Plugin visibility enables by tag, so the list must be re-applied."""
-    env = {"REDMINE_MCP_ALLOW_TOOLS": "get_redmine_issue"}
-    with patch.dict(os.environ, {**ALL_OFF, **env}):
+async def test_a_later_flag_flip_does_not_widen_the_list():
+    """Middleware needs no re-application: it is not a visibility transform."""
+    _attach({"get_redmine_issue"})
+    with patch.dict(os.environ, ALL_OFF):
         apply_plugin_visibility(_server.mcp)
-        apply_tool_allow_list(_server.mcp)
     assert await _listed() == {"get_redmine_issue"}
-    with patch.dict(os.environ, {**ALL_ON, **env}):
+    with patch.dict(os.environ, ALL_ON):
         apply_plugin_visibility(_server.mcp)
-        apply_tool_allow_list(_server.mcp)
     assert await _listed() == {"get_redmine_issue"}
 
 
 # --- unknown names -----------------------------------------------------
 
 
-@pytest.mark.asyncio
-async def test_unknown_name_warns_and_is_ignored(caplog):
-    with patch.dict(
-        os.environ,
-        {**ALL_OFF, "REDMINE_MCP_ALLOW_TOOLS": "get_redmine_issue,get_redmine_issues"},
-    ):
-        apply_plugin_visibility(_server.mcp)
-        with caplog.at_level("WARNING"):
-            applied = apply_tool_allow_list(_server.mcp)
-    assert applied == {"get_redmine_issue"}
-    assert "get_redmine_issues" in caplog.text
-    assert "unknown tool" in caplog.text
-    assert await _listed() == {"get_redmine_issue"}
+def test_unknown_name_warns(caplog):
+    with caplog.at_level("WARNING"):
+        warn_about_unknown_names(
+            _server.mcp, {"get_redmine_issue", "get_redmine_issues"}
+        )
+    text = _warnings(caplog)
+    assert "get_redmine_issues" in text
+    assert "does not" in text
 
 
-@pytest.mark.asyncio
-async def test_all_names_unknown_hides_every_tool(caplog):
-    """A wholly misspelled list is honoured, not silently ignored."""
-    with patch.dict(os.environ, {**ALL_OFF, "REDMINE_MCP_ALLOW_TOOLS": "nope,nope2"}):
-        apply_plugin_visibility(_server.mcp)
-        with caplog.at_level("WARNING"):
-            applied = apply_tool_allow_list(_server.mcp)
-    assert applied == set()
-    assert "unknown tool" in caplog.text
-    assert await _listed() == set()
+def test_a_correct_name_does_not_warn(caplog):
+    with caplog.at_level("WARNING"):
+        warn_about_unknown_names(_server.mcp, {"get_redmine_issue"})
+    assert _warnings(caplog) == ""
+
+
+def test_a_flag_gated_tool_is_not_reported_as_a_typo(caplog):
+    """cleanup_attachment_files registers only under its own flag."""
+    assert "cleanup_attachment_files" in CONDITIONALLY_REGISTERED
+    with caplog.at_level("WARNING"):
+        warn_about_unknown_names(_server.mcp, {"cleanup_attachment_files"})
+    assert _warnings(caplog) == ""
+
+
+def test_no_warning_when_the_registry_cannot_be_read(caplog):
+    class Bare:
+        pass
+
+    with caplog.at_level("WARNING"):
+        warn_about_unknown_names(Bare(), {"whatever"})
+    assert _warnings(caplog) == ""

--- a/tests/test_tool_allow_list.py
+++ b/tests/test_tool_allow_list.py
@@ -1,0 +1,232 @@
+"""Only allow-listed tools are exposed, and the list can never widen."""
+
+import os
+from unittest.mock import patch
+
+import pytest
+from fastmcp import Client
+from fastmcp.exceptions import ToolError
+
+from redmine_mcp_server import server as _server
+from redmine_mcp_server import tools  # noqa: F401  -- triggers @mcp.tool
+from redmine_mcp_server._env import get_allowed_tools
+from redmine_mcp_server._plugin_visibility import (
+    apply_plugin_visibility,
+    enable_all_plugin_tools,
+)
+from redmine_mcp_server._tool_allow_list import (
+    apply_tool_allow_list,
+    registered_tool_names,
+)
+
+ALLOWED = {"get_redmine_issue", "list_redmine_issues", "get_current_user"}
+ALL_OFF = {
+    var: "false"
+    for var in (
+        "REDMINE_CHECKLISTS_ENABLED",
+        "REDMINE_CRM_ENABLED",
+        "REDMINE_DEALS_ENABLED",
+        "REDMINE_PRODUCTS_ENABLED",
+        "REDMINE_DMSF_ENABLED",
+    )
+}
+ALL_ON = {var: "true" for var in ALL_OFF}
+
+
+@pytest.fixture(autouse=True)
+def _restore_surface():
+    """Undo whatever a test hid, so later tests see the full surface."""
+    yield
+    _server.mcp.enable(components={"tool"})
+    enable_all_plugin_tools(_server.mcp)
+
+
+@pytest.fixture(autouse=True)
+def _no_ambient_allow_list(monkeypatch):
+    monkeypatch.delenv("REDMINE_MCP_ALLOW_TOOLS", raising=False)
+    monkeypatch.delenv("REDMINE_MCP_ALLOW_TOOLS_FILE", raising=False)
+
+
+async def _listed() -> set:
+    async with Client(_server.mcp) as client:
+        return {t.name for t in await client.list_tools()}
+
+
+# --- env parsing -------------------------------------------------------
+
+
+def test_unset_means_no_allow_list():
+    assert get_allowed_tools() is None
+
+
+def test_comma_separated_names_are_trimmed(monkeypatch):
+    monkeypatch.setenv(
+        "REDMINE_MCP_ALLOW_TOOLS", " get_redmine_issue , list_redmine_issues ,"
+    )
+    assert get_allowed_tools() == {"get_redmine_issue", "list_redmine_issues"}
+
+
+def test_configured_but_empty_is_an_empty_set(monkeypatch):
+    monkeypatch.setenv("REDMINE_MCP_ALLOW_TOOLS", "  ,  ")
+    assert get_allowed_tools() == set()
+
+
+def test_file_is_read_one_name_per_line_with_comments(monkeypatch, tmp_path):
+    listing = tmp_path / "allow.txt"
+    listing.write_text(
+        "# issue reading\nget_redmine_issue\n\nlist_redmine_issues  # inline\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("REDMINE_MCP_ALLOW_TOOLS_FILE", str(listing))
+    assert get_allowed_tools() == {"get_redmine_issue", "list_redmine_issues"}
+
+
+def test_env_var_wins_over_file(monkeypatch, tmp_path):
+    listing = tmp_path / "allow.txt"
+    listing.write_text("list_redmine_issues\n", encoding="utf-8")
+    monkeypatch.setenv("REDMINE_MCP_ALLOW_TOOLS_FILE", str(listing))
+    monkeypatch.setenv("REDMINE_MCP_ALLOW_TOOLS", "get_redmine_issue")
+    assert get_allowed_tools() == {"get_redmine_issue"}
+
+
+def test_unreadable_file_fails_loudly(monkeypatch, tmp_path):
+    monkeypatch.setenv(
+        "REDMINE_MCP_ALLOW_TOOLS_FILE", str(tmp_path / "does-not-exist.txt")
+    )
+    with pytest.raises(RuntimeError, match="REDMINE_MCP_ALLOW_TOOLS_FILE"):
+        get_allowed_tools()
+
+
+# --- enumeration -------------------------------------------------------
+
+
+def test_registered_tool_names_covers_the_known_surface():
+    names = registered_tool_names(_server.mcp)
+    assert {"get_redmine_issue", "list_redmine_issues", "manage_deal"} <= names
+    assert all("@" not in n and not n.startswith("tool:") for n in names)
+
+
+def test_registered_tool_names_survives_a_missing_registry():
+    class Bare:
+        pass
+
+    assert registered_tool_names(Bare()) == set()
+
+
+# --- applying ----------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_only_listed_tools_are_exposed():
+    with patch.dict(
+        os.environ, {**ALL_OFF, "REDMINE_MCP_ALLOW_TOOLS": ",".join(ALLOWED)}
+    ):
+        apply_plugin_visibility(_server.mcp)
+        applied = apply_tool_allow_list(_server.mcp)
+    assert applied == ALLOWED
+    assert await _listed() == ALLOWED
+
+
+@pytest.mark.asyncio
+async def test_unlisted_tool_is_not_callable():
+    with patch.dict(
+        os.environ, {**ALL_OFF, "REDMINE_MCP_ALLOW_TOOLS": ",".join(ALLOWED)}
+    ):
+        apply_plugin_visibility(_server.mcp)
+        apply_tool_allow_list(_server.mcp)
+    async with Client(_server.mcp) as client:
+        with pytest.raises(ToolError):
+            await client.call_tool("list_time_entries", {})
+
+
+@pytest.mark.asyncio
+async def test_no_allow_list_leaves_the_surface_alone():
+    with patch.dict(os.environ, ALL_OFF):
+        apply_plugin_visibility(_server.mcp)
+        assert apply_tool_allow_list(_server.mcp) is None
+    listed = await _listed()
+    assert "list_time_entries" in listed
+    assert "manage_deal" not in listed  # plugin visibility still applies
+
+
+@pytest.mark.asyncio
+async def test_empty_allow_list_is_ignored_rather_than_hiding_everything(caplog):
+    with patch.dict(os.environ, {**ALL_OFF, "REDMINE_MCP_ALLOW_TOOLS": "  "}):
+        apply_plugin_visibility(_server.mcp)
+        with caplog.at_level("WARNING"):
+            assert apply_tool_allow_list(_server.mcp) is None
+    assert "names no tools" in caplog.text
+    assert "list_redmine_issues" in await _listed()
+
+
+# --- intersection with plugin flags ------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_allow_list_cannot_re_enable_a_plugin_gated_tool():
+    """A listed tool whose plugin flag is off stays hidden."""
+    with patch.dict(
+        os.environ,
+        {**ALL_OFF, "REDMINE_MCP_ALLOW_TOOLS": "get_redmine_issue,manage_deal"},
+    ):
+        apply_plugin_visibility(_server.mcp)
+        applied = apply_tool_allow_list(_server.mcp)
+    assert "manage_deal" in applied  # it is registered, so it is "applied"
+    listed = await _listed()
+    assert "get_redmine_issue" in listed
+    assert "manage_deal" not in listed  # but the plugin flag still wins
+
+
+@pytest.mark.asyncio
+async def test_plugin_flag_on_plus_allow_list_exposes_the_plugin_tool():
+    with patch.dict(
+        os.environ,
+        {**ALL_ON, "REDMINE_MCP_ALLOW_TOOLS": "get_redmine_issue,manage_deal"},
+    ):
+        apply_plugin_visibility(_server.mcp)
+        apply_tool_allow_list(_server.mcp)
+    assert await _listed() == {"get_redmine_issue", "manage_deal"}
+
+
+@pytest.mark.asyncio
+async def test_reapplying_after_a_flag_flip_keeps_the_list_narrow():
+    """Plugin visibility enables by tag, so the list must be re-applied."""
+    env = {"REDMINE_MCP_ALLOW_TOOLS": "get_redmine_issue"}
+    with patch.dict(os.environ, {**ALL_OFF, **env}):
+        apply_plugin_visibility(_server.mcp)
+        apply_tool_allow_list(_server.mcp)
+    assert await _listed() == {"get_redmine_issue"}
+    with patch.dict(os.environ, {**ALL_ON, **env}):
+        apply_plugin_visibility(_server.mcp)
+        apply_tool_allow_list(_server.mcp)
+    assert await _listed() == {"get_redmine_issue"}
+
+
+# --- unknown names -----------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_unknown_name_warns_and_is_ignored(caplog):
+    with patch.dict(
+        os.environ,
+        {**ALL_OFF, "REDMINE_MCP_ALLOW_TOOLS": "get_redmine_issue,get_redmine_issues"},
+    ):
+        apply_plugin_visibility(_server.mcp)
+        with caplog.at_level("WARNING"):
+            applied = apply_tool_allow_list(_server.mcp)
+    assert applied == {"get_redmine_issue"}
+    assert "get_redmine_issues" in caplog.text
+    assert "unknown tool" in caplog.text
+    assert await _listed() == {"get_redmine_issue"}
+
+
+@pytest.mark.asyncio
+async def test_all_names_unknown_hides_every_tool(caplog):
+    """A wholly misspelled list is honoured, not silently ignored."""
+    with patch.dict(os.environ, {**ALL_OFF, "REDMINE_MCP_ALLOW_TOOLS": "nope,nope2"}):
+        apply_plugin_visibility(_server.mcp)
+        with caplog.at_level("WARNING"):
+            applied = apply_tool_allow_list(_server.mcp)
+    assert applied == set()
+    assert "unknown tool" in caplog.text
+    assert await _listed() == set()


### PR DESCRIPTION
Closes #255.

`REDMINE_MCP_ALLOW_TOOLS` names the tools a deployment offers; everything else is hidden from `tools/list` and rejected by `call_tool`. `REDMINE_MCP_ALLOW_TOOLS_FILE` takes one name per line with `#` comments, and is used only when the env var is unset — the same env-var-wins-over-file precedence as `get_secret`. Neither set exposes everything, as before.

Built as you suggested: a second pass in `_tool_allow_list.py`, called from `main.py` right after `apply_plugin_visibility`, using the same FastMCP visibility transforms.

### Your four points

- **Runs after plugin visibility, only ever disables.** It computes the complement and calls `mcp.disable(names=...)`; it never enables. A tool that is both allow-listed and hidden by its plugin flag stays hidden, covered by `test_allow_list_cannot_re_enable_a_plugin_gated_tool`. Because plugin visibility enables by tag, the allow list has to be re-applied after any flag change — `test_reapplying_after_a_flag_flip_keeps_the_list_narrow` pins that.
- **`manage_X(action=...)` granularity.** Documented in the new `docs/tool-reference.md` section and in the README row: whole tools only, per-action control stays `REDMINE_MCP_READ_ONLY`'s job, and the two compose — an allow list containing write tools with read-only off is how selective write access is expressed.
- **Plugin-flag intersection and unknown names in tests.** `tests/test_tool_allow_list.py`, 17 cases: env and file parsing, precedence, unreadable file, enumeration, the intersection in both directions, re-application after a flag flip, unknown-name warning, and an all-unknown list.
- **Docs.** README env table (two rows) plus a pointer under *Available Tools*; new *Tool Allow List* section in `docs/tool-reference.md`, cross-linked with *Read-Only Mode*; CHANGELOG under Unreleased.

### One thing for you to weigh

Enumerating the registered tools needs a synchronous read, because the pass runs at import time next to plugin visibility. FastMCP 3.4.7 has no public synchronous enumeration — `list_tools`, `get_tool` and `_list_tools` are all coroutines — so `registered_tool_names()` reads `mcp._local_provider._components`, whose keys are `"tool:<name>@<version>"`. That is private API. It degrades to a warning and no filtering if the registry ever moves, and `test_registered_tool_names_survives_a_missing_registry` covers that path, but you may prefer one of:

1. an async pass in the lifespan using the public `await mcp.list_tools()` — public API, and the list is already post-plugin-visibility so the complement cannot resurrect anything, at the cost of moving the call site and the test idiom;
2. middleware in the shape of `ScopeEnforcementMiddleware` (`on_list_tools` + `on_call_tool`), which needs no enumeration at all.

Happy to switch to either.

### Two judgment calls

- **A configured but empty list is ignored with a warning**, rather than hiding every tool. Hiding everything cannot be an intended configuration and would look like a broken server; the warning says to remove the variable instead. Say the word if you would rather it be honoured literally, or refuse at startup.
- **All-unknown lists are honoured** and expose nothing, on the grounds that silently ignoring a filter is worse than an empty surface.

### Tests

`2263 passed` on `python -m pytest tests/ -m "not integration"`. Three failures are pre-existing on clean `develop` in my environment and unrelated to this branch — I verified by stashing: two in `test_release_script.py` and one symlink test. All three are Windows-only. The two release-script ones come from `scripts/release.py` and the test itself calling `Path.read_text()` without an encoding, which picks cp1252 here and dies on a UTF-8 byte in README.md; the README Contributors list is in fact already in sync. Untouched in this PR, mentioning it in case it is worth its own issue.