### PR TITLE
fix(tests): skip the cert symlink test where symlinks need a privilege

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   deployments behind a TLS-terminating reverse proxy get a usable URL
   without config changes.
   ([#252](https://github.com/jztan/redmine-mcp-server/issues/252))
+- `test_cert_path_symlink_resolution` now skips instead of erroring where
+  symlinks cannot be created. Creating one on Windows needs
+  `SeCreateSymbolicLinkPrivilege`, which an ordinary account does not hold
+  outside Developer Mode or an elevated shell, so the test failed in its
+  setup for every Windows contributor running the suite locally. Guarded the
+  same way as `test_resolve_local_file_rejects_symlink_escape`, the suite's
+  other symlink test.
 
 ### Contributors
 - @andilem reported the TLS download URI bug with a precise diagnosis and

--- a/tests/test_ssl_configuration.py
+++ b/tests/test_ssl_configuration.py
@@ -118,9 +118,14 @@ class TestCertificateFileValidation:
         actual_cert = tmp_path / "actual_ca.crt"
         actual_cert.write_text("-----BEGIN CERTIFICATE-----\nFAKE\n")
 
-        # Create symlink to certificate
+        # Create symlink to certificate. Windows needs
+        # SeCreateSymbolicLinkPrivilege for this, which an ordinary account
+        # does not hold outside Developer Mode or an elevated shell.
         symlink_cert = tmp_path / "ca.crt"
-        symlink_cert.symlink_to(actual_cert)
+        try:
+            symlink_cert.symlink_to(actual_cert)
+        except (OSError, NotImplementedError):
+            pytest.skip("symlinks not supported on this platform")
 
         # Resolve the symlink
         cert_path = Path(symlink_cert).resolve()


### PR DESCRIPTION
Closes #259.

`test_cert_path_symlink_resolution` calls `Path.symlink_to` in its setup. On Windows that needs `SeCreateSymbolicLinkPrivilege`, which an ordinary account does not hold outside Developer Mode or an elevated shell, so the test errors with `OSError: [WinError 1314]` before it reaches the resolution behaviour it means to check. Details and the full traceback are in the issue.

The guard matches `test_resolve_local_file_rejects_symlink_escape` in `tests/test_upload_content_resolution.py`, the suite's only other symlink test: create the link inside a `try`, skip on `OSError` or `NotImplementedError`. `NotImplementedError` stays in the tuple for the reason it is there already — older Python on Windows raised that instead of `OSError`. Two call sites did not seem worth a shared helper or a `skipif` marker; worth revisiting if a third appears.

Test-only, plus a CHANGELOG entry. No `src/` change, and coverage is unchanged wherever symlinks can actually be created, CI included. `tests/test_ssl_configuration.py` goes from 19 passed / 1 failed to 19 passed / 1 skipped.

Branched off current `develop` (`0748ebf`), and independent of #257 — I checked both merge directions with `git merge-tree` and neither conflicts, despite both touching the CHANGELOG, so the two can land in either order.

Full suite on Windows: 2286 passed, 3 failed, 99 skipped. The three are unrelated to this change: two are the missing-`encoding` reads in `tests/test_release_script.py` that #257 fixes, and `test_ssl_integration.py::test_ssl_cert_file_exists` wants `tests/fixtures/ssl/ca-cert.pem`, which `generate-test-certs.sh` produces and which is not checked in.