### PR TITLE
fix: describe manage_product's parameters in the schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   build; no behaviour change for users.
 
 ### Fixed
+- `manage_product` reaches `tools/list` with its parameters described. All 13
+  of them arrived as bare types behind a three-line tool description, so the
+  split that matters most was invisible: `create` reads the flat parameters
+  and `update` reads only `fields`, which makes the natural call from the
+  schema alone (`action="update", product_id=42, price=9.99`) fail with
+  `fields must be a non-empty dict`. The docstring now says which actions each
+  parameter belongs to, that `status_id` is 1 or 2 and nothing else, that
+  `limit` is clamped at 100, and which keys `fields` accepts and silently
+  drops. `manage_deal` and `add_deal_product` had already described their
+  parameters but paired two of them per line (`currency, due_date` and
+  `tax, discount`), which the docstring parser does not split, so those four
+  reached the schema empty as well; they are now one entry each
+  ([#277](https://github.com/jztan/redmine-mcp-server/issues/277)).
 - `uploads` is documented where a client can read it. `create_redmine_issue`
   and `update_redmine_issue` now describe the parameter in their docstrings,
   so it reaches `tools/list` with its three content sources named instead of

--- a/src/redmine_mcp_server/tools/deals.py
+++ b/src/redmine_mcp_server/tools/deals.py
@@ -549,8 +549,8 @@ async def manage_deal(
         contact_id: ``create`` only. The contact the deal belongs to.
         price: ``create`` only. Send an unformatted string such as
             ``"1500.5"``.
-        currency, due_date: ``create`` only. The deal's currency code, and
-            its due date as ``YYYY-MM-DD``.
+        currency: ``create`` only. The deal's currency code, e.g. ``"USD"``.
+        due_date: ``create`` only. The deal's due date as ``YYYY-MM-DD``.
         fields: ``create`` and ``update`` only. Deal attributes to write.
             On ``update`` it is the only way to change a deal, so it is
             required and must be non-empty.
@@ -987,7 +987,8 @@ async def add_deal_product(
         quantity: Positive number (default 1 on the plugin side).
         price: Unit price, as a string such as ``"100.0"`` or a number.
         description: Line text; required when no ``product_id``.
-        tax, discount: Percentages, 0 to 100.
+        tax: Tax rate on the line, as a percentage from 0 to 100.
+        discount: Discount on the line, as a percentage from 0 to 100.
 
     Returns:
         ``{"success": true, "deal_id", "line"}`` with the line as sent, or

--- a/src/redmine_mcp_server/tools/products.py
+++ b/src/redmine_mcp_server/tools/products.py
@@ -281,9 +281,49 @@ async def manage_product(
 ) -> Union[List[Dict[str, Any]], Dict[str, Any]]:
     """RedmineUP Products plugin tool. Combined CRUD-by-action.
 
-    Actions: ``list``, ``get``, ``create``, ``update``.
-    Requires ``REDMINE_PRODUCTS_ENABLED=true`` and the RedmineUP Products
-    plugin.
+    Actions: ``list``, ``get``, ``create``, ``update``. The plugin exposes no
+    delete endpoint, so there is no ``delete`` action. Requires
+    ``REDMINE_PRODUCTS_ENABLED=true`` and the RedmineUP Products plugin.
+
+    One flat signature serves every action, so most parameters apply to some
+    actions and are ignored by the rest. The two write actions do not take
+    their payload the same way: ``create`` reads the flat parameters below,
+    while ``update`` reads ``fields`` and ignores every flat one.
+
+    Args:
+        action: Which operation to run.
+        project_id: On ``list``, restrict to products in this project; omit
+            for every product the caller can see. On ``create``, the project
+            to file the new product under (optional). Name or numeric id.
+        limit: ``list`` only. Products per call, capped at 100 by Redmine;
+            a larger value is clamped, not rejected.
+        product_id: The product to act on. Required by ``get`` and
+            ``update``, ignored by the rest.
+        name: ``create`` only -- the new product's name (required).
+        status_id: ``create`` only. ``1`` (Active, the default) or ``2``
+            (Inactive); any other value is rejected. To change the status of
+            an existing product, pass ``status_id`` inside ``fields`` on
+            ``update``.
+        description: ``create`` only. Free text.
+        price: ``create`` only. Unit price as a number, e.g. ``49.99``.
+        currency: ``create`` only. Currency code, e.g. ``"USD"``.
+        code: ``create`` only. The product's catalogue code / SKU.
+        category_id: ``create`` only. Product category, as a positive
+            integer id.
+        tag_list: ``create`` only. Comma-separated tag names.
+        custom_fields: ``create`` only. List of ``{"id": N, "value": ...}``
+            dicts.
+        fields: ``update`` only, and the only way to change a product, so it
+            is required there and must be non-empty. Allowed keys: ``name``,
+            ``description``, ``price``, ``currency``, ``status_id``,
+            ``code``, ``project_id``, ``category_id``, ``tag_list``,
+            ``custom_fields``. Any other key is dropped without an error, so
+            check ``updated_fields`` in the response for what was written.
+
+    Returns:
+        ``list`` a list of product dicts, ``get`` / ``create`` one product
+        dict, ``update`` ``{"success": true, "product_id", "updated_fields"}``,
+        and ``{"error": ...}`` on failure.
     """
     if not _is_products_enabled():
         return dict(_PRODUCTS_DISABLED_ERROR)


### PR DESCRIPTION
Closes #277.

`manage_product` reached `tools/list` with 13 undescribed parameters behind a three-line tool description. The create/update split was the expensive gap: `create` reads the flat parameters, `update` reads only `fields`, so the call a client would write from the schema alone fails.

```python
manage_product(action="update", product_id=42, price=9.99)
# {"error": "fields must be a non-empty dict."}
```

The docstring now carries an `Args:` section for all 14 parameters, saying which actions each one belongs to, that `status_id` is 1 or 2 and nothing else, that `limit` is clamped at 100, and which keys `fields` accepts and which it drops without complaint.

`manage_deal` and `add_deal_product` had the same symptom for a different reason. Both already documented their parameters, but paired `currency, due_date` and `tax, discount` two to a line, which the docstring parser does not split, so those four also arrived empty. They get one entry each.

Verification: dumping `tools/list` with the plugin flags on, undescribed parameters drop from 21 to 4. The four left are on `get_triage_board_data` and `get_project_dashboard_data`, the MCP Apps iframe data sources, which this issue does not cover. 2367 unit tests pass, and 105 integration tests pass against the 6.1 sandbox. flake8 and black are clean.
