### PR TITLE
fix: persist oauth-proxy state across container rebuilds

### DIFF
--- a/.env.docker.example
+++ b/.env.docker.example
@@ -122,6 +122,14 @@ ATTACHMENT_EXPIRES_MINUTES=60
 # REDMINE_PER_USER_TRUST_PROXY=true
 # REDMINE_PER_USER_AUDIT_IDENTITY=false
 
+# FastMCP data directory (oauth-proxy mode)
+# OAuthProxy stores encrypted client registrations, transactions, and upstream
+# tokens below FASTMCP_HOME/oauth-proxy/. /app/data is the volume mounted by
+# docker-compose.yml, so state survives `docker compose up --build`. Unset, it
+# would land in the container filesystem and be discarded on every rebuild.
+# The image sets this same default; keep them in agreement if you change it.
+FASTMCP_HOME=/app/data/fastmcp
+
 # Request timeout (optional)
 # Whole seconds to wait for a Redmine HTTP response before failing the call.
 # Applied as connect timeout min(10, value) plus read timeout of the value.

--- a/.env.example
+++ b/.env.example
@@ -71,9 +71,14 @@ REDMINE_MCP_JWT_SIGNING_KEY=
 
 # Optional FastMCP data directory. OAuthProxy stores encrypted client
 # registrations, transactions, and upstream tokens below FASTMCP_HOME/oauth-proxy/.
+# Unset, it resolves to your platform data directory, which persists fine for a
+# local run. Containers are the case that needs care: the Docker image sets
+# FASTMCP_HOME=/app/data/fastmcp so the store lands on the mounted volume rather
+# than in the container filesystem, which a rebuild discards. Do not copy that
+# container path into a local .env, since /app does not exist outside the image.
 # This store is node-local, so oauth-proxy mode is single-replica / sticky-session
 # unless you wire OAuthProxy to a shared client_storage backend.
-# FASTMCP_HOME=/app/data/fastmcp
+# FASTMCP_HOME=./data/fastmcp
 
 # Optional allowlist of client redirect-URI glob patterns for oauth-proxy.
 # Unset = loopback only (http://localhost:* and http://127.0.0.1:*), which suits

--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,10 @@ docker/test-*/
 
 # Runtime data
 attachments/
+# Mounted by docker-compose as /app/data. Holds the encrypted oauth-proxy
+# store (client registrations, upstream tokens), which must never be committed.
+data/
+logs/
 .worktrees/
 
 # Local build/preview artifacts (demo page screenshots, etc.)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   build; no behaviour change for users.
 
 ### Fixed
