### PR TITLE
fix(apps): declare CSP metadata on the MCP Apps UI resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,8 +42,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   setup for every Windows contributor running the suite locally. Guarded the
   same way as `test_resolve_local_file_rejects_symlink_escape`, the suite's
   other symlink test.
+- The two MCP Apps UI resources (`ui://redmine/triage-board.html`,
+  `ui://redmine/project-dashboard.html`) now declare their Content Security
+  Policy in `_meta.ui` on both `resources/list` and `resources/read`, with
+  explicit empty `connectDomains` and `resourceDomains` since the views load
+  nothing external. Hosts read the CSP from the resource, not the tool, so
+  ChatGPT's inspector reported "Widget CSP is not set" for both templates.
+  The tool-side metadata now carries the same explicit lists. `domain` is
+  deliberately left unset: its format is host-specific (Claude and ChatGPT
+  differ), and the MCP Apps spec falls back to the host's own sandbox origin
+  when it is omitted.
+  ([#249](https://github.com/jztan/redmine-mcp-server/issues/249))
 
 ### Contributors
+- @aadnehovda reported the missing widget CSP metadata with the ChatGPT
+  inspector screenshot ([#204](https://github.com/jztan/redmine-mcp-server/issues/204))
 - @andilem reported the TLS download URI bug with a precise diagnosis and
   fix proposal ([#252](https://github.com/jztan/redmine-mcp-server/issues/252))
 - @andilem proposed and implemented the tool allow list

--- a/docs/tool-reference.md
+++ b/docs/tool-reference.md
@@ -1520,6 +1520,14 @@ manage_issue_category(action="delete", category_id=3, reassign_to_id=7)
 
 ## MCP Apps (Interactive Tools)
 
+Both views are self-contained HTML, so their `ui://` resources declare an
+empty Content Security Policy (`connectDomains: []`, `resourceDomains: []`)
+in `_meta.ui`. No widget `domain` is declared: its format is host-specific
+(Claude and ChatGPT use different schemes) and hosts fall back to their own
+sandbox origin when it is omitted. ChatGPT's plugin inspector therefore still
+shows a "Widget domain is not set" notice; that only matters for a ChatGPT
+app directory submission and does not affect rendering.
+
 ### `show_triage_board`
 
 Render an interactive Kanban board of a project's issues (MCP Apps). Columns

--- a/src/redmine_mcp_server/apps/project_dashboard.py
+++ b/src/redmine_mcp_server/apps/project_dashboard.py
@@ -35,6 +35,18 @@ _PROJECT_DASHBOARD_HTML = (
 )
 
 
+def _app_config(**extra: Any) -> AppConfig:
+    """AppConfig shared by the UI resource and its tool (#249).
+
+    The view is self-contained, so the CSP declares no external origins;
+    the lists are explicit (not omitted) so hosts that check for a
+    declared CSP, such as ChatGPT's inspector, see one. ``domain`` is left
+    unset on purpose: its format is host-specific and the host falls back
+    to its own sandbox origin.
+    """
+    return AppConfig(csp=ResourceCSP(connect_domains=[], resource_domains=[]), **extra)
+
+
 def _name(value: Any) -> Optional[str]:
     """Return the ``name`` of a nested Redmine object dict, or None."""
     if isinstance(value, dict):
@@ -238,19 +250,15 @@ async def _build_dashboard_payload(
     }
 
 
-@mcp.resource(_UI_RESOURCE_URI, mime_type="text/html;profile=mcp-app")
+@mcp.resource(
+    _UI_RESOURCE_URI, mime_type="text/html;profile=mcp-app", app=_app_config()
+)
 def project_dashboard_ui() -> str:
     """Serve the self-contained project-dashboard HTML view."""
     return _PROJECT_DASHBOARD_HTML
 
 
-@mcp.tool(
-    app=AppConfig(
-        resource_uri=_UI_RESOURCE_URI,
-        visibility=["model"],
-        csp=ResourceCSP(),
-    )
-)
+@mcp.tool(app=_app_config(resource_uri=_UI_RESOURCE_URI, visibility=["model"]))
 async def show_project_dashboard(
     project_id: Union[int, str],
     filters: Optional[Dict[str, Any]] = None,

--- a/src/redmine_mcp_server/apps/triage_board.py
+++ b/src/redmine_mcp_server/apps/triage_board.py
@@ -29,6 +29,18 @@ _TRIAGE_BOARD_HTML = (
 )
 
 
+def _app_config(**extra: Any) -> AppConfig:
+    """AppConfig shared by the UI resource and its tool (#249).
+
+    The view is self-contained, so the CSP declares no external origins;
+    the lists are explicit (not omitted) so hosts that check for a
+    declared CSP, such as ChatGPT's inspector, see one. ``domain`` is left
+    unset on purpose: its format is host-specific and the host falls back
+    to its own sandbox origin.
+    """
+    return AppConfig(csp=ResourceCSP(connect_domains=[], resource_domains=[]), **extra)
+
+
 def _name(value: Any) -> Optional[str]:
     """Return the ``name`` of a nested Redmine object dict, or None."""
     if isinstance(value, dict):
@@ -98,19 +110,15 @@ async def _build_board_payload(
     }
 
 
-@mcp.resource(_UI_RESOURCE_URI, mime_type="text/html;profile=mcp-app")
+@mcp.resource(
+    _UI_RESOURCE_URI, mime_type="text/html;profile=mcp-app", app=_app_config()
+)
 def triage_board_ui() -> str:
     """Serve the self-contained triage-board HTML view."""
     return _TRIAGE_BOARD_HTML
 
 
-@mcp.tool(
-    app=AppConfig(
-        resource_uri=_UI_RESOURCE_URI,
-        visibility=["model"],
-        csp=ResourceCSP(),
-    )
-)
+@mcp.tool(app=_app_config(resource_uri=_UI_RESOURCE_URI, visibility=["model"]))
 async def show_triage_board(
     project_id: Union[int, str],
     filters: Optional[Dict[str, Any]] = None,

--- a/tests/test_project_dashboard_app.py
+++ b/tests/test_project_dashboard_app.py
@@ -362,8 +362,12 @@ def test_dashboard_html_is_self_contained():
 
 
 # Importing the package registers the resource + tools on the shared mcp.
+from fastmcp import Client  # noqa: E402
+
 from redmine_mcp_server import apps  # noqa: E402,F401
 from redmine_mcp_server.server import mcp  # noqa: E402
+
+_EMPTY_CSP = {"connectDomains": [], "resourceDomains": []}
 
 
 @pytest.mark.asyncio
@@ -380,7 +384,31 @@ async def test_show_project_dashboard_meta_points_at_ui():
     ui = tool.meta["ui"]
     assert ui["resourceUri"] == "ui://redmine/project-dashboard.html"
     assert ui["visibility"] == ["model"]
-    assert ui.get("csp", {}) == {}
+    # Explicit empty allow-lists: the view is self-contained (#249).
+    assert ui["csp"] == _EMPTY_CSP
+
+
+@pytest.mark.asyncio
+async def test_dashboard_ui_resource_listing_declares_csp():
+    # ChatGPT reads the CSP from the template resource, not the tool (#249).
+    async with Client(mcp) as client:
+        entry = next(
+            r
+            for r in await client.list_resources()
+            if str(r.uri) == "ui://redmine/project-dashboard.html"
+        )
+    ui = entry.meta["ui"]
+    assert ui["csp"] == _EMPTY_CSP
+    assert "domain" not in ui  # host-specific format; left to the host
+
+
+@pytest.mark.asyncio
+async def test_dashboard_ui_resource_content_declares_csp():
+    async with Client(mcp) as client:
+        (content,) = await client.read_resource("ui://redmine/project-dashboard.html")
+    ui = content.meta["ui"]
+    assert ui["csp"] == _EMPTY_CSP
+    assert "domain" not in ui
 
 
 @pytest.mark.asyncio

--- a/tests/test_triage_board_app.py
+++ b/tests/test_triage_board_app.py
@@ -95,8 +95,12 @@ async def test_build_board_payload_passes_through_issues_error():
 
 
 # Importing the package registers the resource + tools on the shared mcp.
+from fastmcp import Client  # noqa: E402
+
 from redmine_mcp_server import apps  # noqa: E402,F401
 from redmine_mcp_server.server import mcp  # noqa: E402
+
+_EMPTY_CSP = {"connectDomains": [], "resourceDomains": []}
 
 
 @pytest.mark.asyncio
@@ -113,7 +117,31 @@ async def test_show_triage_board_meta_points_at_ui():
     ui = tool.meta["ui"]
     assert ui["resourceUri"] == "ui://redmine/triage-board.html"
     assert ui["visibility"] == ["model"]
-    assert ui.get("csp", {}) == {}  # no external domains declared
+    # Explicit empty allow-lists: the view is self-contained (#249).
+    assert ui["csp"] == _EMPTY_CSP
+
+
+@pytest.mark.asyncio
+async def test_ui_resource_listing_declares_csp():
+    # ChatGPT reads the CSP from the template resource, not the tool (#249).
+    async with Client(mcp) as client:
+        entry = next(
+            r
+            for r in await client.list_resources()
+            if str(r.uri) == "ui://redmine/triage-board.html"
+        )
+    ui = entry.meta["ui"]
+    assert ui["csp"] == _EMPTY_CSP
+    assert "domain" not in ui  # host-specific format; left to the host
+
+
+@pytest.mark.asyncio
+async def test_ui_resource_content_declares_csp():
+    async with Client(mcp) as client:
+        (content,) = await client.read_resource("ui://redmine/triage-board.html")
+    ui = content.meta["ui"]
+    assert ui["csp"] == _EMPTY_CSP
+    assert "domain" not in ui
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Closes #249

ChatGPT's inspector flagged both MCP Apps templates with "Widget CSP is not
set" (screenshot from @aadnehovda in #204). Hosts read the CSP from the
ui:// resource's _meta.ui, and neither resource carried any. Each app module
now builds one AppConfig for both the resource and its tool, with explicit
empty connectDomains and resourceDomains since the views load nothing
external. fastmcp puts it on resources/list and resources/read.

I did not set `domain`, even though the issue proposed it. The spec makes
the field host-specific: Claude wants a sha256 subdomain on
claudemcpcontent.com, ChatGPT wants an https origin. One static value cannot
satisfy both, and an omitted value means the host uses its own sandbox
origin, which is what happens today. The inspector's "Widget domain" notice
stays and only matters for a directory submission. Noted in
docs/tool-reference.md.

Tests assert the wire shape through an in-memory Client for both templates
on list and read, and were written first and watched fail. 2281 unit tests
pass, black and flake8 clean. Not checked in ChatGPT developer mode; that
needs a public connector.
