### PR TITLE
docs(tool-reference): give upload_file the caveats from #276

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,9 +37,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `(1, 1, 0)` for the whole resource and python-redmine raises no version
   error of its own. That message names the endpoint rather than a core
   version, since distributions vary in what they expose.
-  ([#269](https://github.com/jztan/redmine-mcp-server/issues/269))
-- `search_entire_redmine` now searches news alongside issues and wiki pages,
-  which the module docstring already claimed.
+  `search_entire_redmine` searches news alongside issues and wiki pages, which
+  the module docstring already claimed
+  ([#269](https://github.com/jztan/redmine-mcp-server/issues/269)).
 - Issue serializers pass through top-level keys the standard Redmine API does
   not define, under `unmapped_fields`. Distributions and plugins add their own
   keys to the issue JSON (Easy Redmine sends `easy_sprint` and
@@ -51,10 +51,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   because that is what reaches the client. `get_redmine_issue`,
   `list_redmine_issues` and `search_redmine_issues` expose the key; it is
   omitted when there is nothing to report, so payloads from a stock Redmine are
-  unchanged.
-- `total_estimated_hours` and `total_spent_hours` on the issue serializers.
-  Both are stock Redmine fields carrying the subtask rollup that
-  `estimated_hours` and `spent_hours` leave out.
+  unchanged. The same serializers gain `total_estimated_hours` and
+  `total_spent_hours`, stock Redmine fields carrying the subtask rollup that
+  `estimated_hours` and `spent_hours` leave out
+  ([#263](https://github.com/jztan/redmine-mcp-server/issues/263),
+  [#268](https://github.com/jztan/redmine-mcp-server/pull/268)).
 
 ### Changed
 - Upgraded to FastMCP 4 and the MCP Python SDK v2: `fastmcp>=4.0.1,<5` (locked
@@ -71,48 +72,50 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   build; no behaviour change for users.
 
 ### Fixed
-- The two MCP Apps backend tools, `get_triage_board_data` and
-  `get_project_dashboard_data`, describe their `project_id` and `filters`
-  parameters. They are called by the board and dashboard iframes rather than
-  by a model, so the gap was not costing anyone a failed call, but it left the
-  four last undescribed parameters in the server: with every plugin flag on,
-  all 62 listed tools now describe every parameter they expose
-  ([#281](https://github.com/jztan/redmine-mcp-server/issues/281)).
-- `manage_product` reaches `tools/list` with its parameters described. All 13
-  of them arrived as bare types behind a three-line tool description, so the
-  split that matters most was invisible: `create` reads the flat parameters
-  and `update` reads only `fields`, which makes the natural call from the
-  schema alone (`action="update", product_id=42, price=9.99`) fail with
-  `fields must be a non-empty dict`. The docstring now says which actions each
-  parameter belongs to, that `status_id` is 1 or 2 and nothing else, that
-  `limit` is clamped at 100, and which keys `fields` accepts and silently
-  drops. `manage_deal` and `add_deal_product` had already described their
-  parameters but paired two of them per line (`currency, due_date` and
-  `tax, discount`), which the docstring parser does not split, so those four
-  reached the schema empty as well; they are now one entry each
-  ([#277](https://github.com/jztan/redmine-mcp-server/issues/277)).
 - Every tool parameter now reaches `tools/list` with a description, and a test
-  keeps it that way. `manage_contact`'s `action` was the last one missing one:
-  the docstring documented the other 27 parameters and skipped it. The new
-  check in `tests/test_tool_annotations.py` walks every registered tool with
-  all plugin families visible and fails on any parameter whose schema
-  description is empty. It carries no allowlist, since an exemption list is
-  where the next undocumented parameter would hide
-  ([#278](https://github.com/jztan/redmine-mcp-server/issues/278)).
+  keeps it that way. `manage_product` was the worst of it: all 13 of its
+  parameters arrived as bare types behind a three-line tool description, which
+  hid the split that matters most, since `create` reads the flat parameters and
+  `update` reads only `fields`, so the natural call from the schema alone
+  (`action="update", product_id=42, price=9.99`) failed with `fields must be a
+  non-empty dict`. Its docstring now says which actions each parameter belongs
+  to, that `status_id` is 1 or 2 and nothing else, that `limit` is clamped at
+  100, and which keys `fields` accepts and silently drops. `manage_deal` and
+  `add_deal_product` had described their parameters but paired two of them per
+  line (`currency, due_date` and `tax, discount`), which the docstring parser
+  does not split, so those four reached the schema empty as well; they are now
+  one entry each. The remaining gaps were `manage_contact`'s `action`, the one
+  parameter its docstring skipped out of 28, and the `project_id` and `filters`
+  of the two MCP Apps backend tools, `get_triage_board_data` and
+  `get_project_dashboard_data`, which are called by the board and dashboard
+  iframes rather than by a model, so that pair was not costing anyone a failed
+  call. With every plugin flag on, all 62 listed tools now describe every
+  parameter they expose. The new check in `tests/test_tool_annotations.py`
+  walks every registered tool with all plugin families visible and fails on any
+  parameter whose schema description is empty; it carries no allowlist, since
+  an exemption list is where the next undocumented parameter would hide
+  ([#277](https://github.com/jztan/redmine-mcp-server/issues/277),
+  [#278](https://github.com/jztan/redmine-mcp-server/issues/278),
+  [#281](https://github.com/jztan/redmine-mcp-server/issues/281)).
 - `uploads` is documented where a client can read it. `create_redmine_issue`
   and `update_redmine_issue` now describe the parameter in their docstrings,
   so it reaches `tools/list` with its three content sources named instead of
   as a bare array of objects. `docs/tool-reference.md` had described them all
   along, but a client reads the schema, not the repository: an agent holding a
   file could not discover `content_base64` there, followed the one documented
-  route it could find — `file_path` on `upload_file` — and hit a wall no
+  route it could find (`file_path` on `upload_file`) and hit a wall no
   configuration can open, since that path is read where the server runs rather
   than where the caller does. The upload-roots error now says which filesystem
-  it means and names the two sources that need no roots at all, `upload_file`
-  points at the issue tools for attaching to a ticket, and
-  `manage_redmine_wiki_page` carries the same caveat
+  it means and names the two sources that need no roots at all, and
+  `manage_redmine_wiki_page` carries the same caveat. `upload_file` says which
+  machine it means in its docstring and in both places its reference section
+  describes `file_path`, in place of "already on the server", wording that
+  reads as a fact about the file rather than about the host and sent the
+  reporter looking for a configuration fix; both now also point at the issue
+  and wiki tools for attaching to a ticket or a page
   ([#275](https://github.com/jztan/redmine-mcp-server/issues/275),
-  [#276](https://github.com/jztan/redmine-mcp-server/pull/276)).
+  [#276](https://github.com/jztan/redmine-mcp-server/pull/276),
+  [#279](https://github.com/jztan/redmine-mcp-server/issues/279)).
 - `oauth-proxy` state now survives a container rebuild. `FASTMCP_HOME` was
   unset by default, so FastMCP resolved its store to the running user's
   platform data directory, which in the image is inside the container

--- a/docs/tool-reference.md
+++ b/docs/tool-reference.md
@@ -2343,10 +2343,12 @@ List all files uploaded to a Redmine project's **Files** section (not issue atta
 
 Upload a file to a Redmine project's Files section. Uses Redmine's standard two-step upload (`POST /uploads.json` for the token, then `POST /projects/{id}/files.json`).
 
+This is the project's document store, not an attachment on something. To attach a file to an issue, pass `uploads` to `create_redmine_issue` or `update_redmine_issue`; to a wiki page, pass `uploads` to `manage_redmine_wiki_page`. All three take the same content sources as this tool.
+
 **Provide exactly ONE of `source_url`, `content_base64`, or `file_path`:**
 - `source_url` (string) — the server downloads from an HTTP(S) URL. Use this when chaining from another MCP tool that returns a download URL (e.g., Google Drive MCP's `get_drive_file_download_url`), or when the file is served by a local MCP on `localhost`. **Preferred when a URL is available** — no need for the caller to download and re-encode.
 - `content_base64` (string) — raw file bytes encoded as base64. Use this only when the caller already has the bytes in memory.
-- `file_path` (string): absolute path to a file already on the server. The path must be inside `ATTACHMENTS_DIR` or a directory listed in `REDMINE_MCP_UPLOAD_FILE_ROOTS`. Filename is derived from the path if `filename` is omitted.
+- `file_path` (string): a path on **this server's** filesystem, inside `ATTACHMENTS_DIR` or a directory listed in `REDMINE_MCP_UPLOAD_FILE_ROOTS`. Filename is derived from the path if `filename` is omitted. Where the server runs on the caller's machine that includes the caller's own files, and this source costs no tokens; over HTTP the two are different hosts, and no value of `REDMINE_MCP_UPLOAD_FILE_ROOTS` can bridge the gap, so such a file travels as `content_base64` or `source_url`, neither of which needs roots configured.
 
 **Parameters:**
 - `project_id` (integer or string, required): Project identifier.
@@ -2355,7 +2357,7 @@ Upload a file to a Redmine project's Files section. Uses Redmine's standard two-
   - Optional with `source_url` or `file_path`, inferred from the URL path, `Content-Disposition` header, or file path if omitted, but always prefer passing an explicit filename.
 - `source_url` (string, conditional): HTTP(S) URL to download from.
 - `content_base64` (string, conditional): File content as base64.
-- `file_path` (string, conditional): Absolute path to a file on the server. Restricted to `ATTACHMENTS_DIR` and directories in `REDMINE_MCP_UPLOAD_FILE_ROOTS`.
+- `file_path` (string, conditional): Path to a file on **this server's** filesystem, restricted to `ATTACHMENTS_DIR` and directories in `REDMINE_MCP_UPLOAD_FILE_ROOTS`. A caller-side path is unreachable when the server runs on a different host, whatever the roots are set to.
 - `description` (string, optional): Human-readable description.
 - `version_id` (integer, optional): Version/release ID to attach the file to (use `list_redmine_versions` to discover valid IDs).
 


### PR DESCRIPTION
Closes #279.

`upload_file`'s section in `docs/tool-reference.md` still had the pre-#276 text.
Both places it describes `file_path` said "already on the server", which reads as
a fact about the file rather than about which machine, and that is the reading
that sent the reporter of #275 looking for a configuration fix. The three
`uploads` bullets already carried the server-filesystem caveat.

The section now says "this server's filesystem" in both places, spells out that
no value of `REDMINE_MCP_UPLOAD_FILE_ROOTS` bridges a different host, and opens
with the pointer the docstring gained: to attach a file to an issue use
`create_redmine_issue` or `update_redmine_issue`, to a wiki page
`manage_redmine_wiki_page`.

While in the changelog I also consolidated the Unreleased section. #277, #278 and
#281 were one piece of work split across three entries that read as contradicting
each other, since #278 declared every parameter described and #281 then fixed
four more; #275, #276 and #279 were likewise one entry's worth. Two Added entries
from PR #268 merged the same way, and that entry gained the issue and PR links it
was missing. Diffing the `#nnn` set in the Unreleased section before and after
shows exactly one addition, #279, so no reference or credit was dropped.

Docs only, no code change. Unit suite green at 2369 passed.