+- `oauth-proxy` state now survives a container rebuild. `FASTMCP_HOME` was
+  unset by default, so FastMCP resolved its store to the running user's
+  platform data directory, which in the image is inside the container
+  filesystem: every `docker compose up -d --build` discarded the client
+  registrations and upstream token mappings, and every MCP client had to
+  reauthorize. Nothing errored, which made it hard to trace back to the
+  deploy. The image now sets `FASTMCP_HOME=/app/data/fastmcp`, the directory
+  compose already mounts, so a bare `docker run` inherits the right default
+  too. In `oauth-proxy` mode the server also logs the resolved state
+  directory at startup and warns when `FASTMCP_HOME` is unset, and
+  [`docs/oauth-setup.md`](docs/oauth-setup.md) documents the volume
+  requirement, the uid 1000 ownership rules for bind mounts and named
+  volumes, and that changing `REDMINE_MCP_JWT_SIGNING_KEY` orphans the store
+  just as losing the volume does.
+  ([#266](https://github.com/jztan/redmine-mcp-server/issues/266))
 - Contributor credits are no longer dropped from generated GitHub release
   notes. `_split_contributors` in `scripts/release.py` removed the
   `### Contributors` section from the body and then rebuilt it from a regex

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,11 +27,15 @@ FROM python:3.13-slim AS runtime
 # Set environment variables
 # SERVER_HOST/SERVER_PORT default to a reachable binding so ad-hoc
 # `docker run` works without a full env file; override via env_file or -e.
+# FASTMCP_HOME points at /app/data so oauth-proxy state (client
+# registrations, upstream tokens) lands on the mounted volume instead of
+# the container filesystem, where a rebuild would discard it.
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
     PATH="/opt/venv/bin:$PATH" \
     SERVER_HOST=0.0.0.0 \
-    SERVER_PORT=8000
+    SERVER_PORT=8000 \
+    FASTMCP_HOME=/app/data/fastmcp
 
 # Install system dependencies
 RUN apt-get update && \
@@ -55,7 +59,7 @@ COPY --chown=appuser:appuser src/ ./src/
 COPY --chown=appuser:appuser README.md ./
 
 # Create directories for logs and data
-RUN mkdir -p /app/logs /app/data && \
+RUN mkdir -p /app/logs /app/data /app/data/fastmcp && \
     chown -R appuser:appuser /app
 
 # Switch to non-root user

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ The server runs on `http://localhost:8000` with the MCP endpoint at `/mcp`, heal
 | `REDMINE_MCP_JWT_SIGNING_KEY` | Yes§ | – | Stable signing/encryption key used by FastMCP OAuthProxy tokens and storage |
 | `REDMINE_OAUTH_CLIENT_ID` | No | – | Optional upstream Redmine OAuth client ID for `oauth-proxy`; defaults to `REDMINE_INTROSPECT_CLIENT_ID` |
 | `REDMINE_OAUTH_CLIENT_SECRET` | No | – | Optional upstream Redmine OAuth client secret for `oauth-proxy`; defaults to `REDMINE_INTROSPECT_CLIENT_SECRET` |
-| `FASTMCP_HOME` | No | platform default | FastMCP data directory. In `oauth-proxy` mode, encrypted OAuthProxy state is stored below `FASTMCP_HOME/oauth-proxy/` |
+| `FASTMCP_HOME` | No | platform default (`/app/data/fastmcp` in Docker) | FastMCP data directory. In `oauth-proxy` mode, encrypted OAuthProxy state is stored below `FASTMCP_HOME/oauth-proxy/`, and must be on a persistent volume to survive a container rebuild |
 | `REDMINE_MCP_ALLOWED_CLIENT_REDIRECT_URIS` | No | loopback only | `oauth-proxy` client redirect-URI allowlist (glob patterns, comma/space separated). Unset = `http://localhost:*` and `http://127.0.0.1:*`; `*` = allow any |
 | `HEALTH_INTROSPECTION_TTL_SECONDS` | No | `30` | TTL (seconds) for the `/health` Doorkeeper introspection probe cache. Set to `0` to disable caching. |
 | `SERVER_HOST` | No | `0.0.0.0` | Host/IP the MCP server binds to |

--- a/docs/oauth-setup.md
+++ b/docs/oauth-setup.md
@@ -97,8 +97,10 @@ REDMINE_AUTH_MODE=oauth-proxy
 REDMINE_MCP_JWT_SIGNING_KEY=<stable-random-secret>
 # Or: REDMINE_MCP_JWT_SIGNING_KEY_FILE=/run/secrets/redmine_mcp_jwt_signing_key
 
-# Optional: mount this directory to persistent storage in container deployments.
-# OAuthProxy stores encrypted state below FASTMCP_HOME/oauth-proxy/.
+# Where OAuthProxy keeps its encrypted state (below FASTMCP_HOME/oauth-proxy/).
+# The Docker image already sets this to /app/data/fastmcp, which docker-compose
+# mounts as a volume. Set it yourself only for a non-compose deployment, and use
+# a host path for a local run, since /app exists only inside the image.
 # FASTMCP_HOME=/app/data/fastmcp
 
 # Optional: restrict which client redirect URIs are accepted (see note below).
@@ -119,6 +121,13 @@ Set these in `.env` (local) or `.env.docker` (Docker). Legacy credentials are no
 **Upstream OAuth client:** When `REDMINE_OAUTH_CLIENT_ID` / `REDMINE_OAUTH_CLIENT_SECRET` are unset, the introspection client (Step 2) is reused as the upstream authorization client. That client therefore needs more than introspection rights: it must have the **authorization code** grant enabled and `${REDMINE_MCP_BASE_URL}/auth/callback` registered as a redirect URI, otherwise `/authorize` fails upstream. This is already true if the introspection client is the Step 1 user-flow app; if you registered a separate introspection-only app, either enable the authorization code grant and redirect URI on it or set `REDMINE_OAUTH_CLIENT_ID` / `REDMINE_OAUTH_CLIENT_SECRET` to a dedicated upstream app.
 
 **Storage and scaling:** OAuthProxy keeps client registrations, in-flight authorization transactions, and upstream-token mappings in an encrypted file store under `FASTMCP_HOME/oauth-proxy/`. This store is **node-local**, so a request that registers on one instance and continues on another will fail. Run `oauth-proxy` mode as a single replica, or with sticky sessions, unless you provide a shared `OAuthProxy` `client_storage` backend. Mounting `FASTMCP_HOME` to a persistent volume addresses durability across restarts but not cross-replica consistency.
+
+**Persisting the store across rebuilds:** the store has to sit on a volume, or every `docker compose up -d --build` discards it and each client has to reauthorize. Nothing errors when this is wrong, so the server logs the resolved directory at startup (`OAuthProxy state directory: ...`) and warns when `FASTMCP_HOME` is unset. Check that line first when sessions disappear after a deploy.
+
+- The image sets `FASTMCP_HOME=/app/data/fastmcp` and `docker-compose.yml` mounts `./data:/app/data`, so the default compose deployment is already durable.
+- A `docker run` without an env file inherits the same default, but still needs `-v` on `/app/data` to keep anything.
+- The container runs as uid 1000 (`appuser`). An empty named volume inherits ownership from the image directory it covers, so it works as-is. A **bind mount** does not inherit: on Linux the host directory's owner applies, so `./data` must be writable by uid 1000. A volume that already holds root-owned content stays root-owned and the write fails; remove the volume rather than trying to repair it.
+- The store directory is keyed by a fingerprint of `REDMINE_MCP_JWT_SIGNING_KEY`. Changing that key orphans the existing state just as effectively as losing the volume, which is why the key has to be stable and set explicitly rather than generated per deploy.
 
 **Startup behavior:** When `REDMINE_AUTH_MODE=oauth` is set, the server fails fast at startup if `REDMINE_INTROSPECT_CLIENT_ID` or `REDMINE_INTROSPECT_CLIENT_SECRET` is missing — better to surface the misconfiguration immediately than to return 401 on every request.
 

--- a/src/redmine_mcp_server/_oauth_proxy.py
+++ b/src/redmine_mcp_server/_oauth_proxy.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
+import logging
 import os
+from pathlib import Path
 
+from fastmcp import settings
 from fastmcp.server.auth.oauth_proxy import OAuthProxy
 from fastmcp.server.auth.providers.introspection import IntrospectionTokenVerifier
 from pydantic import AnyHttpUrl
@@ -16,11 +19,49 @@ from ._env import (
 )
 from .oauth_scopes import advertised_scopes
 
+logger = logging.getLogger(__name__)
+
 INTROSPECTION_GUIDANCE = (
     "Register a confidential OAuth client in Redmine and configure "
     "Doorkeeper's allow_token_introspection block to accept it "
     "(see docs/oauth-setup.md Step 2 for the walkthrough)."
 )
+
+
+def oauth_proxy_store_path() -> Path:
+    """Return the directory holding OAuthProxy's encrypted state.
+
+    FastMCP writes client registrations, in-flight authorization
+    transactions, and upstream-token mappings below
+    ``settings.home / "oauth-proxy" / <signing-key fingerprint>``. This
+    returns the stable parent, which is the directory an operator has to
+    keep on a persistent volume.
+
+    Resolved on each call rather than at import so that a test (or a late
+    ``FASTMCP_HOME``) is reflected instead of frozen.
+    """
+    return settings.home / "oauth-proxy"
+
+
+def log_oauth_proxy_store_path(auth_mode: str) -> None:
+    """Log where OAuthProxy state lives, and warn if it is not durable.
+
+    With ``FASTMCP_HOME`` unset, the store resolves into the running
+    user's data directory, which in a container is thrown away on every
+    rebuild. Nothing errors; every client simply has to reauthorize. That
+    is hard to trace back to a deploy, so the path is stated up front.
+    """
+    if auth_mode != "oauth-proxy":
+        return
+
+    logger.info("OAuthProxy state directory: %s", oauth_proxy_store_path())
+    if not os.environ.get("FASTMCP_HOME"):
+        logger.warning(
+            "FASTMCP_HOME is not set, so the directory above is whatever "
+            "FastMCP resolved on its own. In a container that is discarded "
+            "on rebuild and every client must reauthorize. Set FASTMCP_HOME "
+            "to a persistent volume (see docs/oauth-setup.md)."
+        )
 
 
 def _redmine_endpoint(redmine_url: str, path: str) -> AnyHttpUrl:

--- a/src/redmine_mcp_server/main.py
+++ b/src/redmine_mcp_server/main.py
@@ -121,6 +121,13 @@ app = build_app()
 logger.info("Redmine MCP Server v%s", get_version())
 logger.info("Auth mode: %s", REDMINE_AUTH_MODE)
 
+# Imported lazily, matching server.py: legacy deployments should not pull in
+# the OAuthProxy machinery just to skip logging about it.
+if REDMINE_AUTH_MODE == "oauth-proxy":
+    from ._oauth_proxy import log_oauth_proxy_store_path
+
+    log_oauth_proxy_store_path(REDMINE_AUTH_MODE)
+
 
 def main():
     """Main entry point for the console script."""

--- a/tests/test_oauth_proxy.py
+++ b/tests/test_oauth_proxy.py
@@ -137,3 +137,74 @@ async def test_authenticated_app_derives_mount_prefix_from_base_url(
         "/.well-known/oauth-protected-resource/api/mcp"
         in mcp_post.headers["www-authenticate"]
     )
+
+
+class TestStorePathLogging:
+    """The resolved OAuthProxy store path is discoverable from the log.
+
+    Regression cover for #266: the store defaults into the container
+    filesystem when FASTMCP_HOME is unset, and the only symptom is that
+    users reauthorize after a rebuild. Logging the resolved path once at
+    startup makes that answerable from the log.
+    """
+
+    def test_store_path_resolves_below_fastmcp_home(self, monkeypatch, tmp_path):
+        from redmine_mcp_server._oauth_proxy import oauth_proxy_store_path
+
+        monkeypatch.setattr(settings, "home", tmp_path)
+
+        assert oauth_proxy_store_path() == tmp_path / "oauth-proxy"
+
+    def test_store_path_follows_fastmcp_home_changes(self, monkeypatch, tmp_path):
+        """Resolved at call time, not import time, so the env var wins."""
+        from redmine_mcp_server._oauth_proxy import oauth_proxy_store_path
+
+        monkeypatch.setattr(settings, "home", tmp_path / "first")
+        assert oauth_proxy_store_path().parent == tmp_path / "first"
+
+        monkeypatch.setattr(settings, "home", tmp_path / "second")
+        assert oauth_proxy_store_path().parent == tmp_path / "second"
+
+    def test_logs_store_path_in_oauth_proxy_mode(self, monkeypatch, tmp_path, caplog):
+        from redmine_mcp_server._oauth_proxy import log_oauth_proxy_store_path
+
+        monkeypatch.setattr(settings, "home", tmp_path)
+
+        with caplog.at_level("INFO"):
+            log_oauth_proxy_store_path("oauth-proxy")
+
+        assert str(tmp_path / "oauth-proxy") in caplog.text
+
+    def test_warns_when_fastmcp_home_is_unset(self, monkeypatch, tmp_path, caplog):
+        """An unset FASTMCP_HOME is the rebuild-loses-state case."""
+        from redmine_mcp_server._oauth_proxy import log_oauth_proxy_store_path
+
+        monkeypatch.delenv("FASTMCP_HOME", raising=False)
+        monkeypatch.setattr(settings, "home", tmp_path)
+
+        with caplog.at_level("INFO"):
+            log_oauth_proxy_store_path("oauth-proxy")
+
+        assert "FASTMCP_HOME" in caplog.text
+
+    def test_no_warning_when_fastmcp_home_is_set(self, monkeypatch, tmp_path, caplog):
+        from redmine_mcp_server._oauth_proxy import log_oauth_proxy_store_path
+
+        monkeypatch.setenv("FASTMCP_HOME", str(tmp_path))
+        monkeypatch.setattr(settings, "home", tmp_path)
+
+        with caplog.at_level("INFO"):
+            log_oauth_proxy_store_path("oauth-proxy")
+
+        assert not [r for r in caplog.records if r.levelname == "WARNING"]
+
+    def test_silent_in_other_auth_modes(self, monkeypatch, tmp_path, caplog):
+        from redmine_mcp_server._oauth_proxy import log_oauth_proxy_store_path
+
+        monkeypatch.setattr(settings, "home", tmp_path)
+
+        with caplog.at_level("INFO"):
+            log_oauth_proxy_store_path("legacy")
+            log_oauth_proxy_store_path("oauth")
+
+        assert caplog.text == ""


### PR DESCRIPTION
Closes #266.

`FASTMCP_HOME` was unset by default, so FastMCP resolved its store to the running user's platform data directory. In the image that is `/home/appuser/.local/share/fastmcp/`, inside the container filesystem, so every `docker compose up -d --build` discarded the client registrations and upstream token mappings. Nothing errored; each MCP client just had to reauthorize, which is hard to trace back to a deploy.

## Changes

The image now sets `FASTMCP_HOME=/app/data/fastmcp`, the directory compose already mounts, so a bare `docker run` inherits the right default too. In `oauth-proxy` mode the server logs the resolved state directory at startup and warns when `FASTMCP_HOME` is unset. `docs/oauth-setup.md` gets a section on persisting the store, `.env.docker.example` gains the `FASTMCP_HOME` line it never had, and the README env table is updated.

`data/` and `logs/` are now gitignored. Neither had tracked files, and `data/` is where the encrypted store lands under compose.

## Two deviations from the issue

The issue proposed uncommenting `FASTMCP_HOME=/app/data/fastmcp` in `.env.example`. That crashes a local run at import with `OSError: [Errno 30] Read-only file system: '/app'`, so it stays commented out, now with `./data/fastmcp` and a note not to copy the container path into a local `.env`.

`.env.docker` is untracked, so the change landed in `.env.docker.example`, which had no `FASTMCP_HOME` line at all.

## One thing the issue missed

The store is `settings.home / "oauth-proxy" / <fingerprint>` (fastmcp `proxy.py:596`), where the fingerprint derives from `REDMINE_MCP_JWT_SIGNING_KEY`. Changing that key orphans the state as effectively as losing the volume. Verified in-container: a second key produced a second fingerprint directory next to the first. That is now documented.

## Verification

| Check | Result |
|---|---|
| Unit suite (2291 tests) | exit 0 |
| Integration vs sandbox 8080 | 103 passed, 8 skipped |
| flake8 / black on `src/` | clean |
| Container: ENV set, dir owned by `appuser`, writable | pass |
| State survives an image rebuild on a named volume | survived |
| Compose bind mount `./data:/app/data` | store lands on the host |
| Control: `FASTMCP_HOME` cleared | warning fires, path goes container-local |
| Control: signing key changed | state orphaned into a new directory |

The cleared-variable control caught a wording bug on the way: the warning claimed "platform default" when FastMCP had actually resolved a relative path. Reworded.

Legacy mode no longer imports the OAuthProxy machinery at all, matching the lazy import pattern in `server.py`. Verified that `redmine_mcp_server._oauth_proxy` stays out of `sys.modules` on a legacy start.

The uid 1000 bind-mount branch on Linux is still unverified, since Docker Desktop on macOS virtualizes bind-mount ownership. It is documented rather than tested.
