### PR TITLE
fix: read and write text files with an explicit utf-8 encoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Fixed
+- Text files are now read and written with an explicit `encoding="utf-8"` in
+  `scripts/release.py` and in the attachment metadata I/O. Without it Python
+  picks the locale codec, so on a Windows machine with a cp1252 locale
+  `scripts/release.py --sync-contributors` died on `README.md`: the emoji
+  variation selector `U+FE0F` encodes as `EF B8 8F`, and `0x8F` is unmapped
+  in cp1252. Two `test_release_script.py` cases failed for the same reason.
 - `get_redmine_attachment` no longer hardcodes `http://` in the download
   `uri` and no longer appends default ports. The scheme now honors a new
   `PUBLIC_SCHEME` env var, or is derived (`https` when `PUBLIC_PORT=443`),

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -79,7 +79,7 @@ def run_command(
 def get_current_version(project_root: Path) -> str:
     """Read current version from pyproject.toml."""
     pyproject = project_root / "pyproject.toml"
-    content = pyproject.read_text()
+    content = pyproject.read_text(encoding="utf-8")
     match = re.search(r'^version\s*=\s*"([^"]+)"', content, re.MULTILINE)
     if not match:
         print("Error: Could not find version in pyproject.toml")
@@ -212,7 +212,7 @@ def preflight_checks(config: ReleaseConfig) -> None:
         print(export_result.stdout)
         print(export_result.stderr)
         sys.exit(1)
-    Path(requirements_path).write_text(export_result.stdout)
+    Path(requirements_path).write_text(export_result.stdout, encoding="utf-8")
     result = run_command(
         ["bash", str(audit_script), "-r", requirements_path, "--strict"],
         check=False,
@@ -267,7 +267,7 @@ def preflight_checks(config: ReleaseConfig) -> None:
 def update_pyproject_toml(project_root: Path, new_version: str, dry_run: bool) -> None:
     """Update version in pyproject.toml."""
     pyproject = project_root / "pyproject.toml"
-    content = pyproject.read_text()
+    content = pyproject.read_text(encoding="utf-8")
     new_content = re.sub(
         r'^(version\s*=\s*)"[^"]+"',
         f'\\1"{new_version}"',
@@ -278,14 +278,14 @@ def update_pyproject_toml(project_root: Path, new_version: str, dry_run: bool) -
     if dry_run:
         print(f"  [DRY-RUN] Would update pyproject.toml version to {new_version}")
     else:
-        pyproject.write_text(new_content)
+        pyproject.write_text(new_content, encoding="utf-8")
         print("  ✓ Updated pyproject.toml")
 
 
 def update_server_json(project_root: Path, new_version: str, dry_run: bool) -> None:
     """Update version in server.json (both occurrences)."""
     server_json = project_root / "server.json"
-    content = json.loads(server_json.read_text())
+    content = json.loads(server_json.read_text(encoding="utf-8"))
 
     content["version"] = new_version
     if "packages" in content and len(content["packages"]) > 0:
@@ -294,7 +294,7 @@ def update_server_json(project_root: Path, new_version: str, dry_run: bool) -> N
     if dry_run:
         print(f"  [DRY-RUN] Would update server.json version to {new_version}")
     else:
-        server_json.write_text(json.dumps(content, indent=2) + "\n")
+        server_json.write_text(json.dumps(content, indent=2) + "\n", encoding="utf-8")
         print("  ✓ Updated server.json")
 
 
@@ -337,9 +337,11 @@ def update_readme_contributors(project_root: Path, dry_run: bool) -> None:
     three of them merged-PR authors.
     """
     readme = project_root / "README.md"
-    content = readme.read_text()
+    content = readme.read_text(encoding="utf-8")
     line = render_contributors_line(
-        collect_changelog_contributors((project_root / "CHANGELOG.md").read_text())
+        collect_changelog_contributors(
+            (project_root / "CHANGELOG.md").read_text(encoding="utf-8")
+        )
     )
 
     new_content, count = re.subn(
@@ -361,7 +363,7 @@ def update_readme_contributors(project_root: Path, dry_run: bool) -> None:
     elif new_content == content:
         print("  ✓ README.md Contributors list already current")
     else:
-        readme.write_text(new_content)
+        readme.write_text(new_content, encoding="utf-8")
         print("  ✓ Updated README.md Contributors list")
 
 
@@ -373,7 +375,7 @@ def update_changelog(project_root: Path, new_version: str, dry_run: bool) -> Non
     loud instead so the user fills it in before the release goes out.
     """
     changelog = project_root / "CHANGELOG.md"
-    content = changelog.read_text()
+    content = changelog.read_text(encoding="utf-8")
     today = date.today().strftime("%Y-%m-%d")
 
     # Require an [Unreleased] section that exists and has real content.
@@ -429,7 +431,7 @@ def update_changelog(project_root: Path, new_version: str, dry_run: bool) -> Non
     if dry_run:
         print(f"  [DRY-RUN] Would update CHANGELOG.md with version {new_version}")
     else:
-        changelog.write_text(new_content)
+        changelog.write_text(new_content, encoding="utf-8")
         print("  ✓ Updated CHANGELOG.md")
 
 
@@ -508,7 +510,7 @@ def extract_changelog_section(project_root: Path, version: str) -> tuple[str, st
     Returns (main_body, acknowledgements). See _split_contributors.
     """
     changelog = project_root / "CHANGELOG.md"
-    content = changelog.read_text()
+    content = changelog.read_text(encoding="utf-8")
 
     pattern = rf"## \[{re.escape(version)}\][^\n]*\n(.*?)(?=\n## \[|\Z)"
     match = re.search(pattern, content, re.DOTALL)
@@ -525,7 +527,7 @@ def extract_unreleased_section(project_root: Path) -> tuple[str, str]:
     Returns (main_body, acknowledgements). Used before the version bump
     has rewritten [Unreleased] into a numbered section.
     """
-    content = (project_root / "CHANGELOG.md").read_text()
+    content = (project_root / "CHANGELOG.md").read_text(encoding="utf-8")
     match = re.search(
         r"## \[Unreleased\]\s*\n(.*?)(?=^## \[|\Z)",
         content,
@@ -791,12 +793,12 @@ def generate_release_notes(
 
 def write_notes_file(path: Path, title: str, body: str) -> None:
     """Persist approved notes; first line is an invisible title comment."""
-    path.write_text(f"<!-- title: {title} -->\n{body.strip()}\n")
+    path.write_text(f"<!-- title: {title} -->\n{body.strip()}\n", encoding="utf-8")
 
 
 def read_notes_file(path: Path) -> tuple[str | None, str]:
     """Read persisted notes back. Returns (title or None, body)."""
-    content = path.read_text()
+    content = path.read_text(encoding="utf-8")
     match = re.match(r"<!-- title: (.*?) -->\n", content)
     if match:
         return match.group(1), content[match.end() :].strip()

--- a/src/redmine_mcp_server/_http_routes.py
+++ b/src/redmine_mcp_server/_http_routes.py
@@ -254,7 +254,7 @@ async def serve_attachment(request):
 
     try:
         # Read metadata
-        with open(metadata_file, "r") as f:
+        with open(metadata_file, "r", encoding="utf-8") as f:
             metadata = json.load(f)
 
         # Check expiry with proper timezone-aware datetime comparison

--- a/src/redmine_mcp_server/file_manager.py
+++ b/src/redmine_mcp_server/file_manager.py
@@ -31,7 +31,7 @@ class AttachmentFileManager:
                 continue
 
             try:
-                with open(metadata_file, "r") as f:
+                with open(metadata_file, "r", encoding="utf-8") as f:
                     metadata = json.load(f)
 
                 # Parse expiry timestamp (timezone-aware)

--- a/src/redmine_mcp_server/tools/files.py
+++ b/src/redmine_mcp_server/tools/files.py
@@ -416,7 +416,7 @@ async def get_redmine_attachment(
             metadata_file = uuid_dir / "metadata.json"
             temp_metadata = uuid_dir / "metadata.json.tmp"
             try:
-                with open(temp_metadata, "w") as fh:
+                with open(temp_metadata, "w", encoding="utf-8") as fh:
                     json.dump(metadata, fh, indent=2)
                 os.rename(str(temp_metadata), str(metadata_file))
             except (OSError, IOError, ValueError) as exc:

--- a/tests/test_oauth_scopes.py
+++ b/tests/test_oauth_scopes.py
@@ -10,7 +10,7 @@ _PERMS_FIXTURE = Path(__file__).parent / "fixtures" / "redmine_6_permissions.txt
 def _load_redmine_permissions() -> set[str]:
     return {
         line.strip()
-        for line in _PERMS_FIXTURE.read_text().splitlines()
+        for line in _PERMS_FIXTURE.read_text(encoding="utf-8").splitlines()
         if line.strip() and not line.startswith("#")
     }
 

--- a/tests/test_offload.py
+++ b/tests/test_offload.py
@@ -191,7 +191,7 @@ def test_no_blocking_client_call_runs_on_the_event_loop():
 
     offenders = []
     for path in sorted(package.rglob("*.py")):
-        source = path.read_text()
+        source = path.read_text(encoding="utf-8")
         tree = ast.parse(source)
         for lineno, line in enumerate(source.splitlines(), 1):
             stripped = line.strip()

--- a/tests/test_release_script.py
+++ b/tests/test_release_script.py
@@ -19,7 +19,8 @@ def _write_changelog(tmp_path: Path, version: str, body: str) -> Path:
     changelog = tmp_path / "CHANGELOG.md"
     changelog.write_text(
         f"# Changelog\n\n## [{version}] - 2026-05-16\n{body}\n\n"
-        f"## [0.0.1] - 2025-01-01\n### Added\n- seed\n"
+        f"## [0.0.1] - 2025-01-01\n### Added\n- seed\n",
+        encoding="utf-8",
     )
     return changelog
 
@@ -127,8 +128,8 @@ Thanks:
 
 
 def _write_contributor_fixtures(tmp_path: Path) -> None:
-    (tmp_path / "CHANGELOG.md").write_text(CHANGELOG_WITH_CREDITS)
-    (tmp_path / "README.md").write_text(README_WITH_MARKERS)
+    (tmp_path / "CHANGELOG.md").write_text(CHANGELOG_WITH_CREDITS, encoding="utf-8")
+    (tmp_path / "README.md").write_text(README_WITH_MARKERS, encoding="utf-8")
 
 
 def test_readme_contributors_lists_every_changelog_credit(tmp_path):
@@ -139,7 +140,7 @@ def test_readme_contributors_lists_every_changelog_credit(tmp_path):
 
     release_script.update_readme_contributors(tmp_path, dry_run=False)
 
-    readme = (tmp_path / "README.md").read_text()
+    readme = (tmp_path / "README.md").read_text(encoding="utf-8")
     assert "[@first](https://github.com/first)" in readme
     # Both credit punctuations in this changelog are recognised: "@x —" and "@x,".
     assert "[@second](https://github.com/second)" in readme
@@ -171,14 +172,16 @@ def test_readme_contributors_dry_run_writes_nothing(tmp_path):
 
     release_script.update_readme_contributors(tmp_path, dry_run=True)
 
-    assert (tmp_path / "README.md").read_text() == README_WITH_MARKERS
+    assert (tmp_path / "README.md").read_text(encoding="utf-8") == README_WITH_MARKERS
 
 
 def test_readme_contributors_fails_loudly_when_markers_go_missing(tmp_path):
     """If the section is reformatted away, the release must raise rather than
     silently stop crediting people."""
-    (tmp_path / "CHANGELOG.md").write_text(CHANGELOG_WITH_CREDITS)
-    (tmp_path / "README.md").write_text("# Project\n\n## Contributors\n")
+    (tmp_path / "CHANGELOG.md").write_text(CHANGELOG_WITH_CREDITS, encoding="utf-8")
+    (tmp_path / "README.md").write_text(
+        "# Project\n\n## Contributors\n", encoding="utf-8"
+    )
 
     with pytest.raises(RuntimeError, match="contributors:start"):
         release_script.update_readme_contributors(tmp_path, dry_run=False)
@@ -199,10 +202,10 @@ def test_committed_readme_contributors_match_the_changelog():
     repo = Path(__file__).resolve().parent.parent
     expected = release_script.render_contributors_line(
         release_script.collect_changelog_contributors(
-            (repo / "CHANGELOG.md").read_text()
+            (repo / "CHANGELOG.md").read_text(encoding="utf-8")
         )
     )
-    assert expected in (repo / "README.md").read_text(), (
+    assert expected in (repo / "README.md").read_text(encoding="utf-8"), (
         "README Contributors list is stale. Run:\n"
         "    python scripts/release.py --sync-contributors"
     )


### PR DESCRIPTION
Text file I/O without an explicit `encoding` falls back to the locale codec. On a Windows machine with a cp1252 locale that breaks the release script:

```
$ python scripts/release.py --sync-contributors
  File "scripts/release.py", line 340, in update_readme_contributors
    content = readme.read_text()
UnicodeDecodeError: 'charmap' codec can't decode byte 0x8f in position 18068
```

`README.md` contains the emoji variation selector `U+FE0F`, which encodes as `EF B8 8F`, and `0x8F` is unmapped in cp1252. `docs/tool-reference.md` has the same byte. Two cases in `test_release_script.py` failed for the same reason, since they also read the committed `README.md` and `CHANGELOG.md` without an encoding:

```
FAILED tests/test_release_script.py::test_committed_readme_contributors_match_the_changelog
FAILED tests/test_release_script.py::test_sync_contributors_flag_is_wired_up
```

Both pass now, and `--sync-contributors --dry-run` runs. Worth noting that the README Contributors list was never actually stale — the failure was purely the decode.

### What changed

- `scripts/release.py`: all 15 `read_text`/`write_text` calls — `pyproject.toml`, `server.json`, `README.md`, `CHANGELOG.md`, the requirements export and the notes files.
- `tests/test_release_script.py`: the fixture writes, and the two reads of the committed `README.md` and `CHANGELOG.md`.
- Attachment metadata I/O in `tools/files.py`, `file_manager.py` and `_http_routes.py`. `json.dump` defaults to `ensure_ascii=True`, so these are latent rather than live — but a metadata file carries user-controlled `original_filename` values, and relying on that default to keep them ASCII is fragile.

Binary-mode opens are untouched; they take no `encoding` argument.

### Not changed

Roughly 40 further `write_text` calls in other test files write ASCII fixtures into `tmp_path`. They cannot hit this, and touching them would bury the fix in noise. Happy to add them if you would rather have the whole codebase consistent — and if you want this enforced, `flake8-encodings` catches the pattern; flake8 alone does not.

### Test run

`2248 passed`, one unrelated pre-existing failure (`test_cert_path_symlink_resolution`, which needs the Windows symlink privilege).