### PR TITLE
test(schema): fail when a tool parameter has no description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `tax, discount`), which the docstring parser does not split, so those four
   reached the schema empty as well; they are now one entry each
   ([#277](https://github.com/jztan/redmine-mcp-server/issues/277)).
+- Every tool parameter now reaches `tools/list` with a description, and a test
+  keeps it that way. `manage_contact`'s `action` was the last one missing one:
+  the docstring documented the other 27 parameters and skipped it. The new
+  check in `tests/test_tool_annotations.py` walks every registered tool with
+  all plugin families visible and fails on any parameter whose schema
+  description is empty. It carries no allowlist, since an exemption list is
+  where the next undocumented parameter would hide
+  ([#278](https://github.com/jztan/redmine-mcp-server/issues/278)).
 - `uploads` is documented where a client can read it. `create_redmine_issue`
   and `update_redmine_issue` now describe the parameter in their docstrings,
   so it reaches `tools/list` with its three content sources named instead of

--- a/src/redmine_mcp_server/tools/contacts.py
+++ b/src/redmine_mcp_server/tools/contacts.py
@@ -767,6 +767,9 @@ async def manage_contact(
     Which parameter belongs to which action:
 
     Args:
+        action: Which operation to run. One of ``list``, ``get``, ``create``,
+            ``update``, ``delete``, ``assign_to_project``,
+            ``remove_from_project``.
         contact_id: The contact to act on. Required by every action except
             ``list`` and ``create``.
         project_id: On ``list``, restrict to contacts in this project. On

--- a/tests/test_tool_annotations.py
+++ b/tests/test_tool_annotations.py
@@ -347,3 +347,46 @@ class TestAnnotationInteractions:
         assert by_name["list_redmine_projects"].annotations.model_dump(
             exclude_none=True
         ) == expected.model_dump(exclude_none=True)
+
+
+class TestParameterDescriptions:
+    """Anti-drift for #278: the schema is what a client actually reads.
+
+    A parameter documented only in ``docs/tool-reference.md`` reaches an
+    agent as a bare name and a type, which is how #275 and #277 shipped.
+    There is deliberately no allowlist here: an exemption list is exactly
+    where the next undocumented parameter would hide.
+    """
+
+    @pytest.mark.asyncio
+    async def test_every_parameter_has_a_description(self):
+        undocumented = []
+        for tool in await _registered_tools():
+            properties = (tool.parameters or {}).get("properties", {})
+            for name, schema in properties.items():
+                if not str(schema.get("description") or "").strip():
+                    undocumented.append(f"{tool.name}.{name}")
+        assert not undocumented, (
+            "parameters reach tools/list with no description "
+            "(document them in the tool's Args: docstring section, not only "
+            f"in docs/tool-reference.md): {sorted(undocumented)}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_the_check_covers_the_whole_surface(self):
+        """Guard the guard: prove it walks tools that carry parameters.
+
+        Without the ``all_plugin_tools_visible`` fixture the check above
+        would pass while skipping every plugin-gated tool, which is where
+        both known defects were. ``cleanup_attachment_files`` is the one
+        registered tool this cannot reach (admin-gated), and it takes no
+        parameters, so nothing is missed.
+        """
+        tools = await _registered_tools()
+        by_name = {tool.name: tool for tool in tools}
+        for plugin_tool in ("manage_product", "manage_contact", "manage_deal"):
+            assert plugin_tool in by_name, f"{plugin_tool} not enumerated"
+        counted = sum(
+            len((tool.parameters or {}).get("properties", {})) for tool in tools
+        )
+        assert counted > 250, f"only {counted} parameters inspected"


### PR DESCRIPTION
Closes #278.

After #277 and #282, one parameter was still reaching `tools/list` with no
description: `manage_contact`'s `action`. Its docstring documented the other 27
parameters and skipped that one, so it is now documented like every other
dispatch tool's `action`.

The check that stops the next one lives in `tests/test_tool_annotations.py`,
which already enumerates the full surface under the `all_plugin_tools_visible`
fixture. It walks every registered tool and fails on any parameter whose schema
description is empty. There is no allowlist, since an exemption list is where
the next undocumented parameter would hide.

A second test guards the guard: it asserts the plugin-gated tools really were
enumerated and that more than 250 parameters got inspected, so the check cannot
pass by quietly skipping the tools where both known defects were.
`cleanup_attachment_files` is the one registered tool the enumeration cannot
reach (admin-gated), and it takes no parameters.

I confirmed the check bites by deleting the new docstring line again and
watching it fail on `manage_contact.action`.
