### PR TITLE
docs: describe the app backend tools' parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   build; no behaviour change for users.
 
 ### Fixed
+- The two MCP Apps backend tools, `get_triage_board_data` and
+  `get_project_dashboard_data`, describe their `project_id` and `filters`
+  parameters. They are called by the board and dashboard iframes rather than
+  by a model, so the gap was not costing anyone a failed call, but it left the
+  four last undescribed parameters in the server: with every plugin flag on,
+  all 62 listed tools now describe every parameter they expose
+  ([#281](https://github.com/jztan/redmine-mcp-server/issues/281)).
 - `manage_product` reaches `tools/list` with its parameters described. All 13
   of them arrived as bare types behind a three-line tool description, so the
   split that matters most was invisible: `create` reads the flat parameters

--- a/src/redmine_mcp_server/apps/project_dashboard.py
+++ b/src/redmine_mcp_server/apps/project_dashboard.py
@@ -295,6 +295,14 @@ async def get_project_dashboard_data(
     """Backend data source for the project dashboard's Refresh button.
 
     Returns the same payload as ``show_project_dashboard`` without a UI
-    resource; the dashboard's iframe calls this over ``tools/call``.
+    resource; the dashboard's iframe calls this over ``tools/call``. Pass
+    the same arguments the dashboard was opened with, so a refresh redraws
+    the same view. Read-only.
+
+    Args:
+        project_id: The project whose dashboard is being refreshed, as a
+            numeric ID or string identifier (e.g. ``1`` or ``"web"``).
+        filters: Optional extra Redmine filter dict, the same shape
+            ``list_redmine_issues`` accepts (e.g. ``{"tracker_id": 1}``).
     """
     return await _build_dashboard_payload(project_id, filters)

--- a/src/redmine_mcp_server/apps/triage_board.py
+++ b/src/redmine_mcp_server/apps/triage_board.py
@@ -158,6 +158,16 @@ async def get_triage_board_data(
     """Backend data source for the triage board's Refresh button.
 
     Returns the same payload as ``show_triage_board`` without a UI
-    resource; the board's iframe calls this over ``tools/call``.
+    resource; the board's iframe calls this over ``tools/call``. Pass the
+    same arguments the board was opened with, so a refresh redraws the same
+    view. Read-only.
+
+    Args:
+        project_id: The project whose board is being refreshed, as a
+            numeric ID or string identifier (e.g. ``1`` or
+            ``"testing-project1"``).
+        filters: Optional extra Redmine filter dict, the same shape
+            ``list_redmine_issues`` accepts (e.g. ``{"assigned_to_id":
+            "me"}`` or ``{"tracker_id": 1}``).
     """
     return await _build_board_payload(project_id, filters)


### PR DESCRIPTION
Closes #281.

`get_triage_board_data` and `get_project_dashboard_data` exposed `project_id` and `filters` as bare types. Both are `visibility=["app"]` tools that their iframe's Refresh button calls, so no model was guessing at the schema and nothing was failing, but they held the last four undescribed parameters in the server.

Each now has an `Args:` section matching what its `show_*` sibling already says about the same two parameters, plus a line telling the caller to pass the arguments the view was opened with so a refresh redraws the same board.

Verification: with every plugin flag on, 62 tools are listed and none has an undescribed parameter, down from four. 2367 unit tests pass, and 105 integration tests pass against the 6.1 sandbox. flake8 and black are clean.
