### PR TITLE
feat: expose wiki page parent_title (#270)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- `manage_redmine_wiki_page` exposes the wiki page hierarchy. `get`, `create`
+  and `update` now report `parent_title` (the same key `list` already
+  returned), and `create` and `update` accept it, so pages can be filed under
+  a parent and moved between parents. Omitting the parameter leaves an
+  existing parent untouched and `""` moves a page back to the wiki root, so no
+  existing caller can orphan a page. An unknown parent makes Redmine answer
+  422 with an empty error list on both 6.1 and 7.0; that reasonless failure is
+  replaced with a message naming `parent_title` as the likely cause
+  ([#270](https://github.com/jztan/redmine-mcp-server/issues/270)).
 - Issue serializers pass through top-level keys the standard Redmine API does
   not define, under `unmapped_fields`. Distributions and plugins add their own
   keys to the issue JSON (Easy Redmine sends `easy_sprint` and

--- a/docs/tool-reference.md
+++ b/docs/tool-reference.md
@@ -2056,6 +2056,7 @@ List, get, create, update, delete, or rename a Redmine wiki page. Replaces `list
 - `include_attachments` (boolean, optional): Include attachment metadata in `get` response. Default: `true`
 - `text` (string): Page content. Required for `create`. Required for `update` unless `uploads` is provided, in which case the server reuses the page's current text
 - `comments` (string, optional): Change log comment for `create` and `update`
+- `parent_title` (string, optional): Title of the page this page sits under, for `create` and `update`. Omit it and an existing parent is left untouched; pass a title to file the page under it; pass `""` to move the page back to the wiki root. The parent must already exist in the same project -- Redmine rejects an unknown parent with a 422 that carries no error text, so the tool substitutes a message naming `parent_title` as the likely cause. `rename` keeps the current parent on its own; reparent with `update`
 - `new_title` (string): New title for `rename` (must differ from `wiki_page_title`)
 - `redirect_existing_links` (boolean, optional): When `true` (default), `rename` creates a `WikiRedirect` from the old title to the new title
 - `uploads` (list, optional): Files to attach to the page on `create` and `update`. Requires the `edit_wiki_pages` permission on the project. Maximum 10 items. Each item is an object with:
@@ -2069,7 +2070,7 @@ List, get, create, update, delete, or rename a Redmine wiki page. Replaces `list
 
 **Returns:**
 - `list`: array of page metadata dicts (`title`, `version`, `parent_title` if present, `created_on`, `updated_on`) — no body text
-- `get`/`create`/`update`: full wiki page dict (`title`, `text`, `version`, `created_on`, `updated_on`, `author`, `project`, `attachments` when applicable). `project` is only returned by Redmine 7.0+; earlier versions omit the key
+- `get`/`create`/`update`: full wiki page dict (`title`, `text`, `version`, `created_on`, `updated_on`, `author`, `project`, `parent_title`, `attachments` when applicable). `project` is only returned by Redmine 7.0+; earlier versions omit the key. `parent_title` is a plain string and is present only when the page has a parent, matching the key `list` already returns; a page at the wiki root omits it
 - `delete`: `{"success": true, "title": ..., "message": ...}`
 - `rename`: `{"success": true, ...}` plus the renamed page's metadata
 - Error: `{"error": "..."}`
@@ -2101,6 +2102,31 @@ manage_redmine_wiki_page(
     wiki_page_title="Getting_Started",
     text="# Getting Started\n\nWelcome to the project!",
     comments="Initial creation",
+)
+
+# Create a page underneath another page
+manage_redmine_wiki_page(
+    action="create",
+    project_id="my-project",
+    wiki_page_title="Examples_REST_API",
+    text="See the parent page for the index.",
+    parent_title="Examples",
+)
+
+# Move an existing page under a parent, then back to the wiki root
+manage_redmine_wiki_page(
+    action="update",
+    project_id="my-project",
+    wiki_page_title="Examples_REST_API",
+    text="See the parent page for the index.",
+    parent_title="Examples",
+)
+manage_redmine_wiki_page(
+    action="update",
+    project_id="my-project",
+    wiki_page_title="Examples_REST_API",
+    text="See the parent page for the index.",
+    parent_title="",
 )
 
 # Update an existing page

--- a/src/redmine_mcp_server/tools/wiki.py
+++ b/src/redmine_mcp_server/tools/wiki.py
@@ -2,6 +2,8 @@
 
 from typing import Any, Dict, List, Literal, Optional, Union
 
+from redminelib.exceptions import ValidationError
+
 from .._client import _get_redmine_client
 from .._decorators import ActionMode, action_dispatch
 from .._errors import _handle_redmine_error
@@ -54,6 +56,15 @@ def _wiki_page_to_dict(
     if hasattr(wiki_page, "author"):
         result["author"] = _named_ref(wiki_page.author)
 
+    # Add the parent page. python-redmine wraps it as a WikiPage
+    # resource exposing only `title`: its `id` answers 0 and its `name`
+    # answers "", so _named_ref would mint a fabricated
+    # {"id": 0, "name": ""} rather than fail. Read the title directly
+    # and use the same `parent_title` key the list action returns.
+    parent = getattr(wiki_page, "parent", None)
+    if parent is not None:
+        result["parent_title"] = getattr(parent, "title", None)
+
     # Add project info. Only Redmine 7.0+ returns this field (Redmine
     # #43569); on older versions the hasattr guard omits the key. It
     # arrives as a plain dict rather than a resource -- see _named_ref.
@@ -70,6 +81,34 @@ def _wiki_page_to_dict(
         ]
 
     return result
+
+
+def _blank_validation_parent_hint(
+    exc: Exception, parent_title: Optional[str]
+) -> Optional[Dict[str, str]]:
+    """Explain a reasonless 422 when a parent page was requested.
+
+    Redmine rejects an unknown ``parent_title`` with 422 and an empty
+    ``errors`` array (verified on 6.1.1 and 7.0.0), which python-redmine
+    raises as ``ValidationError("")``. That reaches the caller as
+    "Validation failed: " with nothing after it. Naming the most likely
+    cause is a guess, so the message says so rather than asserting it.
+
+    Returns ``None`` when the error does not fit that shape, leaving
+    normal error handling in charge.
+    """
+    if not parent_title:
+        return None
+    if not isinstance(exc, ValidationError) or str(exc).strip():
+        return None
+    return {
+        "error": (
+            "Redmine rejected the wiki page and returned no reason. The "
+            f"most likely cause is parent_title '{parent_title}': it must "
+            "name a wiki page that already exists in this project. Create "
+            "the parent first, or omit parent_title."
+        )
+    }
 
 
 def _require_wiki_page_title(action: str, wiki_page_title: Any) -> Optional[str]:
@@ -145,6 +184,7 @@ async def _create_wiki_page_action(
     wiki_page_title: Optional[str] = None,
     text: Optional[str] = None,
     comments: Optional[str] = None,
+    parent_title: Optional[str] = None,
     uploads: Optional[List[Dict[str, Any]]] = None,
     **_: Any,
 ) -> Dict[str, Any]:
@@ -166,6 +206,11 @@ async def _create_wiki_page_action(
         "text": text,
         "comments": comments if comments else None,
     }
+    # Only send parent_title when the caller named one. Omitting the key
+    # leaves an existing parent untouched; "" moves the page to the wiki
+    # root. Both verified against Redmine 6.1 and 7.0.
+    if parent_title is not None:
+        create_kwargs["parent_title"] = parent_title
     if upload_descriptors:
         create_kwargs["uploads"] = upload_descriptors
 
@@ -174,6 +219,9 @@ async def _create_wiki_page_action(
             wiki_page = _get_redmine_client().wiki_page.create(**create_kwargs)
             return _wiki_page_to_dict(wiki_page)
         except Exception as e:
+            hint = _blank_validation_parent_hint(e, parent_title)
+            if hint is not None:
+                return hint
             return _handle_redmine_error(
                 e,
                 f"creating wiki page '{wiki_page_title}' in project {project_id}",
@@ -188,6 +236,7 @@ async def _update_wiki_page_action(
     wiki_page_title: Optional[str] = None,
     text: Optional[str] = None,
     comments: Optional[str] = None,
+    parent_title: Optional[str] = None,
     uploads: Optional[List[Dict[str, Any]]] = None,
     **_: Any,
 ) -> Dict[str, Any]:
@@ -240,6 +289,11 @@ async def _update_wiki_page_action(
         "project_id": project_id,
         "comments": comments if comments else None,
     }
+    # Absent means "leave the hierarchy alone": Redmine keeps the current
+    # parent when the key is not sent, so a text-only or attachment-only
+    # update can never orphan a child page. "" moves it to the root.
+    if parent_title is not None:
+        update_kwargs["parent_title"] = parent_title
     if upload_descriptors:
         update_kwargs["uploads"] = upload_descriptors
 
@@ -258,6 +312,9 @@ async def _update_wiki_page_action(
             wiki_page = client.wiki_page.get(wiki_page_title, project_id=project_id)
             return _wiki_page_to_dict(wiki_page)
         except Exception as e:
+            hint = _blank_validation_parent_hint(e, parent_title)
+            if hint is not None:
+                return hint
             return _handle_redmine_error(
                 e,
                 f"updating wiki page '{wiki_page_title}' in project {project_id}",
@@ -372,6 +429,7 @@ async def manage_redmine_wiki_page(
     include_attachments: bool = True,
     text: Optional[str] = None,
     comments: Optional[str] = None,
+    parent_title: Optional[str] = None,
     new_title: Optional[str] = None,
     redirect_existing_links: bool = True,
     uploads: Optional[List[Dict[str, Any]]] = None,
@@ -393,6 +451,13 @@ async def manage_redmine_wiki_page(
             update does not have to resend the body.
         comments: Change log comment. Optional for ``create`` and
             ``update``.
+        parent_title: Title of the page this page sits under, for
+            ``create`` and ``update``. Omit it to leave an existing
+            parent untouched; pass a title to file the page under it;
+            pass ``""`` to move the page back to the wiki root. Must
+            name a page that already exists in the same project. A
+            ``rename`` keeps the current parent on its own, so reparent
+            with ``update`` instead.
         new_title: New title for the page (required for ``rename``).
         redirect_existing_links: When ``True`` (default), the rename
             creates a redirect from ``wiki_page_title`` to ``new_title``.
@@ -411,7 +476,9 @@ async def manage_redmine_wiki_page(
 
     Returns:
         ``list``: list of page metadata dicts (no body text).
-        ``get`` / ``create`` / ``update``: wiki page dict.
+        ``get`` / ``create`` / ``update``: wiki page dict, carrying
+        ``parent_title`` when the page has a parent and omitting the
+        key when it sits at the wiki root.
         ``delete``: ``{"success": True, "title": ..., "message": ...}``.
         ``rename``: ``{"success": True, ...}`` with the renamed page's
         metadata to confirm the title change actually applied.

--- a/tests/test_global_search.py
+++ b/tests/test_global_search.py
@@ -407,6 +407,53 @@ class TestManageRedmineWikiPageGet:
     @pytest.mark.asyncio
     @patch("redmine_mcp_server._client.redmine")
     @patch("redmine_mcp_server._cleanup._ensure_cleanup_started")
+    async def test_wiki_page_reports_parent_title(
+        self, mock_cleanup, mock_redmine, mock_wiki_page
+    ):
+        """A child page reports its parent so hierarchy survives a get.
+
+        python-redmine wraps the parent as a WikiPage resource carrying
+        only ``title``; its ``id`` answers 0 and its ``name`` answers
+        "", so _named_ref would mint a fabricated {"id": 0, "name": ""}
+        here instead of failing. Read the title directly. See #270.
+        """
+        from redmine_mcp_server.tools.wiki import manage_redmine_wiki_page
+
+        parent = Mock()
+        parent.title = "Handbook"
+        parent.id = 0
+        parent.name = ""
+        mock_wiki_page.parent = parent
+        mock_redmine.wiki_page.get.return_value = mock_wiki_page
+
+        result = await manage_redmine_wiki_page(
+            action="get", project_id="my-project", wiki_page_title="Installation Guide"
+        )
+
+        assert result["parent_title"] == "Handbook"
+        assert "parent" not in result
+
+    @pytest.mark.asyncio
+    @patch("redmine_mcp_server._client.redmine")
+    @patch("redmine_mcp_server._cleanup._ensure_cleanup_started")
+    async def test_wiki_page_omits_parent_title_at_root(
+        self, mock_cleanup, mock_redmine, mock_wiki_page
+    ):
+        """A top-level page carries no parent_title key at all."""
+        from redmine_mcp_server.tools.wiki import manage_redmine_wiki_page
+
+        mock_wiki_page.parent = None
+        mock_redmine.wiki_page.get.return_value = mock_wiki_page
+
+        result = await manage_redmine_wiki_page(
+            action="get", project_id="my-project", wiki_page_title="Installation Guide"
+        )
+
+        assert "parent_title" not in result
+
+    @pytest.mark.asyncio
+    @patch("redmine_mcp_server._client.redmine")
+    @patch("redmine_mcp_server._cleanup._ensure_cleanup_started")
     async def test_wiki_page_not_found(self, mock_cleanup, mock_redmine):
         """Test handling of non-existent wiki page."""
         from redmine_mcp_server.tools.wiki import manage_redmine_wiki_page

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -470,6 +470,120 @@ class TestRedmineIntegration:
     @pytest.mark.skipif(not REDMINE_URL, reason="REDMINE_URL not configured")
     @pytest.mark.integration
     @pytest.mark.asyncio
+    async def test_wiki_page_hierarchy_integration(self):
+        """Live round trip for the wiki page parent (issue #270).
+
+        Creates a parent and a child, reparents, and clears the parent
+        back to the wiki root, asserting what Redmine actually reports
+        at each step rather than what was sent.
+        """
+        redmine = _get_redmine_or_none()
+        if redmine is None:
+            pytest.skip("Redmine client not initialized")
+
+        from redmine_mcp_server.tools.wiki import manage_redmine_wiki_page
+
+        projects = list(redmine.project.all())
+        if not projects:
+            pytest.skip("No projects available for testing")
+
+        project_id = projects[0].identifier
+        parent_title = "Integration_Test_Wiki_Parent"
+        other_parent_title = "Integration_Test_Wiki_Parent_Two"
+        child_title = "Integration_Test_Wiki_Child"
+
+        async def _delete(title):
+            try:
+                await manage_redmine_wiki_page(
+                    action="delete", project_id=project_id, wiki_page_title=title
+                )
+            except Exception:
+                pass  # Best effort cleanup
+
+        try:
+            for title in (parent_title, other_parent_title):
+                created = await manage_redmine_wiki_page(
+                    action="create",
+                    project_id=project_id,
+                    wiki_page_title=title,
+                    text="Parent page for the hierarchy integration test.",
+                )
+                if "error" in created:
+                    if any(
+                        word in created["error"].lower()
+                        for word in ("denied", "permission", "forbidden")
+                    ):
+                        pytest.skip(f"Wiki editing not permitted: {created['error']}")
+                    pytest.fail(f"Failed to create parent: {created['error']}")
+                # A page at the root must not claim a parent.
+                assert "parent_title" not in created
+
+            # 1. Create a child underneath the first parent.
+            child = await manage_redmine_wiki_page(
+                action="create",
+                project_id=project_id,
+                wiki_page_title=child_title,
+                text="Child page.",
+                parent_title=parent_title,
+            )
+            if "error" in child:
+                pytest.fail(f"Failed to create child page: {child['error']}")
+            assert child["parent_title"] == parent_title
+
+            # 2. A get reports the parent too, not just the create echo.
+            fetched = await manage_redmine_wiki_page(
+                action="get", project_id=project_id, wiki_page_title=child_title
+            )
+            assert fetched["parent_title"] == parent_title
+
+            # 3. A text-only update must leave the parent alone.
+            untouched = await manage_redmine_wiki_page(
+                action="update",
+                project_id=project_id,
+                wiki_page_title=child_title,
+                text="Child page, edited without naming a parent.",
+            )
+            assert untouched["parent_title"] == parent_title
+
+            # 4. Reparent to the second parent.
+            moved = await manage_redmine_wiki_page(
+                action="update",
+                project_id=project_id,
+                wiki_page_title=child_title,
+                text="Child page, moved.",
+                parent_title=other_parent_title,
+            )
+            assert moved["parent_title"] == other_parent_title
+
+            # 5. An empty parent_title returns the page to the wiki root.
+            rooted = await manage_redmine_wiki_page(
+                action="update",
+                project_id=project_id,
+                wiki_page_title=child_title,
+                text="Child page, back at the root.",
+                parent_title="",
+            )
+            assert "parent_title" not in rooted
+
+            # 6. An unknown parent fails with an explanation, not a blank.
+            orphaned = await manage_redmine_wiki_page(
+                action="update",
+                project_id=project_id,
+                wiki_page_title=child_title,
+                text="Child page.",
+                parent_title="Integration_Test_No_Such_Parent",
+            )
+            assert "error" in orphaned
+            assert "Integration_Test_No_Such_Parent" in orphaned["error"]
+
+        finally:
+            # Children first: Redmine refuses to leave pages stranded.
+            for title in (child_title, parent_title, other_parent_title):
+                await _delete(title)
+
+    @pytest.mark.skipif(not REDMINE_URL, reason="REDMINE_URL not configured")
+    @pytest.mark.integration
+    @pytest.mark.asyncio
     async def test_wiki_page_lifecycle_integration(self):
         """Integration test for creating, updating, and deleting a wiki page."""
         redmine = _get_redmine_or_none()

--- a/tests/test_wiki_editing.py
+++ b/tests/test_wiki_editing.py
@@ -100,6 +100,49 @@ class TestManageRedmineWikiPageCreate:
     @pytest.mark.asyncio
     @patch("redmine_mcp_server._client.redmine")
     @patch("redmine_mcp_server._cleanup._ensure_cleanup_started")
+    async def test_create_wiki_page_under_parent(
+        self, mock_cleanup, mock_redmine, mock_wiki_page
+    ):
+        """parent_title files the new page under an existing page (#270)."""
+        from redmine_mcp_server.tools.wiki import manage_redmine_wiki_page
+
+        mock_redmine.wiki_page.create.return_value = mock_wiki_page
+
+        await manage_redmine_wiki_page(
+            action="create",
+            project_id="my-project",
+            wiki_page_title="New Page",
+            text="Content",
+            parent_title="Handbook",
+        )
+
+        kwargs = mock_redmine.wiki_page.create.call_args.kwargs
+        assert kwargs["parent_title"] == "Handbook"
+
+    @pytest.mark.asyncio
+    @patch("redmine_mcp_server._client.redmine")
+    @patch("redmine_mcp_server._cleanup._ensure_cleanup_started")
+    async def test_create_wiki_page_omits_parent_title_when_not_given(
+        self, mock_cleanup, mock_redmine, mock_wiki_page
+    ):
+        """No parent_title argument means the key is never sent."""
+        from redmine_mcp_server.tools.wiki import manage_redmine_wiki_page
+
+        mock_redmine.wiki_page.create.return_value = mock_wiki_page
+
+        await manage_redmine_wiki_page(
+            action="create",
+            project_id="my-project",
+            wiki_page_title="New Page",
+            text="Content",
+        )
+
+        kwargs = mock_redmine.wiki_page.create.call_args.kwargs
+        assert "parent_title" not in kwargs
+
+    @pytest.mark.asyncio
+    @patch("redmine_mcp_server._client.redmine")
+    @patch("redmine_mcp_server._cleanup._ensure_cleanup_started")
     async def test_create_wiki_page_forbidden(self, mock_cleanup, mock_redmine):
         """Test handling of permission denied error."""
         from redmine_mcp_server.tools.wiki import manage_redmine_wiki_page
@@ -138,6 +181,54 @@ class TestManageRedmineWikiPageCreate:
         )
 
         assert "error" in result
+
+    @pytest.mark.asyncio
+    @patch("redmine_mcp_server._client.redmine")
+    @patch("redmine_mcp_server._cleanup._ensure_cleanup_started")
+    async def test_create_with_unknown_parent_explains_itself(
+        self, mock_cleanup, mock_redmine
+    ):
+        """A bad parent_title yields a 422 carrying no reason at all.
+
+        Redmine 6.1 and 7.0 both answer {"errors": []}, which reaches us
+        as ValidationError(""). Left alone the tool would report a blank
+        error, so name the likely cause. See #270.
+        """
+        from redmine_mcp_server.tools.wiki import manage_redmine_wiki_page
+
+        mock_redmine.wiki_page.create.side_effect = ValidationError("")
+
+        result = await manage_redmine_wiki_page(
+            action="create",
+            project_id="my-project",
+            wiki_page_title="New Page",
+            text="Content",
+            parent_title="NoSuchPage",
+        )
+
+        assert "NoSuchPage" in result["error"]
+        assert "parent_title" in result["error"]
+
+    @pytest.mark.asyncio
+    @patch("redmine_mcp_server._client.redmine")
+    @patch("redmine_mcp_server._cleanup._ensure_cleanup_started")
+    async def test_blank_validation_error_unchanged_without_parent_title(
+        self, mock_cleanup, mock_redmine
+    ):
+        """The parent hint is only offered when a parent was requested."""
+        from redmine_mcp_server.tools.wiki import manage_redmine_wiki_page
+
+        mock_redmine.wiki_page.create.side_effect = ValidationError("")
+
+        result = await manage_redmine_wiki_page(
+            action="create",
+            project_id="my-project",
+            wiki_page_title="New Page",
+            text="Content",
+        )
+
+        assert "error" in result
+        assert "parent_title" not in result["error"]
 
     @pytest.mark.asyncio
     @patch("redmine_mcp_server._client.redmine")
@@ -241,6 +332,75 @@ class TestManageRedmineWikiPageUpdate:
         )
 
         assert "error" not in result
+
+    @pytest.mark.asyncio
+    @patch("redmine_mcp_server._client.redmine")
+    @patch("redmine_mcp_server._cleanup._ensure_cleanup_started")
+    async def test_update_wiki_page_reparents(
+        self, mock_cleanup, mock_redmine, mock_wiki_page
+    ):
+        """parent_title moves an existing page under another page (#270)."""
+        from redmine_mcp_server.tools.wiki import manage_redmine_wiki_page
+
+        mock_redmine.wiki_page.get.return_value = mock_wiki_page
+
+        await manage_redmine_wiki_page(
+            action="update",
+            project_id="my-project",
+            wiki_page_title="Existing Page",
+            text="Content",
+            parent_title="Handbook",
+        )
+
+        kwargs = mock_redmine.wiki_page.update.call_args.kwargs
+        assert kwargs["parent_title"] == "Handbook"
+
+    @pytest.mark.asyncio
+    @patch("redmine_mcp_server._client.redmine")
+    @patch("redmine_mcp_server._cleanup._ensure_cleanup_started")
+    async def test_update_wiki_page_clears_parent_with_empty_string(
+        self, mock_cleanup, mock_redmine, mock_wiki_page
+    ):
+        """An empty parent_title moves the page back to the wiki root."""
+        from redmine_mcp_server.tools.wiki import manage_redmine_wiki_page
+
+        mock_redmine.wiki_page.get.return_value = mock_wiki_page
+
+        await manage_redmine_wiki_page(
+            action="update",
+            project_id="my-project",
+            wiki_page_title="Existing Page",
+            text="Content",
+            parent_title="",
+        )
+
+        kwargs = mock_redmine.wiki_page.update.call_args.kwargs
+        assert kwargs["parent_title"] == ""
+
+    @pytest.mark.asyncio
+    @patch("redmine_mcp_server._client.redmine")
+    @patch("redmine_mcp_server._cleanup._ensure_cleanup_started")
+    async def test_update_wiki_page_leaves_parent_untouched(
+        self, mock_cleanup, mock_redmine, mock_wiki_page
+    ):
+        """A text-only update must not orphan a page that has a parent.
+
+        Redmine preserves the parent when the key is absent, so the key
+        must not be sent at all rather than sent as None.
+        """
+        from redmine_mcp_server.tools.wiki import manage_redmine_wiki_page
+
+        mock_redmine.wiki_page.get.return_value = mock_wiki_page
+
+        await manage_redmine_wiki_page(
+            action="update",
+            project_id="my-project",
+            wiki_page_title="Existing Page",
+            text="Content",
+        )
+
+        kwargs = mock_redmine.wiki_page.update.call_args.kwargs
+        assert "parent_title" not in kwargs
 
     @pytest.mark.asyncio
     @patch("redmine_mcp_server._client.redmine")

--- a/tests/test_wiki_management.py
+++ b/tests/test_wiki_management.py
@@ -106,6 +106,27 @@ class TestManageRedmineWikiPageRename:
 
     @pytest.mark.asyncio
     @patch("redmine_mcp_server._client.redmine")
+    async def test_rename_keeps_the_page_under_its_parent(self, mock_redmine):
+        """Renaming a child page must not move it to the wiki root.
+
+        Redmine leaves the parent alone when a wiki PUT omits
+        parent_title, verified against 6.1.1 and 7.0.0. The rename path
+        relies on that, so pin it: sending the key here (even as None)
+        would silently reparent every renamed page. See #270.
+        """
+        existing = _make_wiki_page("Old", parent_title="Handbook", text="Body")
+        renamed = _make_wiki_page("New", parent_title="Handbook", text="Body")
+        mock_redmine.wiki_page.get.side_effect = [existing, renamed]
+
+        result = await manage_redmine_wiki_page(
+            action="rename", project_id="proj", wiki_page_title="Old", new_title="New"
+        )
+
+        assert "parent_title" not in mock_redmine.wiki_page.update.call_args.kwargs
+        assert result["parent_title"] == "Handbook"
+
+    @pytest.mark.asyncio
+    @patch("redmine_mcp_server._client.redmine")
     async def test_rename_without_redirect(self, mock_redmine):
         existing = _make_wiki_page("Old", text="Body")
         renamed = _make_wiki_page("New", text="Body")


### PR DESCRIPTION
Closes #270.

`manage_redmine_wiki_page` could neither report nor set a page's parent, so
pages could not be created in a hierarchy. The `list` action already returned
`parent_title`; `get`, `create` and `update` dropped it.

## What changed

- `get`, `create` and `update` report `parent_title`, the same key `list`
  already returns. The key is absent for a page at the wiki root.
- `create` and `update` accept `parent_title`. Omitting it leaves an existing
  parent untouched, a title files the page under that page, and `""` moves the
  page back to the root.
- An unknown parent makes Redmine answer 422 with an empty error list, which
  reaches the caller as a blank "Validation failed: ". That now becomes a
  message naming `parent_title` as the likely cause.

## Two things worth a closer look in review

The serializer reads the parent's title directly instead of going through
`_named_ref`. python-redmine wraps the parent as a `WikiPage` whose `id`
answers `0` and whose `name` answers `""`, so `_named_ref` would have quietly
produced `{"id": 0, "name": ""}`, inventing an id for a page that has none.

`parent_title` is sent only when the caller names one. Redmine keeps the
current parent when the key is absent but clears it when the key is null, so
sending it unconditionally would orphan every page updated without one. I
checked that this guard actually holds by breaking it on purpose: with the
condition removed, both the unit test and the live test fail, the latter on a
page that really did get moved to the root.

## Testing

2330 unit tests pass. The integration suite passes against both sandboxes,
Redmine 6.1.1 and 7.0.0, including a new live round trip that creates a
parent and a child, reparents, clears back to the root, and checks the error
message for an unknown parent. Every behaviour above was confirmed on both
versions rather than assumed, and none of it needed version-conditional code.
